### PR TITLE
check that the miner is still registered every 10 minutes

### DIFF
--- a/neurons/_miner/miner_session.py
+++ b/neurons/_miner/miner_session.py
@@ -90,6 +90,8 @@ class MinerSession:
                     self.log_batch = []
                 else:
                     bt.logging.debug("No logs to log to WandB")
+                # check if registered
+                self.check_register()
             try:
                 if step % 5 == 0:
                     metagraph = subtensor.metagraph(self.config.netuid)

--- a/neurons/_miner/miner_session.py
+++ b/neurons/_miner/miner_session.py
@@ -90,7 +90,7 @@ class MinerSession:
                     self.log_batch = []
                 else:
                     bt.logging.debug("No logs to log to WandB")
-                # check if registered
+            if step % 600 == 0:
                 self.check_register()
             try:
                 if step % 5 == 0:

--- a/neurons/_miner/miner_session.py
+++ b/neurons/_miner/miner_session.py
@@ -13,7 +13,7 @@ class MinerSession:
     def __init__(self, config):
         self.config = config
         self.configure()
-        self.check_register()
+        self.check_register(true)
         self.auto_update = AutoUpdate()
         self.axon = None
         self.log_batch = []
@@ -118,12 +118,13 @@ class MinerSession:
                 bt.logging.error(traceback.format_exc())
                 continue
 
-    def check_register(self):
+    def check_register(self, exit=False):
         if self.wallet.hotkey.ss58_address not in self.metagraph.hotkeys:
             bt.logging.error(
                 f"\nYour miner: {self.wallet} is not registered to the network: {self.subtensor} \nRun btcli register and try again."
             )
-            exit()
+            if exit:
+                exit()
         else:
             # Each miner gets a unique identity (UID) in the network for differentiation.
             subnet_uid = self.metagraph.hotkeys.index(self.wallet.hotkey.ss58_address)

--- a/neurons/_miner/miner_session.py
+++ b/neurons/_miner/miner_session.py
@@ -13,7 +13,7 @@ class MinerSession:
     def __init__(self, config):
         self.config = config
         self.configure()
-        self.check_register(true)
+        self.check_register(exit=True)
         self.auto_update = AutoUpdate()
         self.axon = None
         self.log_batch = []
@@ -93,7 +93,7 @@ class MinerSession:
             if step % 600 == 0:
                 self.check_register()
             try:
-                if step % 5 == 0:
+                if step % 5 == 0 and self.subnet_uid:
                     metagraph = subtensor.metagraph(self.config.netuid)
                     log = (
                         f"Step:{step} | "
@@ -125,6 +125,7 @@ class MinerSession:
             )
             if exit:
                 exit()
+            self.subnet_uid = None
         else:
             # Each miner gets a unique identity (UID) in the network for differentiation.
             subnet_uid = self.metagraph.hotkeys.index(self.wallet.hotkey.ss58_address)


### PR DESCRIPTION
Don't do anything if its not registered once the miner is already running besides letting the user know (so we just default to the standard check_registration function), because some people like myself run registration bots that will reregister them after dereg, and I expect the miner to just pick up when it detects its registered (current behavior) again. The code also states the miner should not shut down after its been started unless explicitly caused by the user or an auto update, so this fits that as well. The only time the miner will close is at startup if not registered (current behavior).

to summarize, no behavior changes, only logging changes w/ a periodic registration check.