### PR TITLE
Resolve miner proof system config detection from circuit metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -287,7 +287,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -361,23 +361,7 @@ dependencies = [
  "itertools 0.13.0",
  "log",
  "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "tynm",
-]
-
-[[package]]
-name = "arith"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "ark-std 0.4.0",
- "criterion",
- "ethnum",
- "halo2curves",
- "itertools 0.13.0",
- "log",
- "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "serdes",
  "tynm",
 ]
 
@@ -1093,23 +1077,11 @@ name = "babybear"
 version = "0.4.0"
 source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "ark-std 0.4.0",
  "ethnum",
  "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
-]
-
-[[package]]
-name = "babybear"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ark-std 0.4.0",
- "ethnum",
- "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "serdes",
 ]
 
 [[package]]
@@ -1197,58 +1169,28 @@ name = "bin"
 version = "0.4.0"
 source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "babybear 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
+ "babybear",
  "bytes",
  "chrono",
- "circuit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "circuit",
  "clap",
- "config_macros 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gf2 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gf2_128 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "goldilocks 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "config_macros",
+ "gf2",
+ "gf2_128",
+ "gkr",
+ "gkr_engine",
+ "gkr_hashers",
+ "goldilocks",
  "log",
- "mersenne31 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "poly_commit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "polynomials 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "sumcheck 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "mersenne31",
+ "poly_commit",
+ "polynomials",
+ "serdes",
+ "sumcheck",
  "tokio",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "utils 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "warp",
-]
-
-[[package]]
-name = "bin"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "babybear 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "bytes",
- "chrono",
- "circuit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "clap",
- "config_macros 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gf2 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gf2_128 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "goldilocks 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "log",
- "mersenne31 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "poly_commit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "polynomials 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "sumcheck 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "tokio",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "utils 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "transcript",
+ "utils",
  "warp",
 ]
 
@@ -2017,35 +1959,17 @@ name = "circuit"
 version = "0.4.0"
 source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "ark-std 0.4.0",
  "bytes",
  "ethnum",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "gkr_engine",
+ "gkr_hashers",
  "log",
  "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "serdes",
  "thiserror 2.0.18",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
-]
-
-[[package]]
-name = "circuit"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ark-std 0.4.0",
- "bytes",
- "ethnum",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "log",
- "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "thiserror 2.0.18",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "transcript",
 ]
 
 [[package]]
@@ -2053,51 +1977,24 @@ name = "circuit-std-rs"
 version = "0.4.0"
 source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "ark-bls12-381",
  "ark-ec",
  "ark-ff 0.4.2",
  "ark-std 0.4.0",
  "big-int",
- "circuit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "circuit",
  "ethnum",
- "expander_compiler 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gf2 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "expander_compiler",
+ "gf2",
+ "gkr",
+ "gkr_hashers",
  "halo2curves",
- "mersenne31 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "mersenne31",
  "num-bigint",
  "num-traits",
  "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "sha2 0.10.9",
- "tiny-keccak",
-]
-
-[[package]]
-name = "circuit-std-rs"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ark-bls12-381",
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-std 0.4.0",
- "big-int",
- "circuit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ethnum",
- "expander_compiler 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gf2 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "halo2curves",
- "mersenne31 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "num-bigint",
- "num-traits",
- "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "serdes",
  "sha2 0.10.9",
  "tiny-keccak",
 ]
@@ -2208,27 +2105,13 @@ name = "config_macros"
 version = "0.4.0"
 source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
 dependencies = [
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "poly_commit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "gkr_engine",
+ "gkr_hashers",
+ "poly_commit",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
-]
-
-[[package]]
-name = "config_macros"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "poly_commit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "transcript",
 ]
 
 [[package]]
@@ -2582,37 +2465,18 @@ name = "crosslayer_prototype"
 version = "0.4.0"
 source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "env_logger 0.11.10",
  "ethnum",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "gkr_engine",
+ "gkr_hashers",
  "log",
- "polynomials 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "polynomials",
  "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "sumcheck 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "serdes",
+ "sumcheck",
  "thiserror 2.0.18",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
-]
-
-[[package]]
-name = "crosslayer_prototype"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "env_logger 0.11.10",
- "ethnum",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "log",
- "polynomials 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "sumcheck 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "thiserror 2.0.18",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "transcript",
 ]
 
 [[package]]
@@ -3339,7 +3203,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3406,10 +3270,10 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 [[package]]
 name = "dsperse"
 version = "0.0.0"
-source = "git+https://github.com/inference-labs-inc/dsperse?rev=3d1db73f#3d1db73f5cb75dc00a615238f6c360382ef6ba11"
+source = "git+https://github.com/inference-labs-inc/dsperse?rev=839ca564#839ca56428b21834ab1e949919e686c197fb9ab6"
 dependencies = [
  "clap",
- "jstprove_circuits 0.1.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "jstprove_circuits",
  "libc",
  "ndarray 0.17.2",
  "prost 0.13.5",
@@ -3725,7 +3589,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3826,81 +3690,40 @@ name = "expander_compiler"
 version = "0.4.0"
 source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "ark-std 0.4.0",
  "axum",
- "babybear 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "bin 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "babybear",
+ "bin",
  "chrono",
- "circuit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "circuit",
  "clap",
- "crosslayer_prototype 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "crosslayer_prototype",
  "ethnum",
- "gf2 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "goldilocks 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "gf2",
+ "gkr",
+ "gkr_engine",
+ "gkr_hashers",
+ "goldilocks",
  "halo2curves",
- "macros 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "mersenne31 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "macros",
+ "mersenne31",
  "num_cpus",
  "once_cell",
- "poly_commit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "polynomials 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "poly_commit",
+ "polynomials",
  "rand 0.8.5",
  "rayon",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "serdes",
  "shared_memory",
- "sumcheck 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "sumcheck",
  "tiny-keccak",
  "tokio",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "utils 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
-]
-
-[[package]]
-name = "expander_compiler"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ark-std 0.4.0",
- "axum",
- "babybear 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "bin 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "chrono",
- "circuit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "clap",
- "crosslayer_prototype 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ethnum",
- "gf2 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "goldilocks 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "halo2curves",
- "macros 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "mersenne31 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "num_cpus",
- "once_cell",
- "poly_commit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "polynomials 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "rand 0.8.5",
- "rayon",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "shared_memory",
- "sumcheck 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "tiny-keccak",
- "tokio",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "utils 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "transcript",
+ "utils",
 ]
 
 [[package]]
@@ -4621,7 +4444,7 @@ name = "gf2"
 version = "0.4.0"
 source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "ark-std 0.4.0",
  "cfg-if",
  "ethnum",
@@ -4629,24 +4452,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "raw-cpuid",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gf2"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ark-std 0.4.0",
- "cfg-if",
- "ethnum",
- "halo2curves",
- "log",
- "rand 0.8.5",
- "raw-cpuid",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "serdes",
  "thiserror 2.0.18",
 ]
 
@@ -4655,25 +4461,12 @@ name = "gf2_128"
 version = "0.4.0"
 source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "ark-std 0.4.0",
  "ethnum",
- "gf2 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "gf2",
  "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
-]
-
-[[package]]
-name = "gf2_128"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ark-std 0.4.0",
- "ethnum",
- "gf2 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "serdes",
 ]
 
 [[package]]
@@ -4718,63 +4511,31 @@ name = "gkr"
 version = "0.4.0"
 source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "ark-std 0.4.0",
- "babybear 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "circuit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "config_macros 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "babybear",
+ "circuit",
+ "config_macros",
  "env_logger 0.11.10",
  "ethnum",
- "gf2 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gf2_128 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "goldilocks 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "gf2",
+ "gf2_128",
+ "gkr_engine",
+ "gkr_hashers",
+ "goldilocks",
  "halo2curves",
  "log",
- "mersenne31 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "poly_commit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "polynomials 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "mersenne31",
+ "poly_commit",
+ "polynomials",
  "rand 0.8.5",
  "rayon",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "serdes",
  "sha2 0.10.9",
- "sumcheck 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "sumcheck",
  "thiserror 2.0.18",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "utils 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
-]
-
-[[package]]
-name = "gkr"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ark-std 0.4.0",
- "babybear 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "circuit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "config_macros 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "env_logger 0.11.10",
- "ethnum",
- "gf2 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gf2_128 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "goldilocks 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "halo2curves",
- "log",
- "mersenne31 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "poly_commit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "polynomials 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "rand 0.8.5",
- "rayon",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "sha2 0.10.9",
- "sumcheck 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "thiserror 2.0.18",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "utils 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "transcript",
+ "utils",
 ]
 
 [[package]]
@@ -4782,34 +4543,16 @@ name = "gkr_engine"
 version = "0.4.0"
 source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "babybear 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gf2 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gf2_128 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "goldilocks 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
+ "babybear",
+ "gf2",
+ "gf2_128",
+ "goldilocks",
  "itertools 0.13.0",
- "mersenne31 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "polynomials 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "mersenne31",
+ "polynomials",
  "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gkr_engine"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "babybear 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gf2 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gf2_128 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "goldilocks 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "itertools 0.13.0",
- "mersenne31 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "polynomials 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "serdes",
  "thiserror 2.0.18",
 ]
 
@@ -4818,21 +4561,9 @@ name = "gkr_hashers"
 version = "0.4.0"
 source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "halo2curves",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "sha2 0.10.9",
- "tiny-keccak",
-]
-
-[[package]]
-name = "gkr_hashers"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "halo2curves",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "serdes",
  "sha2 0.10.9",
  "tiny-keccak",
 ]
@@ -4842,23 +4573,11 @@ name = "goldilocks"
 version = "0.4.0"
 source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "ark-std 0.4.0",
  "ethnum",
  "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
-]
-
-[[package]]
-name = "goldilocks"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ark-std 0.4.0",
- "ethnum",
- "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "serdes",
 ]
 
 [[package]]
@@ -5661,7 +5380,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6087,32 +5806,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "jstprove-io"
-version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "anyhow",
- "crc32c",
- "rmp-serde",
- "serde",
- "zstd 0.13.3",
-]
-
-[[package]]
 name = "jstprove-onnx"
 version = "0.1.0"
 source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
-dependencies = [
- "anyhow",
- "prost 0.13.5",
- "prost-build",
- "serde",
-]
-
-[[package]]
-name = "jstprove-onnx"
-version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
 dependencies = [
  "anyhow",
  "prost 0.13.5",
@@ -6126,58 +5822,18 @@ version = "0.1.0"
 source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
 dependencies = [
  "anyhow",
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "ark-std 0.4.0",
  "chrono",
- "circuit-std-rs 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "circuit-std-rs",
  "clap",
  "console 0.15.11",
  "ethnum",
- "expander_compiler 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "expander_compiler",
  "halo2curves",
  "indicatif",
- "jstprove-io 0.1.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "jstprove-onnx 0.1.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "lazy_static",
- "ndarray 0.16.1",
- "num-bigint",
- "num-traits",
- "once_cell",
- "openssl",
- "rand 0.8.5",
- "rayon",
- "rmp-serde",
- "rmpv",
- "serde",
- "serde_bytes",
- "serde_json",
- "strum 0.27.2",
- "strum_macros 0.27.2",
- "tempfile",
- "thiserror 2.0.18",
- "tiny-keccak",
- "tracing",
- "zstd 0.13.3",
-]
-
-[[package]]
-name = "jstprove_circuits"
-version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "anyhow",
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ark-std 0.4.0",
- "chrono",
- "circuit-std-rs 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "clap",
- "console 0.15.11",
- "ethnum",
- "expander_compiler 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "halo2curves",
- "indicatif",
- "jstprove-io 0.1.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "jstprove-onnx 0.1.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "jstprove-io",
+ "jstprove-onnx",
  "lazy_static",
  "ndarray 0.16.1",
  "num-bigint",
@@ -6539,16 +6195,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "macros"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6656,34 +6302,16 @@ name = "mersenne31"
 version = "0.4.0"
 source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "ark-std 0.4.0",
  "cfg-if",
  "ethnum",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "gkr_hashers",
  "halo2curves",
  "log",
  "rand 0.8.5",
  "raw-cpuid",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "mersenne31"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ark-std 0.4.0",
- "cfg-if",
- "ethnum",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "halo2curves",
- "log",
- "rand 0.8.5",
- "raw-cpuid",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "serdes",
  "thiserror 2.0.18",
 ]
 
@@ -6935,7 +6563,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10231,51 +9859,25 @@ name = "poly_commit"
 version = "0.4.0"
 source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "ark-std 0.4.0",
  "derivative",
  "ethnum",
- "gf2 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "gf2",
+ "gkr_engine",
  "halo2curves",
  "itertools 0.13.0",
- "polynomials 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "polynomials",
  "rand 0.8.5",
  "rayon",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "serdes",
  "sha2 0.10.9",
- "sumcheck 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "sumcheck",
  "thiserror 2.0.18",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "transcript",
  "transpose",
- "tree 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "utils 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
-]
-
-[[package]]
-name = "poly_commit"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ark-std 0.4.0",
- "derivative",
- "ethnum",
- "gf2 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "halo2curves",
- "itertools 0.13.0",
- "polynomials 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "rand 0.8.5",
- "rayon",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "sha2 0.10.9",
- "sumcheck 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "thiserror 2.0.18",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "transpose",
- "tree 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "utils 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "tree",
+ "utils",
 ]
 
 [[package]]
@@ -10283,27 +9885,13 @@ name = "polynomials"
 version = "0.4.0"
 source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "ark-std 0.4.0",
  "criterion",
  "halo2curves",
  "itertools 0.13.0",
  "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
-]
-
-[[package]]
-name = "polynomials"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ark-std 0.4.0",
- "criterion",
- "halo2curves",
- "itertools 0.13.0",
- "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "serdes",
 ]
 
 [[package]]
@@ -11297,7 +10885,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11467,7 +11055,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12247,18 +11835,7 @@ source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#75
 dependencies = [
  "ethnum",
  "halo2curves",
- "serdes_derive 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "serdes"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "ethnum",
- "halo2curves",
- "serdes_derive 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "serdes_derive",
  "thiserror 2.0.18",
 ]
 
@@ -12266,16 +11843,6 @@ dependencies = [
 name = "serdes_derive"
 version = "0.4.0"
 source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "serdes_derive"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12715,6 +12282,7 @@ dependencies = [
  "clap",
  "dsperse",
  "hex",
+ "jstprove-io",
  "reqwest 0.12.28",
  "rmp-serde",
  "serde_json",
@@ -12778,8 +12346,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "hex",
- "jstprove-io 0.1.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "jstprove_circuits 0.1.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "jstprove-io",
+ "jstprove_circuits",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -13130,7 +12698,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14643,35 +14211,17 @@ name = "sumcheck"
 version = "0.4.0"
 source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "circuit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
+ "circuit",
  "env_logger 0.11.10",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "gkr_engine",
+ "gkr_hashers",
  "log",
- "polynomials 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "polynomials",
  "rayon",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "utils 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
-]
-
-[[package]]
-name = "sumcheck"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "circuit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "env_logger 0.11.10",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "log",
- "polynomials 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "rayon",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "utils 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "serdes",
+ "transcript",
+ "utils",
 ]
 
 [[package]]
@@ -14800,7 +14350,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15537,23 +15087,10 @@ name = "transcript"
 version = "0.4.0"
 source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "sha2 0.10.9",
- "tiny-keccak",
-]
-
-[[package]]
-name = "transcript"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "arith",
+ "gkr_engine",
+ "gkr_hashers",
+ "serdes",
  "sha2 0.10.9",
  "tiny-keccak",
 ]
@@ -15573,20 +15110,9 @@ name = "tree"
 version = "0.4.0"
 source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "ark-std 0.4.0",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "tiny-keccak",
-]
-
-[[package]]
-name = "tree"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ark-std 0.4.0",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "serdes",
  "tiny-keccak",
 ]
 
@@ -15842,11 +15368,6 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 name = "utils"
 version = "0.4.0"
 source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
-
-[[package]]
-name = "utils"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
 
 [[package]]
 name = "uuid"
@@ -16536,7 +16057,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ futures-util = "0.3"
 shellexpand = "3.1.2"
 openssl = { version = "0.10", features = ["vendored"] }
 flate2 = "1"
-dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "3d1db73f" }
+dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "839ca564" }
 ndarray = { version = "0.17", features = ["serde"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 bittensor-drand = { git = "https://github.com/inference-labs-inc/bittensor-drand.git", rev = "e55ed98", default-features = false }

--- a/crates/sn2-miner/Cargo.toml
+++ b/crates/sn2-miner/Cargo.toml
@@ -25,3 +25,4 @@ hex = { workspace = true }
 subxt = { workspace = true }
 shellexpand = { workspace = true }
 rmp-serde = { workspace = true }
+jstprove-io = { workspace = true }

--- a/crates/sn2-miner/src/dsperse.rs
+++ b/crates/sn2-miner/src/dsperse.rs
@@ -56,6 +56,28 @@ fn extract_input_json(inputs: &serde_json::Value) -> &serde_json::Value {
     inputs
 }
 
+fn detect_curve_from_bundle(circuit_path: &Path) -> Option<dsperse::backend::jstprove::Curve> {
+    use dsperse::backend::jstprove::Curve;
+    let blob = jstprove_io::bundle::read_circuit_blob(circuit_path).ok()?;
+    let data = jstprove_io::compress::auto_decompress_bytes(&blob).ok()?;
+    if data.len() < 40 {
+        return None;
+    }
+    let modulus = &data[8..40];
+    #[rustfmt::skip]
+    const BN254_MODULUS: [u8; 32] = [
+        0x01, 0x00, 0x00, 0xf0, 0x93, 0xf5, 0xe1, 0x43,
+        0x91, 0x70, 0xb9, 0x79, 0x48, 0xe8, 0x33, 0x28,
+        0x5d, 0x58, 0x81, 0x81, 0xb6, 0x45, 0x50, 0xb8,
+        0x29, 0xa0, 0x31, 0xe1, 0x72, 0x4e, 0x64, 0x30,
+    ];
+    if modulus[..32] == BN254_MODULUS {
+        Some(Curve::Bn254)
+    } else {
+        Some(Curve::GoldilocksWhirPQ)
+    }
+}
+
 fn prove_and_build_response(
     backend: &dsperse::backend::jstprove::JstproveBackend,
     circuit_path: &Path,
@@ -169,7 +191,10 @@ impl DSperseClient {
 
         tokio::task::spawn_blocking(move || -> Result<serde_json::Value> {
             let inputs_bytes = rmp_serde::to_vec_named(&inputs_clone)?;
-            let backend = dsperse::backend::jstprove::JstproveBackend::new();
+            let mut backend = dsperse::backend::jstprove::JstproveBackend::new();
+            if let Some(curve) = detect_curve_from_bundle(&circuit_path) {
+                backend = backend.with_curve(curve);
+            }
 
             let params = backend
                 .load_params(&circuit_path)
@@ -236,7 +261,10 @@ impl DSperseClient {
                 "invalid input tensor: flattened input is empty"
             );
 
-            let backend = dsperse::backend::jstprove::JstproveBackend::new();
+            let mut backend = dsperse::backend::jstprove::JstproveBackend::new();
+            if let Some(curve) = detect_curve_from_bundle(&circuit_path) {
+                backend = backend.with_curve(curve);
+            }
             let params = backend
                 .load_params(&circuit_path)
                 .map_err(|e| anyhow::anyhow!("loading circuit params: {e}"))?;


### PR DESCRIPTION
## Summary

- Read the curve field from circuit params and configure the proving backend accordingly
- Replaces hardcoded default config, enabling miners to generate proofs for circuits compiled with non-default configurations

## Test plan

- [x] `cargo clippy -- -D warnings` — clean
- [ ] Deploy miner on testnet and verify proof generation with multi-config circuits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic curve detection from circuit bundles so the miner adapts to the circuit's curve when present.

* **Bug Fixes**
  * Applies detected curve parameters to the proof backend before loading circuit parameters and generating witnesses/proofs, improving reliability.

* **Chores**
  * Updated dependency revisions and added a workspace IO dependency to support the feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->