### PR TITLE
Demote unnecessarily verbose automatic update messages

### DIFF
--- a/neurons/_validator/core/validator_loop.py
+++ b/neurons/_validator/core/validator_loop.py
@@ -167,7 +167,7 @@ class ValidatorLoop:
         if not self.config.config.no_auto_update:
             self.auto_update.try_update()
         else:
-            bt.logging.info("Automatic updates are disabled, skipping version check")
+            bt.logging.debug("Automatic updates are disabled, skipping version check")
 
     def _process_requests(self, requests):
         """

--- a/neurons/utils/auto_update.py
+++ b/neurons/utils/auto_update.py
@@ -193,7 +193,7 @@ class AutoUpdate:
         Automatic update entrypoint method
         """
         if self.repo.head.is_detached or self.repo.active_branch.name != "main":
-            logging.warning("Not on the main branch, skipping auto-update")
+            logging.debug("Not on the main branch, skipping auto-update")
             return
 
         if not self.check_version_updated():


### PR DESCRIPTION
The update messages which appear in both miner and validator are of a too high message info level, causing unnecessary console spam (the check is performed very often) -- therefore I have demoted these messages to "DEBUG" status. Both changes (a branch that is not main and providing an autoupdate disabling argument) are very intentional and there's no need to tell an user that they have done a very intentional change.

The frequency of the messages caused them to be annoying, that's why they have been demoted in this PR.