### PR TITLE
Migrate dsperse for WHIR PCS and field-aware witness parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,7 +352,7 @@ dependencies = [
 [[package]]
 name = "arith"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "ark-std 0.4.0",
  "criterion",
@@ -1075,7 +1075,7 @@ dependencies = [
 [[package]]
 name = "babybear"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -1167,7 +1167,7 @@ dependencies = [
 [[package]]
 name = "bin"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "babybear",
@@ -1957,7 +1957,7 @@ dependencies = [
 [[package]]
 name = "circuit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -1975,7 +1975,7 @@ dependencies = [
 [[package]]
 name = "circuit-std-rs"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "ark-bls12-381",
@@ -2103,7 +2103,7 @@ dependencies = [
 [[package]]
 name = "config_macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "gkr_engine",
  "gkr_hashers",
@@ -2463,7 +2463,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 [[package]]
 name = "crosslayer_prototype"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "env_logger 0.11.10",
@@ -3270,7 +3270,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 [[package]]
 name = "dsperse"
 version = "0.0.0"
-source = "git+https://github.com/inference-labs-inc/dsperse?rev=0e510b82#0e510b824da042c6235af7560835aa625edaaae9"
+source = "git+https://github.com/inference-labs-inc/dsperse?rev=68d94dc6#68d94dc63f2c19bf054b69a327e5ff0f27ac53aa"
 dependencies = [
  "clap",
  "jstprove_circuits",
@@ -3688,7 +3688,7 @@ dependencies = [
 [[package]]
 name = "expander_compiler"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -4442,7 +4442,7 @@ dependencies = [
 [[package]]
 name = "gf2"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -4459,7 +4459,7 @@ dependencies = [
 [[package]]
 name = "gf2_128"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -4509,7 +4509,7 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 [[package]]
 name = "gkr"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -4541,7 +4541,7 @@ dependencies = [
 [[package]]
 name = "gkr_engine"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "babybear",
@@ -4559,7 +4559,7 @@ dependencies = [
 [[package]]
 name = "gkr_hashers"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "halo2curves",
@@ -4571,7 +4571,7 @@ dependencies = [
 [[package]]
 name = "goldilocks"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -5796,7 +5796,7 @@ dependencies = [
 [[package]]
 name = "jstprove-io"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "anyhow",
  "crc32c",
@@ -5808,7 +5808,7 @@ dependencies = [
 [[package]]
 name = "jstprove-onnx"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "anyhow",
  "prost 0.13.5",
@@ -5819,7 +5819,7 @@ dependencies = [
 [[package]]
 name = "jstprove_circuits"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "anyhow",
  "arith",
@@ -6187,7 +6187,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6300,7 +6300,7 @@ dependencies = [
 [[package]]
 name = "mersenne31"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -9857,7 +9857,7 @@ dependencies = [
 [[package]]
 name = "poly_commit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -9883,7 +9883,7 @@ dependencies = [
 [[package]]
 name = "polynomials"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -11831,7 +11831,7 @@ dependencies = [
 [[package]]
 name = "serdes"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "ethnum",
  "halo2curves",
@@ -11842,7 +11842,7 @@ dependencies = [
 [[package]]
 name = "serdes_derive"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14207,7 +14207,7 @@ dependencies = [
 [[package]]
 name = "sumcheck"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "circuit",
@@ -15083,7 +15083,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "gkr_engine",
@@ -15106,7 +15106,7 @@ dependencies = [
 [[package]]
 name = "tree"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -15365,7 +15365,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ futures-util = "0.3"
 shellexpand = "3.1.2"
 openssl = { version = "0.10", features = ["vendored"] }
 flate2 = "1"
-dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "0e510b82" }
+dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "68d94dc6" }
 ndarray = { version = "0.17", features = ["serde"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 bittensor-drand = { git = "https://github.com/inference-labs-inc/bittensor-drand.git", rev = "e55ed98", default-features = false }

--- a/crates/sn2-miner/src/dsperse.rs
+++ b/crates/sn2-miner/src/dsperse.rs
@@ -67,9 +67,18 @@ fn prove_and_build_response(
         .map_err(|e| anyhow::anyhow!("proof generation: {e}"))?;
 
     let computed_outputs = if let Some(num_model_inputs) = effective_input_dims {
-        backend
-            .extract_outputs(witness_bytes, num_model_inputs)
-            .map_err(|e| anyhow::anyhow!("extracting outputs: {e}"))?
+        match backend.extract_outputs(witness_bytes, num_model_inputs) {
+            Ok(outputs) => outputs,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    num_model_inputs,
+                    witness_len = witness_bytes.len(),
+                    "output extraction failed; validator will extract from verified proof"
+                );
+                Vec::new()
+            }
+        }
     } else {
         Vec::new()
     };

--- a/crates/sn2-validator/src/response_processor.rs
+++ b/crates/sn2-validator/src/response_processor.rs
@@ -246,7 +246,11 @@ impl ResponseProcessor {
                 Ok(true)
             }
             Err(e) => {
-                warn!(uid = response.uid, error = %e, "verification failed");
+                warn!(
+                    uid = response.uid,
+                    error = format!("{e:#}"),
+                    "verification failed"
+                );
                 Ok(false)
             }
         }


### PR DESCRIPTION
## Summary

Bumps dsperse to a revision carrying jstprove fixes that enable end-to-end Goldilocks WHIR PQ proving and verification:

- **WHIR PCS leaf alignment**: \`gen_params\` now clamps \`n_input_vars\` to a minimum that guarantees the codeword fills at least one Merkle tree leaf for the target field element size, preventing an assertion panic on small polynomials.
- **Field-size-aware witness parsing**: \`parse_public_inputs_from_witness_bytes\` reads the element size from the embedded modulus instead of hardcoding 32 bytes (BN254), so Goldilocks 8-byte witnesses are correctly parsed during both extraction and verification.
- **Dim-split template fallback**: slices with \`dim_split\` metadata but no materialized template on disk fall through to single-slice execution instead of aborting the entire run.

### Miner changes

Gracefully handle \`extract_outputs\` failure by returning the proof with empty \`computed_outputs\` instead of aborting. The validator extracts outputs via its own config-aware \`verify_and_extract\` path.

### Validator changes

Surface the full anyhow error chain in verification failure logs so the underlying cause is visible.

### Testnet verification

Tested end-to-end on sn2-testnet-1 with \`ff5f\` model (209 circuit slices, Goldilocks Ext4 WHIR PQ):
- Miner: \`witness and proof generated witness_size=279570 proof_size=115920 num_outputs=1536\`
- Validator: \`proof verified uid=0 elapsed="2.337s"\`

## Test plan

- [x] \`cargo build\` — clean
- [x] \`cargo clippy -- -D warnings\` — clean
- [x] Testnet UAT — proofs generating and verifying

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made output extraction more resilient by handling extraction failures without failing the whole operation

* **Chores**
  * Pinned an updated dependency revision for greater stability
  * Improved diagnostic logging to provide richer, pretty-printed error information
<!-- end of auto-generated comment: release notes by coderabbit.ai -->