### PR TITLE
Delegate circuit loading and verification to dsperse backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -287,7 +287,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -352,7 +352,7 @@ dependencies = [
 [[package]]
 name = "arith"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "ark-std 0.4.0",
  "criterion",
@@ -361,23 +361,7 @@ dependencies = [
  "itertools 0.13.0",
  "log",
  "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "tynm",
-]
-
-[[package]]
-name = "arith"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "ark-std 0.4.0",
- "criterion",
- "ethnum",
- "halo2curves",
- "itertools 0.13.0",
- "log",
- "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "serdes",
  "tynm",
 ]
 
@@ -1091,25 +1075,13 @@ dependencies = [
 [[package]]
 name = "babybear"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "ark-std 0.4.0",
  "ethnum",
  "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
-]
-
-[[package]]
-name = "babybear"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ark-std 0.4.0",
- "ethnum",
- "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "serdes",
 ]
 
 [[package]]
@@ -1195,60 +1167,30 @@ dependencies = [
 [[package]]
 name = "bin"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "babybear 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
+ "babybear",
  "bytes",
  "chrono",
- "circuit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "circuit",
  "clap",
- "config_macros 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gf2 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gf2_128 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "goldilocks 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "config_macros",
+ "gf2",
+ "gf2_128",
+ "gkr",
+ "gkr_engine",
+ "gkr_hashers",
+ "goldilocks",
  "log",
- "mersenne31 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "poly_commit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "polynomials 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "sumcheck 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "mersenne31",
+ "poly_commit",
+ "polynomials",
+ "serdes",
+ "sumcheck",
  "tokio",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "utils 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "warp",
-]
-
-[[package]]
-name = "bin"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "babybear 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "bytes",
- "chrono",
- "circuit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "clap",
- "config_macros 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gf2 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gf2_128 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "goldilocks 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "log",
- "mersenne31 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "poly_commit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "polynomials 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "sumcheck 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "tokio",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "utils 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "transcript",
+ "utils",
  "warp",
 ]
 
@@ -2015,89 +1957,44 @@ dependencies = [
 [[package]]
 name = "circuit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "ark-std 0.4.0",
  "bytes",
  "ethnum",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "gkr_engine",
+ "gkr_hashers",
  "log",
  "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "serdes",
  "thiserror 2.0.18",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
-]
-
-[[package]]
-name = "circuit"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ark-std 0.4.0",
- "bytes",
- "ethnum",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "log",
- "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "thiserror 2.0.18",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "transcript",
 ]
 
 [[package]]
 name = "circuit-std-rs"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "ark-bls12-381",
  "ark-ec",
  "ark-ff 0.4.2",
  "ark-std 0.4.0",
  "big-int",
- "circuit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "circuit",
  "ethnum",
- "expander_compiler 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gf2 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "expander_compiler",
+ "gf2",
+ "gkr",
+ "gkr_hashers",
  "halo2curves",
- "mersenne31 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "mersenne31",
  "num-bigint",
  "num-traits",
  "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "sha2 0.10.9",
- "tiny-keccak",
-]
-
-[[package]]
-name = "circuit-std-rs"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ark-bls12-381",
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-std 0.4.0",
- "big-int",
- "circuit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ethnum",
- "expander_compiler 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gf2 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "halo2curves",
- "mersenne31 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "num-bigint",
- "num-traits",
- "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "serdes",
  "sha2 0.10.9",
  "tiny-keccak",
 ]
@@ -2206,29 +2103,15 @@ dependencies = [
 [[package]]
 name = "config_macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "poly_commit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "gkr_engine",
+ "gkr_hashers",
+ "poly_commit",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
-]
-
-[[package]]
-name = "config_macros"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "poly_commit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "transcript",
 ]
 
 [[package]]
@@ -2580,39 +2463,20 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 [[package]]
 name = "crosslayer_prototype"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "env_logger 0.11.10",
  "ethnum",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "gkr_engine",
+ "gkr_hashers",
  "log",
- "polynomials 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "polynomials",
  "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "sumcheck 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "serdes",
+ "sumcheck",
  "thiserror 2.0.18",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
-]
-
-[[package]]
-name = "crosslayer_prototype"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "env_logger 0.11.10",
- "ethnum",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "log",
- "polynomials 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "sumcheck 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "thiserror 2.0.18",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "transcript",
 ]
 
 [[package]]
@@ -3339,7 +3203,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3406,10 +3270,10 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 [[package]]
 name = "dsperse"
 version = "0.0.0"
-source = "git+https://github.com/inference-labs-inc/dsperse?rev=3d1db73f#3d1db73f5cb75dc00a615238f6c360382ef6ba11"
+source = "git+https://github.com/inference-labs-inc/dsperse?rev=bf11b93c#bf11b93cc8de70ef0b98cef1d3cfcedc6e2ffded"
 dependencies = [
  "clap",
- "jstprove_circuits 0.1.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "jstprove_circuits",
  "libc",
  "ndarray 0.17.2",
  "prost 0.13.5",
@@ -3725,7 +3589,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3824,83 +3688,42 @@ dependencies = [
 [[package]]
 name = "expander_compiler"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "ark-std 0.4.0",
  "axum",
- "babybear 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "bin 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "babybear",
+ "bin",
  "chrono",
- "circuit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "circuit",
  "clap",
- "crosslayer_prototype 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "crosslayer_prototype",
  "ethnum",
- "gf2 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "goldilocks 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "gf2",
+ "gkr",
+ "gkr_engine",
+ "gkr_hashers",
+ "goldilocks",
  "halo2curves",
- "macros 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "mersenne31 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "macros",
+ "mersenne31",
  "num_cpus",
  "once_cell",
- "poly_commit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "polynomials 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "poly_commit",
+ "polynomials",
  "rand 0.8.5",
  "rayon",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "serdes",
  "shared_memory",
- "sumcheck 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "sumcheck",
  "tiny-keccak",
  "tokio",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "utils 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
-]
-
-[[package]]
-name = "expander_compiler"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ark-std 0.4.0",
- "axum",
- "babybear 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "bin 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "chrono",
- "circuit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "clap",
- "crosslayer_prototype 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ethnum",
- "gf2 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "goldilocks 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "halo2curves",
- "macros 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "mersenne31 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "num_cpus",
- "once_cell",
- "poly_commit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "polynomials 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "rand 0.8.5",
- "rayon",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "shared_memory",
- "sumcheck 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "tiny-keccak",
- "tokio",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "utils 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "transcript",
+ "utils",
 ]
 
 [[package]]
@@ -4619,9 +4442,9 @@ dependencies = [
 [[package]]
 name = "gf2"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "ark-std 0.4.0",
  "cfg-if",
  "ethnum",
@@ -4629,51 +4452,21 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "raw-cpuid",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gf2"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ark-std 0.4.0",
- "cfg-if",
- "ethnum",
- "halo2curves",
- "log",
- "rand 0.8.5",
- "raw-cpuid",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "serdes",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gf2_128"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "ark-std 0.4.0",
  "ethnum",
- "gf2 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "gf2",
  "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
-]
-
-[[package]]
-name = "gf2_128"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ark-std 0.4.0",
- "ethnum",
- "gf2 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "serdes",
 ]
 
 [[package]]
@@ -4716,123 +4509,61 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 [[package]]
 name = "gkr"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "ark-std 0.4.0",
- "babybear 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "circuit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "config_macros 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "babybear",
+ "circuit",
+ "config_macros",
  "env_logger 0.11.10",
  "ethnum",
- "gf2 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gf2_128 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "goldilocks 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "gf2",
+ "gf2_128",
+ "gkr_engine",
+ "gkr_hashers",
+ "goldilocks",
  "halo2curves",
  "log",
- "mersenne31 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "poly_commit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "polynomials 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "mersenne31",
+ "poly_commit",
+ "polynomials",
  "rand 0.8.5",
  "rayon",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "serdes",
  "sha2 0.10.9",
- "sumcheck 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "sumcheck",
  "thiserror 2.0.18",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "utils 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
-]
-
-[[package]]
-name = "gkr"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ark-std 0.4.0",
- "babybear 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "circuit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "config_macros 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "env_logger 0.11.10",
- "ethnum",
- "gf2 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gf2_128 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "goldilocks 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "halo2curves",
- "log",
- "mersenne31 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "poly_commit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "polynomials 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "rand 0.8.5",
- "rayon",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "sha2 0.10.9",
- "sumcheck 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "thiserror 2.0.18",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "utils 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "transcript",
+ "utils",
 ]
 
 [[package]]
 name = "gkr_engine"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "babybear 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gf2 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gf2_128 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "goldilocks 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
+ "babybear",
+ "gf2",
+ "gf2_128",
+ "goldilocks",
  "itertools 0.13.0",
- "mersenne31 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "polynomials 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "mersenne31",
+ "polynomials",
  "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gkr_engine"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "babybear 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gf2 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gf2_128 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "goldilocks 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "itertools 0.13.0",
- "mersenne31 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "polynomials 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "serdes",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gkr_hashers"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "halo2curves",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "sha2 0.10.9",
- "tiny-keccak",
-]
-
-[[package]]
-name = "gkr_hashers"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "halo2curves",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "serdes",
  "sha2 0.10.9",
  "tiny-keccak",
 ]
@@ -4840,25 +4571,13 @@ dependencies = [
 [[package]]
 name = "goldilocks"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "ark-std 0.4.0",
  "ethnum",
  "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
-]
-
-[[package]]
-name = "goldilocks"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ark-std 0.4.0",
- "ethnum",
- "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "serdes",
 ]
 
 [[package]]
@@ -5661,7 +5380,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6077,19 +5796,7 @@ dependencies = [
 [[package]]
 name = "jstprove-io"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
-dependencies = [
- "anyhow",
- "crc32c",
- "rmp-serde",
- "serde",
- "zstd 0.13.3",
-]
-
-[[package]]
-name = "jstprove-io"
-version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "anyhow",
  "crc32c",
@@ -6101,18 +5808,7 @@ dependencies = [
 [[package]]
 name = "jstprove-onnx"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
-dependencies = [
- "anyhow",
- "prost 0.13.5",
- "prost-build",
- "serde",
-]
-
-[[package]]
-name = "jstprove-onnx"
-version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "anyhow",
  "prost 0.13.5",
@@ -6123,61 +5819,21 @@ dependencies = [
 [[package]]
 name = "jstprove_circuits"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "anyhow",
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "ark-std 0.4.0",
  "chrono",
- "circuit-std-rs 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "circuit-std-rs",
  "clap",
  "console 0.15.11",
  "ethnum",
- "expander_compiler 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "expander_compiler",
  "halo2curves",
  "indicatif",
- "jstprove-io 0.1.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "jstprove-onnx 0.1.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "lazy_static",
- "ndarray 0.16.1",
- "num-bigint",
- "num-traits",
- "once_cell",
- "openssl",
- "rand 0.8.5",
- "rayon",
- "rmp-serde",
- "rmpv",
- "serde",
- "serde_bytes",
- "serde_json",
- "strum 0.27.2",
- "strum_macros 0.27.2",
- "tempfile",
- "thiserror 2.0.18",
- "tiny-keccak",
- "tracing",
- "zstd 0.13.3",
-]
-
-[[package]]
-name = "jstprove_circuits"
-version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "anyhow",
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ark-std 0.4.0",
- "chrono",
- "circuit-std-rs 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "clap",
- "console 0.15.11",
- "ethnum",
- "expander_compiler 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "halo2curves",
- "indicatif",
- "jstprove-io 0.1.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "jstprove-onnx 0.1.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "jstprove-io",
+ "jstprove-onnx",
  "lazy_static",
  "ndarray 0.16.1",
  "num-bigint",
@@ -6531,17 +6187,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "macros"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6654,36 +6300,18 @@ dependencies = [
 [[package]]
 name = "mersenne31"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "ark-std 0.4.0",
  "cfg-if",
  "ethnum",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "gkr_hashers",
  "halo2curves",
  "log",
  "rand 0.8.5",
  "raw-cpuid",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "mersenne31"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ark-std 0.4.0",
- "cfg-if",
- "ethnum",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "halo2curves",
- "log",
- "rand 0.8.5",
- "raw-cpuid",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "serdes",
  "thiserror 2.0.18",
 ]
 
@@ -6935,7 +6563,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10229,81 +9857,41 @@ dependencies = [
 [[package]]
 name = "poly_commit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "ark-std 0.4.0",
  "derivative",
  "ethnum",
- "gf2 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "gf2",
+ "gkr_engine",
  "halo2curves",
  "itertools 0.13.0",
- "polynomials 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "polynomials",
  "rand 0.8.5",
  "rayon",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "serdes",
  "sha2 0.10.9",
- "sumcheck 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "sumcheck",
  "thiserror 2.0.18",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "transcript",
  "transpose",
- "tree 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "utils 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
-]
-
-[[package]]
-name = "poly_commit"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ark-std 0.4.0",
- "derivative",
- "ethnum",
- "gf2 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "halo2curves",
- "itertools 0.13.0",
- "polynomials 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "rand 0.8.5",
- "rayon",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "sha2 0.10.9",
- "sumcheck 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "thiserror 2.0.18",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "transpose",
- "tree 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "utils 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "tree",
+ "utils",
 ]
 
 [[package]]
 name = "polynomials"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "ark-std 0.4.0",
  "criterion",
  "halo2curves",
  "itertools 0.13.0",
  "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
-]
-
-[[package]]
-name = "polynomials"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ark-std 0.4.0",
- "criterion",
- "halo2curves",
- "itertools 0.13.0",
- "rand 0.8.5",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "serdes",
 ]
 
 [[package]]
@@ -10523,8 +10111,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.12.1",
+ "heck 0.4.1",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -10544,7 +10132,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10557,7 +10145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11297,7 +10885,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11467,7 +11055,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12243,39 +11831,18 @@ dependencies = [
 [[package]]
 name = "serdes"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "ethnum",
  "halo2curves",
- "serdes_derive 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "serdes"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "ethnum",
- "halo2curves",
- "serdes_derive 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "serdes_derive",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "serdes_derive"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "serdes_derive"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12777,9 +12344,8 @@ name = "sn2-verify"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "dsperse",
  "hex",
- "jstprove-io 0.1.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "jstprove_circuits 0.1.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -13130,7 +12696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14641,37 +14207,19 @@ dependencies = [
 [[package]]
 name = "sumcheck"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "circuit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
+ "circuit",
  "env_logger 0.11.10",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "gkr_engine",
+ "gkr_hashers",
  "log",
- "polynomials 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "polynomials",
  "rayon",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "utils 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
-]
-
-[[package]]
-name = "sumcheck"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "circuit 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "env_logger 0.11.10",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "log",
- "polynomials 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "rayon",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "transcript 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "utils 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "serdes",
+ "transcript",
+ "utils",
 ]
 
 [[package]]
@@ -14800,7 +14348,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15535,25 +15083,12 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "sha2 0.10.9",
- "tiny-keccak",
-]
-
-[[package]]
-name = "transcript"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr_engine 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "gkr_hashers 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "arith",
+ "gkr_engine",
+ "gkr_hashers",
+ "serdes",
  "sha2 0.10.9",
  "tiny-keccak",
 ]
@@ -15571,22 +15106,11 @@ dependencies = [
 [[package]]
 name = "tree"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
+ "arith",
  "ark-std 0.4.0",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff)",
- "tiny-keccak",
-]
-
-[[package]]
-name = "tree"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
-dependencies = [
- "arith 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
- "ark-std 0.4.0",
- "serdes 0.4.0 (git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446)",
+ "serdes",
  "tiny-keccak",
 ]
 
@@ -15841,12 +15365,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=7515b9ff#7515b9ff9e7909e6751fafb064208d2f24db93a1"
-
-[[package]]
-name = "utils"
-version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 
 [[package]]
 name = "uuid"
@@ -16536,7 +16055,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,7 +352,7 @@ dependencies = [
 [[package]]
 name = "arith"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "ark-std 0.4.0",
  "criterion",
@@ -1075,7 +1075,7 @@ dependencies = [
 [[package]]
 name = "babybear"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -1167,7 +1167,7 @@ dependencies = [
 [[package]]
 name = "bin"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "babybear",
@@ -1957,7 +1957,7 @@ dependencies = [
 [[package]]
 name = "circuit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -1975,7 +1975,7 @@ dependencies = [
 [[package]]
 name = "circuit-std-rs"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "ark-bls12-381",
@@ -2103,7 +2103,7 @@ dependencies = [
 [[package]]
 name = "config_macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "gkr_engine",
  "gkr_hashers",
@@ -2463,7 +2463,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 [[package]]
 name = "crosslayer_prototype"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "env_logger 0.11.10",
@@ -3270,7 +3270,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 [[package]]
 name = "dsperse"
 version = "0.0.0"
-source = "git+https://github.com/inference-labs-inc/dsperse?rev=2d0c435c#2d0c435c736d1a8e86fba5dc1589b6d4718e5128"
+source = "git+https://github.com/inference-labs-inc/dsperse?rev=dec4ec6e#dec4ec6e88e6792eb78f3af161032bbfbc5b6ef1"
 dependencies = [
  "clap",
  "jstprove_circuits",
@@ -3688,7 +3688,7 @@ dependencies = [
 [[package]]
 name = "expander_compiler"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -4442,7 +4442,7 @@ dependencies = [
 [[package]]
 name = "gf2"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -4459,7 +4459,7 @@ dependencies = [
 [[package]]
 name = "gf2_128"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -4509,7 +4509,7 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 [[package]]
 name = "gkr"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -4541,7 +4541,7 @@ dependencies = [
 [[package]]
 name = "gkr_engine"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "babybear",
@@ -4559,7 +4559,7 @@ dependencies = [
 [[package]]
 name = "gkr_hashers"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "halo2curves",
@@ -4571,7 +4571,7 @@ dependencies = [
 [[package]]
 name = "goldilocks"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -5796,7 +5796,7 @@ dependencies = [
 [[package]]
 name = "jstprove-io"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "anyhow",
  "crc32c",
@@ -5808,7 +5808,7 @@ dependencies = [
 [[package]]
 name = "jstprove-onnx"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "anyhow",
  "prost 0.13.5",
@@ -5819,7 +5819,7 @@ dependencies = [
 [[package]]
 name = "jstprove_circuits"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "anyhow",
  "arith",
@@ -6187,7 +6187,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6300,7 +6300,7 @@ dependencies = [
 [[package]]
 name = "mersenne31"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -9857,7 +9857,7 @@ dependencies = [
 [[package]]
 name = "poly_commit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -9883,7 +9883,7 @@ dependencies = [
 [[package]]
 name = "polynomials"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -10111,8 +10111,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.11.0",
+ "heck 0.5.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -10132,7 +10132,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10145,7 +10145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11831,7 +11831,7 @@ dependencies = [
 [[package]]
 name = "serdes"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "ethnum",
  "halo2curves",
@@ -11842,7 +11842,7 @@ dependencies = [
 [[package]]
 name = "serdes_derive"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14207,7 +14207,7 @@ dependencies = [
 [[package]]
 name = "sumcheck"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "circuit",
@@ -15083,7 +15083,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "gkr_engine",
@@ -15106,7 +15106,7 @@ dependencies = [
 [[package]]
 name = "tree"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -15365,7 +15365,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3270,7 +3270,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 [[package]]
 name = "dsperse"
 version = "0.0.0"
-source = "git+https://github.com/inference-labs-inc/dsperse?rev=35042107#35042107082a7bb9c61e815235a4b6af14d1e1ef"
+source = "git+https://github.com/inference-labs-inc/dsperse?rev=2d0c435c#2d0c435c736d1a8e86fba5dc1589b6d4718e5128"
 dependencies = [
  "clap",
  "jstprove_circuits",
@@ -10111,8 +10111,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.12.1",
+ "heck 0.4.1",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -10132,7 +10132,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10145,7 +10145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,7 +352,7 @@ dependencies = [
 [[package]]
 name = "arith"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "ark-std 0.4.0",
  "criterion",
@@ -1075,7 +1075,7 @@ dependencies = [
 [[package]]
 name = "babybear"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -1167,7 +1167,7 @@ dependencies = [
 [[package]]
 name = "bin"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "babybear",
@@ -1957,7 +1957,7 @@ dependencies = [
 [[package]]
 name = "circuit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -1975,7 +1975,7 @@ dependencies = [
 [[package]]
 name = "circuit-std-rs"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "ark-bls12-381",
@@ -2103,7 +2103,7 @@ dependencies = [
 [[package]]
 name = "config_macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "gkr_engine",
  "gkr_hashers",
@@ -2463,7 +2463,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 [[package]]
 name = "crosslayer_prototype"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "env_logger 0.11.10",
@@ -3270,7 +3270,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 [[package]]
 name = "dsperse"
 version = "0.0.0"
-source = "git+https://github.com/inference-labs-inc/dsperse?rev=bf11b93c#bf11b93cc8de70ef0b98cef1d3cfcedc6e2ffded"
+source = "git+https://github.com/inference-labs-inc/dsperse?rev=35042107#35042107082a7bb9c61e815235a4b6af14d1e1ef"
 dependencies = [
  "clap",
  "jstprove_circuits",
@@ -3688,7 +3688,7 @@ dependencies = [
 [[package]]
 name = "expander_compiler"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -4442,7 +4442,7 @@ dependencies = [
 [[package]]
 name = "gf2"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -4459,7 +4459,7 @@ dependencies = [
 [[package]]
 name = "gf2_128"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -4509,7 +4509,7 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 [[package]]
 name = "gkr"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -4541,7 +4541,7 @@ dependencies = [
 [[package]]
 name = "gkr_engine"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "babybear",
@@ -4559,7 +4559,7 @@ dependencies = [
 [[package]]
 name = "gkr_hashers"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "halo2curves",
@@ -4571,7 +4571,7 @@ dependencies = [
 [[package]]
 name = "goldilocks"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -5796,7 +5796,7 @@ dependencies = [
 [[package]]
 name = "jstprove-io"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "anyhow",
  "crc32c",
@@ -5808,7 +5808,7 @@ dependencies = [
 [[package]]
 name = "jstprove-onnx"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "anyhow",
  "prost 0.13.5",
@@ -5819,7 +5819,7 @@ dependencies = [
 [[package]]
 name = "jstprove_circuits"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "anyhow",
  "arith",
@@ -6187,7 +6187,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6300,7 +6300,7 @@ dependencies = [
 [[package]]
 name = "mersenne31"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -9857,7 +9857,7 @@ dependencies = [
 [[package]]
 name = "poly_commit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -9883,7 +9883,7 @@ dependencies = [
 [[package]]
 name = "polynomials"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -10111,8 +10111,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.11.0",
+ "heck 0.5.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -10132,7 +10132,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10145,7 +10145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11831,7 +11831,7 @@ dependencies = [
 [[package]]
 name = "serdes"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "ethnum",
  "halo2curves",
@@ -11842,7 +11842,7 @@ dependencies = [
 [[package]]
 name = "serdes_derive"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14207,7 +14207,7 @@ dependencies = [
 [[package]]
 name = "sumcheck"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "circuit",
@@ -15083,7 +15083,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "gkr_engine",
@@ -15106,7 +15106,7 @@ dependencies = [
 [[package]]
 name = "tree"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -15365,7 +15365,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ futures-util = "0.3"
 shellexpand = "3.1.2"
 openssl = { version = "0.10", features = ["vendored"] }
 flate2 = "1"
-dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "bf11b93c" }
+dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "35042107" }
 ndarray = { version = "0.17", features = ["serde"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 bittensor-drand = { git = "https://github.com/inference-labs-inc/bittensor-drand.git", rev = "e55ed98", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,9 +50,7 @@ futures-util = "0.3"
 shellexpand = "3.1.2"
 openssl = { version = "0.10", features = ["vendored"] }
 flate2 = "1"
-dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "3d1db73f" }
+dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "bf11b93c" }
 ndarray = { version = "0.17", features = ["serde"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 bittensor-drand = { git = "https://github.com/inference-labs-inc/bittensor-drand.git", rev = "e55ed98", default-features = false }
-jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "7515b9ff" }
-jstprove-io = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "7515b9ff" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ futures-util = "0.3"
 shellexpand = "3.1.2"
 openssl = { version = "0.10", features = ["vendored"] }
 flate2 = "1"
-dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "35042107" }
+dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "2d0c435c" }
 ndarray = { version = "0.17", features = ["serde"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 bittensor-drand = { git = "https://github.com/inference-labs-inc/bittensor-drand.git", rev = "e55ed98", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ futures-util = "0.3"
 shellexpand = "3.1.2"
 openssl = { version = "0.10", features = ["vendored"] }
 flate2 = "1"
-dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "2d0c435c" }
+dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "dec4ec6e" }
 ndarray = { version = "0.17", features = ["serde"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 bittensor-drand = { git = "https://github.com/inference-labs-inc/bittensor-drand.git", rev = "e55ed98", default-features = false }

--- a/crates/sn2-verify/Cargo.toml
+++ b/crates/sn2-verify/Cargo.toml
@@ -22,5 +22,4 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 rmp-serde = { workspace = true }
 hex = { workspace = true }
-jstprove_circuits = { workspace = true }
-jstprove-io = { workspace = true }
+dsperse = { workspace = true }

--- a/crates/sn2-verify/src/verify.rs
+++ b/crates/sn2-verify/src/verify.rs
@@ -1,175 +1,29 @@
-use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, LazyLock, Mutex, RwLock};
+use std::sync::{Arc, LazyLock};
 
 use anyhow::{Context, Result};
-use tracing::{info, warn};
+use tracing::warn;
 
-use jstprove_circuits::onnx::{
-    deserialize_circuit_bn254, deserialize_circuit_goldilocks_whir_pq, flatten_circuit_bn254,
-    flatten_circuit_goldilocks_whir_pq, verify_and_extract_bn254_with_flat_ref,
-    verify_and_extract_goldilocks_whir_pq_with_flat_ref, FlatCircuitBN254,
-    FlatCircuitGoldilocksWhirPQ,
-};
+use dsperse::backend::jstprove::JstproveBackend;
 
-enum CachedCircuit {
-    BN254(Arc<FlatCircuitBN254>),
-    GoldilocksWhirPQ(Arc<FlatCircuitGoldilocksWhirPQ>),
-}
-
-static CIRCUIT_CACHE: LazyLock<RwLock<HashMap<String, CachedCircuit>>> =
-    LazyLock::new(|| RwLock::new(HashMap::new()));
-
-static LOADING_LOCKS: LazyLock<Mutex<HashMap<String, Arc<Mutex<()>>>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
-
-static EVICTION_GEN: AtomicU64 = AtomicU64::new(0);
+static BACKEND: LazyLock<Arc<JstproveBackend>> = LazyLock::new(|| Arc::new(JstproveBackend::new()));
 
 use crate::protocol::{StoreResponse, VerifyAndStoreRequest, VerifyRequest, VerifyResponse};
 use crate::store::{StoredTile, TileStore};
 
+/// Evict cached bundles whose canonical path starts with the given prefix.
 pub fn evict_circuit_cache(path_prefix: &str) {
-    let mut cache = CIRCUIT_CACHE.write().unwrap();
-    EVICTION_GEN.fetch_add(1, Ordering::SeqCst);
-    let before = cache.len();
-    cache.retain(|k, _| !k.starts_with(path_prefix));
-    let evicted = before - cache.len();
-    if evicted > 0 {
-        info!(prefix = %path_prefix, evicted, remaining = cache.len(), "evicted circuit cache entries");
-    }
+    BACKEND.evict_cache_by_prefix(std::path::Path::new(path_prefix));
 }
 
+/// Clear all cached bundles.
 pub fn clear_circuit_cache() {
-    let mut cache = CIRCUIT_CACHE.write().unwrap();
-    EVICTION_GEN.fetch_add(1, Ordering::SeqCst);
-    let count = cache.len();
-    cache.clear();
-    if count > 0 {
-        info!(cleared = count, "cleared circuit cache");
-    }
-}
-
-fn get_or_load(circuit_path: &str) -> Result<()> {
-    {
-        let cache = CIRCUIT_CACHE.read().unwrap();
-        if cache.contains_key(circuit_path) {
-            return Ok(());
-        }
-    }
-
-    let path_lock = {
-        let mut loading = LOADING_LOCKS.lock().unwrap();
-        Arc::clone(loading.entry(circuit_path.to_string()).or_default())
-    };
-    let _guard = path_lock.lock().unwrap();
-
-    {
-        let cache = CIRCUIT_CACHE.read().unwrap();
-        if cache.contains_key(circuit_path) {
-            return Ok(());
-        }
-    }
-
-    let gen_before = EVICTION_GEN.load(Ordering::SeqCst);
-
-    let circuit_bytes = {
-        let p = std::path::Path::new(circuit_path);
-        if p.is_dir() {
-            jstprove_io::bundle::read_circuit_blob(p)
-                .with_context(|| format!("reading circuit from bundle {circuit_path}"))?
-        } else {
-            std::fs::read(circuit_path).with_context(|| format!("reading {circuit_path}"))?
-        }
-    };
-
-    let cached = if let Ok(layered) = deserialize_circuit_bn254(&circuit_bytes) {
-        let flat = flatten_circuit_bn254(&layered);
-        drop(layered);
-        info!(
-            path = %circuit_path,
-            config = "BN254",
-            size_mb = circuit_bytes.len() as f64 / (1024.0 * 1024.0),
-            "cached flattened circuit"
-        );
-        CachedCircuit::BN254(Arc::new(flat))
-    } else if let Ok(layered) = deserialize_circuit_goldilocks_whir_pq(&circuit_bytes) {
-        let flat = flatten_circuit_goldilocks_whir_pq(&layered);
-        drop(layered);
-        info!(
-            path = %circuit_path,
-            config = "GoldilocksWhirPQ",
-            size_mb = circuit_bytes.len() as f64 / (1024.0 * 1024.0),
-            "cached flattened circuit"
-        );
-        CachedCircuit::GoldilocksWhirPQ(Arc::new(flat))
-    } else {
-        anyhow::bail!(
-            "circuit {circuit_path} does not match any supported config (BN254, GoldilocksWhirPQ)"
-        );
-    };
-
-    let mut cache = CIRCUIT_CACHE.write().unwrap();
-    if EVICTION_GEN.load(Ordering::SeqCst) == gen_before {
-        cache.insert(circuit_path.to_string(), cached);
-    } else {
-        info!(
-            path = %circuit_path,
-            "eviction occurred during load, skipping cache insert"
-        );
-    }
-
-    Ok(())
+    BACKEND.clear_cache();
 }
 
 pub struct VerifyResult {
     pub rescaled_outputs: Vec<f64>,
     pub scale_base: u64,
     pub scale_exponent: u64,
-}
-
-fn verify_with_cache(
-    circuit_path: &str,
-    witness_bytes: &[u8],
-    proof_bytes: &[u8],
-    num_inputs: usize,
-    expected_inputs: Option<&[f64]>,
-) -> Result<VerifyResult> {
-    get_or_load(circuit_path)?;
-
-    let cache = CIRCUIT_CACHE.read().unwrap();
-    let cached = cache
-        .get(circuit_path)
-        .ok_or_else(|| anyhow::anyhow!("circuit evicted during verify"))?;
-
-    let result = match cached {
-        CachedCircuit::BN254(circuit) => verify_and_extract_bn254_with_flat_ref(
-            circuit,
-            witness_bytes,
-            proof_bytes,
-            num_inputs,
-            expected_inputs,
-        ),
-        CachedCircuit::GoldilocksWhirPQ(circuit) => {
-            verify_and_extract_goldilocks_whir_pq_with_flat_ref(
-                circuit,
-                witness_bytes,
-                proof_bytes,
-                num_inputs,
-                expected_inputs,
-            )
-        }
-    }
-    .map_err(|e| anyhow::anyhow!("verification: {e}"))?;
-
-    if !result.valid {
-        anyhow::bail!("proof verification failed");
-    }
-
-    Ok(VerifyResult {
-        rescaled_outputs: result.outputs,
-        scale_base: result.scale_base,
-        scale_exponent: result.scale_exponent,
-    })
 }
 
 pub async fn verify_inner(
@@ -181,22 +35,35 @@ pub async fn verify_inner(
     expected_inputs: &Option<Vec<f64>>,
     _pcs_type: &str,
 ) -> Result<VerifyResult> {
-    let circuit_path = circuit_path.to_string();
+    let circuit_path = std::path::PathBuf::from(circuit_path);
     let witness_hex = witness_hex.to_string();
     let proof_hex = proof_hex.to_string();
     let expected_inputs = expected_inputs.clone();
+    let backend = Arc::clone(&*BACKEND);
 
     tokio::task::spawn_blocking(move || {
         let witness_bytes = hex::decode(witness_hex.trim()).context("hex-decoding witness")?;
         let proof_bytes = hex::decode(proof_hex.trim()).context("hex-decoding proof")?;
 
-        verify_with_cache(
-            &circuit_path,
-            &witness_bytes,
-            &proof_bytes,
-            num_inputs,
-            expected_inputs.as_deref(),
-        )
+        let verified = backend
+            .verify_and_extract(
+                &circuit_path,
+                &witness_bytes,
+                &proof_bytes,
+                num_inputs,
+                expected_inputs.as_deref(),
+            )
+            .map_err(|e| anyhow::anyhow!("verification: {e}"))?;
+
+        if !verified.valid {
+            anyhow::bail!("proof verification failed");
+        }
+
+        Ok(VerifyResult {
+            rescaled_outputs: verified.outputs,
+            scale_base: verified.scale_base,
+            scale_exponent: verified.scale_exponent,
+        })
     })
     .await
     .context("verification task panicked")?


### PR DESCRIPTION
## Summary

- Replace sn2-verify's hand-rolled multi-config caching and dispatch logic with a thin wrapper over `dsperse::backend::jstprove::JstproveBackend`. The backend now resolves the curve per bundle from its manifest at load time, so callers no longer need to detect, cache, or dispatch by configuration.
- Remove direct `jstprove_circuits` and `jstprove-io` dependencies from sn2-verify; the backend is the only surface that needs them.
- Expose `evict_circuit_cache` and `clear_circuit_cache` as thin shims over the backend's bundle cache eviction API to preserve the existing validator eviction contract.
- Bump dsperse to a revision that carries per-bundle curve resolution, `verify_and_extract`, and `evict_cache_by_prefix`.

This reverts the hand-rolled multi-config logic introduced in #436 and relocates responsibility to the layer that owns circuit bundle loading. The resulting diff deletes ~620 lines of duplicated cache/dispatch logic from sn2-verify.

Depends on inference-labs-inc/JSTprove#259 and inference-labs-inc/dsperse#180.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test` — all pass
- [ ] Deploy on testnet, verify both curves dispatch correctly
- [ ] Deploy on mainnet after testnet validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a pinned workspace dependency and removed two workspace-managed dependency entries.
* **Refactor**
  * Circuit verification now uses a shared backend with centralized cache management; public verification interfaces remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->