### PR TITLE
sn2: dominating miner (docs-only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,5 @@ competition_circuit/**
 
 # intellij files
 .idea/
+.env.super
+sn2-keys-ADDRESSES.txt

--- a/docs/sn2-recovery/BLUEPRINT.md
+++ b/docs/sn2-recovery/BLUEPRINT.md
@@ -1,0 +1,44 @@
+﻿# BLUEPRINT  Dominating Miner on Any Subnet (Docs-Only)
+
+## 1) Recon & Rules
+- Confirm admission model (stake vs PoW vs allowlist).
+- Read the subnets README/spec and validator expectations.
+- **See:** docs/sn2-recovery/DECISIONS.txt for SN2 constraints (image tag format, monitoring policy, backups).
+
+## 2) Wallets & Security
+- Keep wallets on the server only; never commit keys.
+- **Before creation set:** umask 0077 (restrictive defaults).
+- Enforce: chmod -R go-rwx /root/.bittensor/wallets (or your wallet path).
+- Store *addresses-only* snapshot (SS58) in a private note (no secrets).
+
+## 3) Infra Baseline
+- Host networking, stable public IP, open Axon port, synced time.
+- Pin container digest; verify mounts and /dev/shm exist.
+
+## 4) Image & Axon
+- Pin GHCR digest (no floating :latest in production).
+- Bind Axon on a reserved port; confirm listener locally and via public IP (curl HEAD).
+
+## 5) Admission (Timing Strategy)
+- Register only when infra is green. On stake-based nets (e.g., SN2), stake *after* registration and **only** when youre ready to answer immediately.
+
+## 6) Performance Guardrails
+- Start with --axon.max_workers 1; scale cautiously.
+- CPU pinning and SHM sized appropriately; pre-sync models to NVMe.
+
+## 7) Trust & Success Rate
+- Target **99.9%** success (timeouts/rejects capped).
+- Keep response latency within validator budgets; avoid cold starts.
+
+## 8) Monitoring (Examples)
+Tail logs for: Request by, Running proof, , timeout.
+
+**Example lines to spot:**
+- [INFO] Request by validator-xyz in 45ms 
+- [WARN] Running proof took 89ms (budget: 60ms) timeout
+- Miner Status: healthy; proofs=123; success_rate=99.95%
+
+## 9) Rollback & Hygiene
+- Keep a known-good digest and one-liner to restore.
+- Keep wallets backed up (encrypted) with retention policy (30d).
+

--- a/docs/sn2-recovery/DECISIONS.txt
+++ b/docs/sn2-recovery/DECISIONS.txt
@@ -1,0 +1,5 @@
+﻿# DECISIONS (SN2)
+1) Image tag format: ghcr.io/<org>/omron:omron-znver2-YYYYMMDD-<GITSHA_SHORT>
+2) .env.super is gitignored; wallets only on server.
+3) Monitoring private; if exposing, use VPN or UFW allowlist (never 0.0.0.0/0).
+4) Off-host backups only with encryption and 30d retention.

--- a/docs/sn2-recovery/PR_BODY_PLACEHOLDER.md
+++ b/docs/sn2-recovery/PR_BODY_PLACEHOLDER.md
@@ -1,0 +1,11 @@
+**Docs-only PR for SN2 recovery.**
+- After the main miner PR merges and CI publishes, pin the tag from release-note.txt.
+- Target success_rate  99.9% (1h window or 10k requests).
+
+## Checklist
+- [ ] Link to DECISIONS/README
+- [ ] Paste CI image tag + pinned digest
+- [ ] Attach acceptance + loadtest logs
+- [ ] Confirm monitoring remains non-public
+
+

--- a/docs/sn2-recovery/README.md
+++ b/docs/sn2-recovery/README.md
@@ -1,0 +1,14 @@
+# SN2 Dominating Miner  Recovery & Ops (Docs Only)
+**This PR is documentation-only.** Deploy/ops scripts (e.g. deploy_super_miner.sh, pin_image.sh, rollback.sh),
+Makefile targets, and scripts/acceptance.sh live in the **main miner PR**.
+Do **not** run deploy steps until those files are present.
+
+## Checklist
+- [ ] Pin CI-built image tag: `ghcr.io/<org>/omron:omron-znver2-YYYYMMDD-abcdef0`
+- [ ] Attach acceptance + loadtest logs
+- [ ] Keep monitoring non-public (VPN/UFW allowlist only)
+
+## Notes
+- Wallet values stay only in `/opt/omron-super/.env.super` on the server; never commit them.
+
+


### PR DESCRIPTION
**Docs-only PR for SN2 recovery.**
- After the main miner PR merges and CI publishes, pin the tag from `release-note.txt`.
- Target success_rate ≥ 99.9% (1h window or ≥10k requests).

**Checklist**
- [ ] Link to DECISIONS/README in this PR
- [ ] Paste CI image tag + pinned digest
- [ ] Attach acceptance + loadtest logs
- [ ] Confirm monitoring remains non-public (VPN/UFW allowlist only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive recovery and operational docs: decisions, deployment blueprint, runbooks, checklist, monitoring and rollback guidance for miner operations.

* **Chores**
  * Updated ignore rules to exclude sensitive configuration and wallet files from source control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->