### PR TITLE
Add metadata API endpoint and refactor validator APIs

### DIFF
--- a/neurons/_validator/api/__init__.py
+++ b/neurons/_validator/api/__init__.py
@@ -6,15 +6,20 @@ from fastapi import (
     WebSocket,
     WebSocketDisconnect,
     WebSocketException,
+    Request,
+    Response,
 )
+
+from fastapi.responses import JSONResponse
+
 from jsonrpcserver import (
-    method,
     async_dispatch,
     Success,
     Error,
     InvalidParams,
 )
 
+from fastapi.routing import APIRoute, APIWebSocketRoute
 import bittensor as bt
 from _validator.models.poc_rpc_request import ProofOfComputationRPCRequest
 from _validator.models.pow_rpc_request import ProofOfWeightsRPCRequest
@@ -36,22 +41,39 @@ from _validator.api.certificate_manager import CertificateManager
 from _validator.api.websocket_manager import WebSocketManager
 import asyncio
 from OpenSSL import crypto
+from deployment_layer.circuit_store import circuit_store
+
+
+app = FastAPI()
 
 
 class ValidatorAPI:
     def __init__(self, config: ValidatorConfig):
         self.config = config
-        self.app = FastAPI()
         self.external_requests_queue: list[
             ProofOfWeightsRPCRequest | ProofOfComputationRPCRequest
         ] = []
         self.ws_manager = WebSocketManager()
+        self.recent_requests: dict[str, int] = {}
         self.validator_keys_cache = ValidatorKeysCache(config)
         self.server_thread: threading.Thread | None = None
         self.pending_requests: dict[str, asyncio.Event] = {}
         self.request_results: dict[str, dict[str, any]] = {}
         self.is_testnet = config.bt_config.subtensor.network == "test"
         self._setup_api()
+
+    @app.middleware("http")
+    async def rate_limiter(self, request: Request, call_next):
+        ip = request.client.host
+        if self._should_rate_limit(ip):
+            return Response(status_code=429)
+        return call_next(request)
+
+    def _should_rate_limit(self, ip: str):
+        if ip in self.recent_requests.keys():
+            return max(0, time.time() - self.recent_requests[ip]) < 1
+        self.recent_requests[ip] = time.time()
+        return False
 
     def _setup_api(self) -> None:
         if not self.config.api.enabled:
@@ -70,163 +92,178 @@ class ValidatorAPI:
         self.start_server()
         bt.logging.success("Ready to serve external requests")
 
-    def setup_rpc_methods(self) -> None:
-        @self.app.websocket("/rpc")
-        async def websocket_endpoint(websocket: WebSocket):
-            if (
-                self.config.api.verify_external_signatures
-                and not await self.validate_connection(websocket.headers)
-            ):
-                raise WebSocketException(
-                    code=3000, reason="Connection validation failed"
-                )
+    async def handle_ws(self, websocket: WebSocket):
+        if (
+            self.config.api.verify_external_signatures
+            and not await self.validate_connection(websocket.headers)
+        ):
+            raise WebSocketException(code=3000, reason="Connection validation failed")
 
+        try:
+            await self.ws_manager.connect(websocket)
+            async for data in websocket.iter_text():
+                response = await async_dispatch(
+                    data,
+                    context=websocket,
+                    methods={
+                        "omron.proof_of_weights": self.handle_proof_of_weights,
+                        "omron.proof_of_computation": self.handle_proof_of_computation,
+                    },
+                )
+                await websocket.send_text(str(response))
+        except WebSocketDisconnect:
+            bt.logging.debug("Client disconnected normally")
+        except Exception as e:
+            bt.logging.error(f"WebSocket error: {str(e)}")
+        finally:
+            await self.ws_manager.disconnect(websocket)
+
+    def get_circuits(self, request: Request) -> None:
+
+        try:
+            return JSONResponse(circuit_store.list_circuit_metadata())
+        except Exception:
+            bt.logging.error("Failed to fetch circuit metadata from circuit store.")
+            traceback.print_exc()
+        return Response(status_code=500)
+
+    def _get_routes(self) -> list[APIWebSocketRoute | APIRoute]:
+        rpc_endpoint = APIWebSocketRoute("/rpc", self.handle_ws)
+        get_circuits_endpoint = APIRoute("/circuits", self.get_circuits)
+        return [rpc_endpoint, get_circuits_endpoint]
+
+    async def handle_proof_of_weights(
+        self, websocket: WebSocket, **params: dict[str, object]
+    ) -> dict[str, object]:
+        if not websocket.headers.get("x-netuid"):
+            return InvalidParams(
+                "Missing x-netuid header (required for proof of weights requests)"
+            )
+
+        evaluation_data = params.get("evaluation_data")
+        weights_version = params.get("weights_version")
+
+        if not evaluation_data:
+            return InvalidParams("Missing evaluation data")
+
+        try:
+            netuid = websocket.headers.get("x-netuid")
+            if netuid is None:
+                return InvalidParams("Missing x-netuid header")
+
+            if self.is_testnet:
+                testnet_uids = [
+                    uid[0] for uid in MAINNET_TESTNET_UIDS if uid[1] == int(netuid)
+                ]
+                if not testnet_uids:
+                    return InvalidParams(
+                        f"No testnet UID mapping found for mainnet UID {netuid}"
+                    )
+                netuid = testnet_uids[0]
+
+            netuid = int(netuid)
             try:
-                await self.ws_manager.connect(websocket)
-                async for data in websocket.iter_text():
-                    response = await async_dispatch(data, context=websocket)
-                    await websocket.send_text(str(response))
-            except WebSocketDisconnect:
-                bt.logging.debug("Client disconnected normally")
-            except Exception as e:
-                bt.logging.error(f"WebSocket error: {str(e)}")
+                external_request = ProofOfWeightsRPCRequest(
+                    evaluation_data=evaluation_data,
+                    netuid=netuid,
+                    weights_version=weights_version,
+                )
+            except ValueError as e:
+                return InvalidParams(str(e))
+
+            self.pending_requests[external_request.hash] = asyncio.Event()
+            self.external_requests_queue.insert(0, external_request)
+            bt.logging.success(
+                f"External request with hash {external_request.hash} added to queue"
+            )
+            try:
+                await asyncio.wait_for(
+                    self.pending_requests[external_request.hash].wait(),
+                    timeout=VALIDATOR_REQUEST_TIMEOUT_SECONDS
+                    + EXTERNAL_REQUEST_QUEUE_TIME_SECONDS,
+                )
+                result = self.request_results.pop(external_request.hash, None)
+
+                if result["success"]:
+                    bt.logging.success(
+                        f"External request with hash {external_request.hash} processed successfully"
+                    )
+                    return Success(result)
+                bt.logging.error(
+                    f"External request with hash {external_request.hash} failed to process"
+                )
+                return Error(9, "Request processing failed")
+            except asyncio.TimeoutError:
+                bt.logging.error(
+                    f"External request with hash {external_request.hash} timed out"
+                )
+                return Error(9, "Request processing failed", "Request timed out")
             finally:
-                await self.ws_manager.disconnect(websocket)
+                self.pending_requests.pop(external_request.hash, None)
 
-        @method(name="omron.proof_of_weights")
-        async def omron_proof_of_weights(
-            websocket: WebSocket, **params: dict[str, object]
-        ) -> dict[str, object]:
-            if not websocket.headers.get("x-netuid"):
-                return InvalidParams(
-                    "Missing x-netuid header (required for proof of weights requests)"
-                )
+        except Exception as e:
+            bt.logging.error(f"Error processing request: {str(e)}")
+            traceback.print_exc()
+            return Error(9, "Request processing failed", str(e))
 
-            evaluation_data = params.get("evaluation_data")
-            weights_version = params.get("weights_version")
+    async def handle_proof_of_computation(
+        self, websocket: WebSocket, **params: dict[str, object]
+    ) -> dict[str, object]:
+        input_json = params.get("input")
+        circuit_id = params.get("circuit")
 
-            if not evaluation_data:
-                return InvalidParams("Missing evaluation data")
+        if not input_json:
+            return InvalidParams("Missing input to the circuit")
 
+        if not circuit_id:
+            return InvalidParams("Missing circuit id")
+
+        try:
             try:
-                netuid = websocket.headers.get("x-netuid")
-                if netuid is None:
-                    return InvalidParams("Missing x-netuid header")
-
-                if self.is_testnet:
-                    testnet_uids = [
-                        uid[0] for uid in MAINNET_TESTNET_UIDS if uid[1] == int(netuid)
-                    ]
-                    if not testnet_uids:
-                        return InvalidParams(
-                            f"No testnet UID mapping found for mainnet UID {netuid}"
-                        )
-                    netuid = testnet_uids[0]
-
-                netuid = int(netuid)
-                try:
-                    external_request = ProofOfWeightsRPCRequest(
-                        evaluation_data=evaluation_data,
-                        netuid=netuid,
-                        weights_version=weights_version,
-                    )
-                except ValueError as e:
-                    return InvalidParams(str(e))
-
-                self.pending_requests[external_request.hash] = asyncio.Event()
-                self.external_requests_queue.insert(0, external_request)
-                bt.logging.success(
-                    f"External request with hash {external_request.hash} added to queue"
+                external_request = ProofOfComputationRPCRequest(
+                    circuit_id=circuit_id,
+                    inputs=input_json,
                 )
-                try:
-                    await asyncio.wait_for(
-                        self.pending_requests[external_request.hash].wait(),
-                        timeout=VALIDATOR_REQUEST_TIMEOUT_SECONDS
-                        + EXTERNAL_REQUEST_QUEUE_TIME_SECONDS,
-                    )
-                    result = self.request_results.pop(external_request.hash, None)
+            except ValueError as e:
+                bt.logging.error(
+                    f"Error creating proof of computation request: {str(e)}"
+                )
+                return InvalidParams(str(e))
 
-                    if result["success"]:
-                        bt.logging.success(
-                            f"External request with hash {external_request.hash} processed successfully"
-                        )
-                        return Success(result)
-                    bt.logging.error(
-                        f"External request with hash {external_request.hash} failed to process"
-                    )
-                    return Error(9, "Request processing failed")
-                except asyncio.TimeoutError:
-                    bt.logging.error(
-                        f"External request with hash {external_request.hash} timed out"
-                    )
-                    return Error(9, "Request processing failed", "Request timed out")
-                finally:
-                    self.pending_requests.pop(external_request.hash, None)
-
-            except Exception as e:
-                bt.logging.error(f"Error processing request: {str(e)}")
-                traceback.print_exc()
-                return Error(9, "Request processing failed", str(e))
-
-        @method(name="omron.proof_of_computation")
-        async def omron_proof_of_computation(
-            websocket: WebSocket, **params: dict[str, object]
-        ) -> dict[str, object]:
-            input_json = params.get("input")
-            circuit_id = params.get("circuit")
-
-            if not input_json:
-                return InvalidParams("Missing input to the circuit")
-
-            if not circuit_id:
-                return InvalidParams("Missing circuit id")
-
+            self.pending_requests[external_request.hash] = asyncio.Event()
+            self.external_requests_queue.insert(0, external_request)
+            bt.logging.success(
+                f"External request with hash {external_request.hash} added to queue"
+            )
             try:
-                try:
-                    external_request = ProofOfComputationRPCRequest(
-                        circuit_id=circuit_id,
-                        inputs=input_json,
-                    )
-                except ValueError as e:
-                    bt.logging.error(
-                        f"Error creating proof of computation request: {str(e)}"
-                    )
-                    return InvalidParams(str(e))
-
-                self.pending_requests[external_request.hash] = asyncio.Event()
-                self.external_requests_queue.insert(0, external_request)
-                bt.logging.success(
-                    f"External request with hash {external_request.hash} added to queue"
+                await asyncio.wait_for(
+                    self.pending_requests[external_request.hash].wait(),
+                    timeout=VALIDATOR_REQUEST_TIMEOUT_SECONDS
+                    + EXTERNAL_REQUEST_QUEUE_TIME_SECONDS,
                 )
-                try:
-                    await asyncio.wait_for(
-                        self.pending_requests[external_request.hash].wait(),
-                        timeout=VALIDATOR_REQUEST_TIMEOUT_SECONDS
-                        + EXTERNAL_REQUEST_QUEUE_TIME_SECONDS,
-                    )
-                    result = self.request_results.pop(external_request.hash, None)
+                result = self.request_results.pop(external_request.hash, None)
 
-                    if result["success"]:
-                        bt.logging.success(
-                            f"External request with hash {external_request.hash} processed successfully"
-                        )
-                        return Success(result)
-                    bt.logging.error(
-                        f"External request with hash {external_request.hash} failed to process"
+                if result["success"]:
+                    bt.logging.success(
+                        f"External request with hash {external_request.hash} processed successfully"
                     )
-                    return Error(9, "Request processing failed")
-                except asyncio.TimeoutError:
-                    bt.logging.error(
-                        f"External request with hash {external_request.hash} timed out"
-                    )
-                    return Error(9, "Request processing failed", "Request timed out")
-                finally:
-                    self.pending_requests.pop(external_request.hash, None)
+                    return Success(result)
+                bt.logging.error(
+                    f"External request with hash {external_request.hash} failed to process"
+                )
+                return Error(9, "Request processing failed")
+            except asyncio.TimeoutError:
+                bt.logging.error(
+                    f"External request with hash {external_request.hash} timed out"
+                )
+                return Error(9, "Request processing failed", "Request timed out")
+            finally:
+                self.pending_requests.pop(external_request.hash, None)
 
-            except Exception as e:
-                bt.logging.error(f"Error processing request: {str(e)}")
-                traceback.print_exc()
-                return Error(9, "Request processing failed", str(e))
+        except Exception as e:
+            bt.logging.error(f"Error processing request: {str(e)}")
+            traceback.print_exc()
+            return Error(9, "Request processing failed", str(e))
 
     def start_server(self):
         """Start the uvicorn server in a separate thread"""

--- a/neurons/_validator/api/__init__.py
+++ b/neurons/_validator/api/__init__.py
@@ -88,7 +88,6 @@ class ValidatorAPI:
             )
             self.commit_cert_hash()
 
-        self.setup_rpc_methods()
         self.start_server()
         bt.logging.success("Ready to serve external requests")
 

--- a/neurons/_validator/api/__init__.py
+++ b/neurons/_validator/api/__init__.py
@@ -268,7 +268,7 @@ class ValidatorAPI:
         """Start the uvicorn server in a separate thread"""
         self.server_thread = threading.Thread(
             target=uvicorn.run,
-            args=(self.app,),
+            args=(app,),
             kwargs={
                 "host": "0.0.0.0",
                 "port": self.config.api.port,

--- a/neurons/_validator/api/__init__.py
+++ b/neurons/_validator/api/__init__.py
@@ -81,6 +81,10 @@ class ValidatorAPI:
             return
 
         bt.logging.debug("Starting WebSocket API server...")
+
+        for route in self._get_routes():
+            app.routes.append(route)
+
         if self.config.api.certificate_path:
             cert_manager = CertificateManager(self.config.api.certificate_path)
             cert_manager.ensure_valid_certificate(

--- a/neurons/_validator/api/__init__.py
+++ b/neurons/_validator/api/__init__.py
@@ -78,6 +78,7 @@ class ValidatorAPI:
         self.validator_keys_cache = ValidatorKeysCache(config)
         self.server_thread: threading.Thread | None = None
         self.pending_requests: dict[str, asyncio.Event] = {}
+        self.request_results: dict[str, dict[str, any]] = {}
         self.is_testnet = config.bt_config.subtensor.network == "test"
         self._setup_api()
 

--- a/neurons/_validator/config/__init__.py
+++ b/neurons/_validator/config/__init__.py
@@ -33,7 +33,7 @@ class ValidatorConfig:
         for key, value in vars(config).items():
             setattr(self, key, value)
 
-        self.bt_config = config
+        self.bt_config: bt.Config = config
         self.subnet_uid = int(
             self.bt_config.netuid if self.bt_config.netuid else DEFAULT_NETUID
         )

--- a/neurons/deployment_layer/circuit_store.py
+++ b/neurons/deployment_layer/circuit_store.py
@@ -170,7 +170,7 @@ class CircuitStore:
                     "description": circuit.metadata.description,
                     "author": circuit.metadata.author,
                     "version": circuit.metadata.version,
-                    "type": circuit.metadata.type.value,
+                    "type": circuit.metadata.type,
                     "proof_system": circuit.metadata.proof_system,
                     "netuid": circuit.metadata.netuid,
                     "weights_version": circuit.metadata.weights_version,

--- a/neurons/deployment_layer/circuit_store.py
+++ b/neurons/deployment_layer/circuit_store.py
@@ -175,9 +175,9 @@ class CircuitStore:
                     "netuid": circuit.metadata.netuid,
                     "testnet_netuids": (
                         [
-                            uid[0]
+                            uid[1]
                             for uid in MAINNET_TESTNET_UIDS
-                            if uid[1] == int(circuit.metadata.netuid)
+                            if uid[0] == int(circuit.metadata.netuid)
                         ]
                         if circuit.metadata.netuid
                         else None

--- a/neurons/deployment_layer/circuit_store.py
+++ b/neurons/deployment_layer/circuit_store.py
@@ -7,7 +7,7 @@ from typing import Optional
 import bittensor as bt
 from packaging import version
 
-from constants import IGNORED_MODEL_HASHES
+from constants import IGNORED_MODEL_HASHES, MAINNET_TESTNET_UIDS
 from execution_layer.circuit import Circuit
 
 
@@ -173,6 +173,15 @@ class CircuitStore:
                     "type": circuit.metadata.type,
                     "proof_system": circuit.metadata.proof_system,
                     "netuid": circuit.metadata.netuid,
+                    "testnet_netuids": (
+                        [
+                            uid[0]
+                            for uid in MAINNET_TESTNET_UIDS
+                            if uid[1] == int(circuit.metadata.netuid)
+                        ]
+                        if circuit.metadata.netuid
+                        else None
+                    ),
                     "weights_version": circuit.metadata.weights_version,
                     "input_schema": circuit.input_handler.schema.model_json_schema(),
                 }

--- a/neurons/deployment_layer/circuit_store.py
+++ b/neurons/deployment_layer/circuit_store.py
@@ -157,6 +157,28 @@ class CircuitStore:
         bt.logging.debug(f"Listed {len(circuit_list)} circuits")
         return circuit_list
 
+    def list_circuit_metadata(self) -> list[dict]:
+        """
+        JSON safe circuit metadata for use in API serving.
+        """
+        data: list[dict] = []
+        for circuit in self.circuits.values():
+            data.append(
+                {
+                    "id": circuit.id,
+                    "name": circuit.metadata.name,
+                    "description": circuit.metadata.description,
+                    "author": circuit.metadata.author,
+                    "version": circuit.metadata.version,
+                    "type": circuit.metadata.type.value,
+                    "proof_system": circuit.metadata.proof_system,
+                    "netuid": circuit.metadata.netuid,
+                    "weights_version": circuit.metadata.weights_version,
+                    "input_schema": circuit.input_handler.schema.model_json_schema(),
+                }
+            )
+        return data
+
 
 circuit_store = CircuitStore()
 bt.logging.info("CircuitStore initialized")

--- a/neurons/deployment_layer/model_1e6fcdaea58741e7248b631718dda90398a17b294480beb12ce8232e27ca3bff/input.py
+++ b/neurons/deployment_layer/model_1e6fcdaea58741e7248b631718dda90398a17b294480beb12ce8232e27ca3bff/input.py
@@ -51,7 +51,7 @@ class CircuitInput(BaseInput):
     ):
         if request_type == RequestType.RWR and data is not None:
             data = self._add_missing_constants(data)
-        super().__init__(request_type, data)
+        super().__init__(CircuitInputSchema, request_type, data)
 
     @staticmethod
     def generate() -> dict[str, object]:

--- a/neurons/deployment_layer/model_1e6fcdaea58741e7248b631718dda90398a17b294480beb12ce8232e27ca3bff/input.py
+++ b/neurons/deployment_layer/model_1e6fcdaea58741e7248b631718dda90398a17b294480beb12ce8232e27ca3bff/input.py
@@ -46,12 +46,15 @@ class CircuitInputSchema(BaseModel):
     "1e6fcdaea58741e7248b631718dda90398a17b294480beb12ce8232e27ca3bff"
 )
 class CircuitInput(BaseInput):
+
+    schema = CircuitInputSchema
+
     def __init__(
         self, request_type: RequestType, data: dict[str, object] | None = None
     ):
         if request_type == RequestType.RWR and data is not None:
             data = self._add_missing_constants(data)
-        super().__init__(CircuitInputSchema, request_type, data)
+        super().__init__(request_type, data)
 
     @staticmethod
     def generate() -> dict[str, object]:

--- a/neurons/deployment_layer/model_22825c0d407161956e363b0d14d55d7d90c53706eebfa4fe9fcd839dae6a4a65/input.py
+++ b/neurons/deployment_layer/model_22825c0d407161956e363b0d14d55d7d90c53706eebfa4fe9fcd839dae6a4a65/input.py
@@ -28,10 +28,13 @@ class CircuitInputSchema(BaseModel):
     "22825c0d407161956e363b0d14d55d7d90c53706eebfa4fe9fcd839dae6a4a65"
 )
 class CircuitInput(BaseInput):
+
+    schema = CircuitInputSchema
+
     def __init__(
         self, request_type: RequestType, data: dict[str, object] | None = None
     ):
-        super().__init__(CircuitInputSchema, request_type, data)
+        super().__init__(request_type, data)
 
     @staticmethod
     def generate() -> dict[str, object]:

--- a/neurons/deployment_layer/model_22825c0d407161956e363b0d14d55d7d90c53706eebfa4fe9fcd839dae6a4a65/input.py
+++ b/neurons/deployment_layer/model_22825c0d407161956e363b0d14d55d7d90c53706eebfa4fe9fcd839dae6a4a65/input.py
@@ -31,7 +31,7 @@ class CircuitInput(BaseInput):
     def __init__(
         self, request_type: RequestType, data: dict[str, object] | None = None
     ):
-        super().__init__(request_type, data)
+        super().__init__(CircuitInputSchema, request_type, data)
 
     @staticmethod
     def generate() -> dict[str, object]:

--- a/neurons/deployment_layer/model_96a1315ab963a5a906fb9c7515f60ba386d58310c0ad47bb1049f2dc9b2bdd64/input.py
+++ b/neurons/deployment_layer/model_96a1315ab963a5a906fb9c7515f60ba386d58310c0ad47bb1049f2dc9b2bdd64/input.py
@@ -16,10 +16,13 @@ class CircuitInputSchema(BaseModel):
     "96a1315ab963a5a906fb9c7515f60ba386d58310c0ad47bb1049f2dc9b2bdd64"
 )
 class CircuitInput(BaseInput):
+
+    schema = CircuitInputSchema
+
     def __init__(
         self, request_type: RequestType, data: dict[str, object] | None = None
     ):
-        super().__init__(CircuitInputSchema, request_type, data)
+        super().__init__(request_type, data)
 
     @staticmethod
     def generate() -> dict[str, object]:

--- a/neurons/deployment_layer/model_96a1315ab963a5a906fb9c7515f60ba386d58310c0ad47bb1049f2dc9b2bdd64/input.py
+++ b/neurons/deployment_layer/model_96a1315ab963a5a906fb9c7515f60ba386d58310c0ad47bb1049f2dc9b2bdd64/input.py
@@ -19,7 +19,7 @@ class CircuitInput(BaseInput):
     def __init__(
         self, request_type: RequestType, data: dict[str, object] | None = None
     ):
-        super().__init__(request_type, data)
+        super().__init__(CircuitInputSchema, request_type, data)
 
     @staticmethod
     def generate() -> dict[str, object]:

--- a/neurons/deployment_layer/model_c3d88b7b81ada251385f1fdc3c40ab7ec1673737fefda0ab21b19c8b19b28d10/input.py
+++ b/neurons/deployment_layer/model_c3d88b7b81ada251385f1fdc3c40ab7ec1673737fefda0ab21b19c8b19b28d10/input.py
@@ -43,10 +43,13 @@ class CircuitInputSchema(BaseModel):
     "c3d88b7b81ada251385f1fdc3c40ab7ec1673737fefda0ab21b19c8b19b28d10"
 )
 class CircuitInput(BaseInput):
+
+    schema = CircuitInputSchema
+
     def __init__(
         self, request_type: RequestType, data: dict[str, object] | None = None
     ):
-        super().__init__(CircuitInputSchema, request_type, data)
+        super().__init__(request_type, data)
 
     @staticmethod
     def generate() -> dict[str, object]:

--- a/neurons/deployment_layer/model_c3d88b7b81ada251385f1fdc3c40ab7ec1673737fefda0ab21b19c8b19b28d10/input.py
+++ b/neurons/deployment_layer/model_c3d88b7b81ada251385f1fdc3c40ab7ec1673737fefda0ab21b19c8b19b28d10/input.py
@@ -46,7 +46,7 @@ class CircuitInput(BaseInput):
     def __init__(
         self, request_type: RequestType, data: dict[str, object] | None = None
     ):
-        super().__init__(request_type, data)
+        super().__init__(CircuitInputSchema, request_type, data)
 
     @staticmethod
     def generate() -> dict[str, object]:

--- a/neurons/deployment_layer/model_fa0d509d52abe2d1e809124f8aba46258a02f7253582f7b7f5a22e1e0bca0dfb/input.py
+++ b/neurons/deployment_layer/model_fa0d509d52abe2d1e809124f8aba46258a02f7253582f7b7f5a22e1e0bca0dfb/input.py
@@ -51,7 +51,7 @@ class CircuitInput(BaseInput):
     ):
         if request_type == RequestType.RWR and data is not None:
             data = self._add_missing_constants(data)
-        super().__init__(request_type, data)
+        super().__init__(CircuitInputSchema, request_type, data)
 
     @staticmethod
     def generate() -> dict[str, object]:

--- a/neurons/deployment_layer/model_fa0d509d52abe2d1e809124f8aba46258a02f7253582f7b7f5a22e1e0bca0dfb/input.py
+++ b/neurons/deployment_layer/model_fa0d509d52abe2d1e809124f8aba46258a02f7253582f7b7f5a22e1e0bca0dfb/input.py
@@ -46,12 +46,15 @@ class CircuitInputSchema(BaseModel):
     "fa0d509d52abe2d1e809124f8aba46258a02f7253582f7b7f5a22e1e0bca0dfb"
 )
 class CircuitInput(BaseInput):
+
+    schema = CircuitInputSchema
+
     def __init__(
         self, request_type: RequestType, data: dict[str, object] | None = None
     ):
         if request_type == RequestType.RWR and data is not None:
             data = self._add_missing_constants(data)
-        super().__init__(CircuitInputSchema, request_type, data)
+        super().__init__(request_type, data)
 
     @staticmethod
     def generate() -> dict[str, object]:

--- a/neurons/execution_layer/base_input.py
+++ b/neurons/execution_layer/base_input.py
@@ -10,6 +10,8 @@ class BaseInput(ABC):
     for manipulating circuit input data.
     """
 
+    schema: type[BaseModel]
+
     def __init__(
         self,
         schema: BaseModel,

--- a/neurons/execution_layer/base_input.py
+++ b/neurons/execution_layer/base_input.py
@@ -14,12 +14,10 @@ class BaseInput(ABC):
 
     def __init__(
         self,
-        schema: BaseModel,
         request_type: RequestType,
         data: dict[str, object] | None = None,
     ):
         self.request_type = request_type
-        self.schema = schema
         if request_type == RequestType.BENCHMARK:
             self.data = self.generate()
         else:

--- a/neurons/execution_layer/base_input.py
+++ b/neurons/execution_layer/base_input.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from _validator.models.request_type import RequestType
+from pydantic import BaseModel
 
 
 class BaseInput(ABC):
@@ -10,9 +11,13 @@ class BaseInput(ABC):
     """
 
     def __init__(
-        self, request_type: RequestType, data: dict[str, object] | None = None
+        self,
+        schema: BaseModel,
+        request_type: RequestType,
+        data: dict[str, object] | None = None,
     ):
         self.request_type = request_type
+        self.schema = schema
         if request_type == RequestType.BENCHMARK:
             self.data = self.generate()
         else:

--- a/neurons/execution_layer/circuit.py
+++ b/neurons/execution_layer/circuit.py
@@ -6,6 +6,7 @@ import os
 import json
 import cli_parser
 from execution_layer.input_registry import InputRegistry
+from execution_layer.base_input import BaseInput
 
 # trunk-ignore(pylint/E0611)
 from bittensor import logging
@@ -310,7 +311,7 @@ class Circuit:
             logging.warning(
                 f"Failed to load settings for model {self.id}. Using default settings."
             )
-        self.input_handler = InputRegistry.get_handler(self.id)
+        self.input_handler: BaseInput = InputRegistry.get_handler(self.id)
 
     def __str__(self):
         return (

--- a/neurons/execution_layer/generic_input.py
+++ b/neurons/execution_layer/generic_input.py
@@ -5,10 +5,13 @@ from pydantic import BaseModel
 
 
 class GenericInput(BaseInput):
+
+    schema = BaseModel
+
     def __init__(
         self, request_type: RequestType, data: dict[str, object] | None = None
     ):
-        super().__init__(BaseModel, request_type, data)
+        super().__init__(request_type, data)
 
     @staticmethod
     def generate() -> dict[str, object]:

--- a/neurons/execution_layer/generic_input.py
+++ b/neurons/execution_layer/generic_input.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 from execution_layer.base_input import BaseInput
 from _validator.models.request_type import RequestType
+from pydantic import BaseModel
 
 
 class GenericInput(BaseInput):
     def __init__(
         self, request_type: RequestType, data: dict[str, object] | None = None
     ):
-        super().__init__(request_type, data)
+        super().__init__(BaseModel, request_type, data)
 
     @staticmethod
     def generate() -> dict[str, object]:


### PR DESCRIPTION
- Adds `GET /circuits` providing metadata to frontends regarding circuits supported and input schemas
- Refactors API handlers to align more closely with FastAPI specs and provide a more intuitive websocket flow