### PR TITLE
External IP autodetection fix

### DIFF
--- a/neurons/_miner/server.py
+++ b/neurons/_miner/server.py
@@ -3,6 +3,7 @@ import threading
 
 import bittensor as bt
 import uvicorn
+from bittensor.utils import networking
 from bittensor_wallet import Wallet
 from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException, Request
 from pydantic import BaseModel
@@ -26,7 +27,9 @@ class MinerServer:
         self.metagraph = metagraph
         self.ip: str = self.config.axon.ip
         self.port: int = self.config.axon.port
-        self.external_ip: str = self.config.axon.external_ip
+        self.external_ip: str = (
+            self.config.axon.external_ip or networking.get_external_ip()
+        )
         self.external_port: int = (
             self.config.axon.external_port
             if self.config.axon.external_port is not None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Server now uses automatic network detection to determine its external IP when not explicitly configured. Existing external port behavior remains unchanged.
  * No other functional changes were introduced; startup and connectivity behavior should remain the same unless external IP was previously manually set.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->