### PR TITLE
Use aria2 instead of curl in model-sync script.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -179,6 +179,24 @@ if ! command -v jq >/dev/null 2>&1; then
 	esac
 fi
 
+# Check if aria2 is installed, if not then install it
+if ! [ -x "$(command -v aria2c)" ]; then
+	echo "aria2 not found. Installing aria2..."
+	case ${OS} in
+	'Linux')
+		sudo apt update
+		sudo apt install -y aria2
+		;;
+	'Darwin')
+		brew install aria2
+		;;
+	*)
+		echo "Unsupported OS for aria2 installation"
+		exit 1
+		;;
+	esac
+fi
+
 # Check if PM2 is installed, if not then install it
 if ! command -v pm2 >/dev/null 2>&1; then
 	echo "pm2 not found. Installing pm2..."
@@ -244,10 +262,6 @@ fi
 
 # Set working directory to install dir
 cd "${INSTALL_PATH}" || exit
-
-# Sync remote files for all models
-echo "Syncing model files..."
-bash "./sync_model_files.sh"
 
 # Display next steps
 echo -e "\033[32mOmron has been installed to ${INSTALL_PATH}. Please run \`cd ${INSTALL_PATH}\` to navigate to the directory.\033[0m"

--- a/sync_model_files.sh
+++ b/sync_model_files.sh
@@ -26,7 +26,7 @@ for MODEL_FOLDER in $(find "$MODEL_DIR" -maxdepth 1 -type d -name 'model_*'); do
         fi
         # If the file doesn't exist we'll pull from the URL specified
         echo "Downloading ${url} to ${MODEL_FOLDER}/${key}..."
-        curl -o "${MODEL_FOLDER}/${key}" "${url}"
+        aria2c ${url} -d "${MODEL_FOLDER}" -o "${key}"
         # If the file doesn't download then we'll skip this file and echo the error
         if [ $? -ne 0 ]; then
             echo "Error: Failed to download ${url} to ${MODEL_FOLDER}/${key}"


### PR DESCRIPTION
 - Add aria2 installation to `setup.sh`
 - Use aria2 instead of curl in model-sync script. 
 - Do not sync models during setup stage (that sync is a part of "pre-flight" stage of miner/validator service)