### PR TITLE
docs: fix typos and improve grammar

### DIFF
--- a/docs/competitions/QUICKSTART.md
+++ b/docs/competitions/QUICKSTART.md
@@ -70,7 +70,7 @@ Required files in your circuit directory:
 For an example of how to compile this circuit, see the following.
 
 > [!NOTE]
-> This script generates it's own model and is for demonstration purposes only. To compile your own model based on the competition template ONNX, please find it within `neurons/_validator/competitions/1/age.onnx` along with an example `input.json` file.
+> This script generates its own model and is for demonstration purposes only. To compile your own model based on the competition template ONNX, please find it within `neurons/_validator/competitions/1/age.onnx` along with an example `input.json` file.
 
 ```bash
 ./neurons/scripts/create_competition_circuit.py

--- a/docs/competitions/README.md
+++ b/docs/competitions/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This guide provides a deep technical dive into participating in competitions as a miner. Competitions are a mechanism for miners to submit optimized zero-knowledge circuits that prove neural network execution, with rewards based on circuit performance across multiple metrics.
+This guide offers a comprehensive technical overview of participating in competitions as a miner. Competitions serve as a mechanism for miners to submit optimized zero-knowledge circuits that prove the execution of neural networks, with rewards based on circuit performance across multiple metrics.
 
 ## Circuit Evaluation
 
@@ -44,4 +44,4 @@ Resource management plays a crucial role in performance. Proof generation demand
 
 ## Platform Requirements
 
-Currently, validators run using macOS arm64 architecture. This requirement ensures consistent evaluation environments across all participants. While you can develop and test on other platforms, final submissions must be validated on the required architecture to maintain consensus and provide the most optimal benchmark for the use case.
+Currently, validators run using the macOS arm64 architecture. This requirement ensures consistent evaluation environments across all participants. While you can develop and test on other platforms, final submissions must be validated on the required architecture to maintain consensus and provide the most optimal benchmark for the use case.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected two “its” vs. “it’s” typos in competitions quickstart notes referencing example paths and input files.
  * Refined competitions overview wording for clarity (e.g., “serve as a mechanism” and “the execution of neural networks”).
  * Standardized platform requirements phrasing to “the macOS arm64 architecture.”
  * No functional or API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->