### PR TITLE
Eliminate stale model cache directories on startup and deactivation

### DIFF
--- a/crates/sn2-circuit-store/src/lib.rs
+++ b/crates/sn2-circuit-store/src/lib.rs
@@ -138,6 +138,11 @@ impl CircuitStore {
         }
 
         info!(count = self.circuits.len(), "circuits loaded");
+
+        if complete {
+            self.purge_stale_cache_dirs();
+        }
+
         Ok(())
     }
 
@@ -222,6 +227,7 @@ impl CircuitStore {
         for id in &removed {
             info!(id = id, "removing deactivated circuit");
             self.circuits.remove(id);
+            self.remove_cache_dir(id);
         }
 
         Ok(removed)
@@ -850,6 +856,62 @@ impl CircuitStore {
             info!(filename, "downloaded model artifact");
         }
         Ok(())
+    }
+
+    fn remove_cache_dir(&self, circuit_id: &str) {
+        let dir = self.cache_dir.join(format!("model_{circuit_id}"));
+        if dir.exists() {
+            match std::fs::remove_dir_all(&dir) {
+                Ok(()) => {
+                    info!(id = circuit_id, path = %dir.display(), "removed stale model cache directory")
+                }
+                Err(e) => {
+                    warn!(id = circuit_id, path = %dir.display(), error = %e, "failed to remove stale model cache directory")
+                }
+            }
+        }
+    }
+
+    fn purge_stale_cache_dirs(&self) {
+        let entries = match std::fs::read_dir(&self.cache_dir) {
+            Ok(e) => e,
+            Err(_) => return,
+        };
+
+        let downloading = self
+            .inflight_downloads
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone();
+
+        let mut purged = 0usize;
+        for entry in entries.flatten() {
+            let dir_name = entry.file_name().to_string_lossy().to_string();
+            let circuit_id = match dir_name.strip_prefix("model_") {
+                Some(id) if id.len() == 64 => id,
+                _ => continue,
+            };
+
+            if self.circuits.contains_key(circuit_id)
+                || self.pinned_ids.contains(circuit_id)
+                || downloading.contains(circuit_id)
+            {
+                continue;
+            }
+
+            match std::fs::remove_dir_all(entry.path()) {
+                Ok(()) => {
+                    purged += 1;
+                }
+                Err(e) => {
+                    warn!(id = circuit_id, error = %e, "failed to purge stale cache directory");
+                }
+            }
+        }
+
+        if purged > 0 {
+            info!(purged, "purged stale model cache directories");
+        }
     }
 
     fn load_from_cache(&mut self, active_ids: &HashSet<String>) {

--- a/crates/sn2-circuit-store/src/lib.rs
+++ b/crates/sn2-circuit-store/src/lib.rs
@@ -140,7 +140,7 @@ impl CircuitStore {
         info!(count = self.circuits.len(), "circuits loaded");
 
         if complete {
-            self.purge_stale_cache_dirs();
+            self.purge_stale_cache_dirs(&load_ids);
         }
 
         Ok(())
@@ -227,7 +227,7 @@ impl CircuitStore {
         for id in &removed {
             info!(id = id, "removing deactivated circuit");
             self.circuits.remove(id);
-            self.remove_cache_dir(id);
+            self.component_sha_map.retain(|(mid, _), _| mid != id);
         }
 
         Ok(removed)
@@ -858,21 +858,7 @@ impl CircuitStore {
         Ok(())
     }
 
-    fn remove_cache_dir(&self, circuit_id: &str) {
-        let dir = self.cache_dir.join(format!("model_{circuit_id}"));
-        if dir.exists() {
-            match std::fs::remove_dir_all(&dir) {
-                Ok(()) => {
-                    info!(id = circuit_id, path = %dir.display(), "removed stale model cache directory")
-                }
-                Err(e) => {
-                    warn!(id = circuit_id, path = %dir.display(), error = %e, "failed to remove stale model cache directory")
-                }
-            }
-        }
-    }
-
-    fn purge_stale_cache_dirs(&self) {
+    fn purge_stale_cache_dirs(&self, retain_ids: &HashSet<String>) {
         let entries = match std::fs::read_dir(&self.cache_dir) {
             Ok(e) => e,
             Err(_) => return,
@@ -892,10 +878,7 @@ impl CircuitStore {
                 _ => continue,
             };
 
-            if self.circuits.contains_key(circuit_id)
-                || self.pinned_ids.contains(circuit_id)
-                || downloading.contains(circuit_id)
-            {
+            if retain_ids.contains(circuit_id) || downloading.contains(circuit_id) {
                 continue;
             }
 

--- a/crates/sn2-circuit-store/src/lib.rs
+++ b/crates/sn2-circuit-store/src/lib.rs
@@ -874,7 +874,7 @@ impl CircuitStore {
         for entry in entries.flatten() {
             let dir_name = entry.file_name().to_string_lossy().to_string();
             let circuit_id = match dir_name.strip_prefix("model_") {
-                Some(id) if id.len() == 64 => id,
+                Some(id) if is_sha256_hex(id) => id,
                 _ => continue,
             };
 
@@ -882,7 +882,12 @@ impl CircuitStore {
                 continue;
             }
 
-            match std::fs::remove_dir_all(entry.path()) {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+
+            match std::fs::remove_dir_all(&path) {
                 Ok(()) => {
                     purged += 1;
                 }


### PR DESCRIPTION
## Summary
- Introduce `purge_stale_cache_dirs` that runs on validator startup (after `load_circuits`) when the API response is complete — scans `~/.bittensor/subnet-2/circuit_cache/` and removes any `model_*` directories not in the loaded/pinned/downloading sets
- Introduce `remove_cache_dir` called during `refresh_circuits` when circuits leave the active set — deletes the disk cache immediately alongside the existing in-memory eviction
- Previously, `evict_circuit_cache` only cleared in-memory state; `model_*` directories accumulated on disk indefinitely

## Test plan
- [ ] Deploy to testnet validator, confirm stale directories are purged on startup (check logs for `purged stale model cache directories`)
- [ ] Deactivate a model via repository API, verify directory is removed on next refresh cycle (check logs for `removed stale model cache directory`)
- [ ] Confirm active/pinned circuits are not affected
- [ ] Verify partial API responses skip the purge (existing safeguard preserved)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved cache lifecycle: stale model cache directories are now automatically purged when API fetches complete and when circuits are refreshed or removed, reducing disk usage.
  * Metadata cleanup: obsolete component checksum entries tied to removed circuits are now removed, keeping local metadata consistent.
  * Operational visibility: purges increment counters and emit logs for successful and failed removals to aid monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->