### PR TITLE
Increase validator timeout due to SN27 Jolt complexity

### DIFF
--- a/neurons/constants.py
+++ b/neurons/constants.py
@@ -16,7 +16,7 @@ IGNORED_MODEL_HASHES = [
 ]
 
 # The maximum timespan allowed for miners to respond to a query
-VALIDATOR_REQUEST_TIMEOUT_SECONDS = 60
+VALIDATOR_REQUEST_TIMEOUT_SECONDS = 120
 # The timeout for aggregation requests
 VALIDATOR_AGG_REQUEST_TIMEOUT_SECONDS = 600
 # Maximum number of concurrent requests that the validator will handle


### PR DESCRIPTION
The new Jolt SN27 model is so complex, that its default implementation takes over 60s to calculate. Therefore, the validator timeout that's hardcoded to 60s is no longer sufficient. I propose this limit be doubled to 120s in order to properly receive correct responses which are simply taking longer to calculate.