### PR TITLE
Introduce in-memory slice blocklist for unverifiable circuit slices

### DIFF
--- a/crates/sn2-validator/src/incremental_runner.rs
+++ b/crates/sn2-validator/src/incremental_runner.rs
@@ -91,6 +91,7 @@ pub struct IncrementalRunManager {
     runs: HashMap<String, ActiveRun>,
     evicted: BoundedFifoSet<String>,
     tile_counters: HashMap<(String, String), TileCounter>,
+    verified_tile_counts: HashMap<(String, String), usize>,
 }
 
 impl Default for IncrementalRunManager {
@@ -99,6 +100,7 @@ impl Default for IncrementalRunManager {
             runs: HashMap::new(),
             evicted: BoundedFifoSet::new(EVICTED_CAP),
             tile_counters: HashMap::new(),
+            verified_tile_counts: HashMap::new(),
         }
     }
 }
@@ -148,6 +150,13 @@ impl IncrementalRunManager {
 
     pub fn circuit_id_for_run(&self, run_uid: &str) -> Option<&str> {
         self.runs.get(run_uid).map(|r| r.circuit_id.as_str())
+    }
+
+    pub fn verified_tile_count(&self, run_uid: &str, slice_id: &str) -> usize {
+        self.verified_tile_counts
+            .get(&(run_uid.to_string(), slice_id.to_string()))
+            .copied()
+            .unwrap_or(0)
     }
 
     pub fn slice_tile_counts(&self, run_uid: &str) -> (usize, usize, HashMap<String, usize>) {
@@ -283,6 +292,7 @@ impl IncrementalRunManager {
             );
             return TileBufferOutcome::Waiting;
         }
+        *self.verified_tile_counts.entry(key.clone()).or_insert(0) += 1;
         debug!(
             run_uid = %run_uid,
             slice = %slice_id,
@@ -373,6 +383,8 @@ impl IncrementalRunManager {
 
     pub fn remove_run(&mut self, run_uid: &str) -> Option<ActiveRun> {
         self.tile_counters.retain(|(uid, _), _| uid != run_uid);
+        self.verified_tile_counts
+            .retain(|(uid, _), _| uid != run_uid);
         self.runs.remove(run_uid)
     }
 
@@ -404,6 +416,8 @@ impl IncrementalRunManager {
         let evict_set: HashSet<&str> = to_remove.iter().map(|s| s.as_str()).collect();
         self.tile_counters
             .retain(|(run_uid, _), _| !evict_set.contains(run_uid.as_str()));
+        self.verified_tile_counts
+            .retain(|(run_uid, _), _| !evict_set.contains(run_uid.as_str()));
         for uid in to_remove.iter() {
             self.runs.remove(uid);
             self.evicted.insert(uid.clone());
@@ -424,6 +438,8 @@ impl IncrementalRunManager {
         }
         let stale_set: HashSet<&str> = stale.iter().map(|s| s.as_str()).collect();
         self.tile_counters
+            .retain(|(run_uid, _), _| !stale_set.contains(run_uid.as_str()));
+        self.verified_tile_counts
             .retain(|(run_uid, _), _| !stale_set.contains(run_uid.as_str()));
         for uid in stale.iter() {
             self.runs.remove(uid);

--- a/crates/sn2-validator/src/incremental_runner.rs
+++ b/crates/sn2-validator/src/incremental_runner.rs
@@ -146,6 +146,10 @@ impl IncrementalRunManager {
         self.runs.contains_key(run_uid)
     }
 
+    pub fn circuit_id_for_run(&self, run_uid: &str) -> Option<&str> {
+        self.runs.get(run_uid).map(|r| r.circuit_id.as_str())
+    }
+
     pub fn slice_tile_counts(&self, run_uid: &str) -> (usize, usize, HashMap<String, usize>) {
         let run = match self.runs.get(run_uid) {
             Some(r) => r,

--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -234,8 +234,7 @@ impl ValidatorLoop {
                         .into_iter()
                         .partition(|w| !disabled.contains(&w.slice_id));
                     for work in &skipped {
-                        self.run_manager
-                            .mark_slice_failed(run_uid, &work.slice_id);
+                        self.run_manager.mark_slice_failed(run_uid, &work.slice_id);
                     }
                     if !skipped.is_empty() {
                         info!(
@@ -411,21 +410,29 @@ impl ValidatorLoop {
             .map(str::to_string)
         {
             let (_, _, slice_tiles) = self.run_manager.slice_tile_counts(run_uid);
-            let newly_disabled: Vec<String> = slice_tiles
+            let candidates: Vec<String> = slice_tiles
                 .into_keys()
-                .filter(|slice_id| self.run_manager.is_slice_failed(run_uid, slice_id))
+                .filter(|slice_id| {
+                    self.run_manager.is_slice_failed(run_uid, slice_id)
+                        && self.run_manager.verified_tile_count(run_uid, slice_id) == 0
+                })
                 .collect();
-            if !newly_disabled.is_empty() {
+            if !candidates.is_empty() {
                 let entry = self.disabled_slices.entry(circuit_id.clone()).or_default();
-                for slice_id in &newly_disabled {
-                    entry.insert(slice_id.clone());
+                let mut inserted = 0usize;
+                for slice_id in &candidates {
+                    if entry.insert(slice_id.clone()) {
+                        inserted += 1;
+                    }
                 }
-                info!(
-                    circuit_id = %circuit_id,
-                    newly_disabled = newly_disabled.len(),
-                    total_disabled_for_circuit = entry.len(),
-                    "disabled slices with zero verified tiles"
-                );
+                if inserted > 0 {
+                    info!(
+                        circuit_id = %circuit_id,
+                        newly_disabled = inserted,
+                        total_disabled_for_circuit = entry.len(),
+                        "disabled slices with zero verified tiles"
+                    );
+                }
             }
         }
 

--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -226,6 +226,31 @@ impl ValidatorLoop {
             }
         };
 
+        let work_items: Vec<_> = {
+            let disabled = self.disabled_slices.get(&circuit.id).cloned();
+            match disabled {
+                Some(disabled) if !disabled.is_empty() => {
+                    let (kept, skipped): (Vec<_>, Vec<_>) = work_items
+                        .into_iter()
+                        .partition(|w| !disabled.contains(&w.slice_id));
+                    for work in &skipped {
+                        self.run_manager
+                            .mark_slice_failed(run_uid, &work.slice_id);
+                    }
+                    if !skipped.is_empty() {
+                        info!(
+                            run_uid = %run_uid,
+                            circuit_id = %circuit.id,
+                            skipped = skipped.len(),
+                            "skipping slices previously disabled for this circuit"
+                        );
+                    }
+                    kept
+                }
+                _ => work_items,
+            }
+        };
+
         if work_items.is_empty() {
             info!(run_uid = %run_uid, "no circuit slices to dispatch, completing run");
             self.finalize_combined_run(run_uid).await;
@@ -379,6 +404,30 @@ impl ValidatorLoop {
 
         let failed_count = self.run_manager.failed_slice_count(run_uid);
         info!(run_uid = %run_uid, failed_count, "combined run complete");
+
+        if let Some(circuit_id) = self
+            .run_manager
+            .circuit_id_for_run(run_uid)
+            .map(str::to_string)
+        {
+            let (_, _, slice_tiles) = self.run_manager.slice_tile_counts(run_uid);
+            let newly_disabled: Vec<String> = slice_tiles
+                .into_keys()
+                .filter(|slice_id| self.run_manager.is_slice_failed(run_uid, slice_id))
+                .collect();
+            if !newly_disabled.is_empty() {
+                let entry = self.disabled_slices.entry(circuit_id.clone()).or_default();
+                for slice_id in &newly_disabled {
+                    entry.insert(slice_id.clone());
+                }
+                info!(
+                    circuit_id = %circuit_id,
+                    newly_disabled = newly_disabled.len(),
+                    total_disabled_for_circuit = entry.len(),
+                    "disabled slices with zero verified tiles"
+                );
+            }
+        }
 
         let final_output = self.run_manager.final_output_json(run_uid);
         let mut active_run = self.run_manager.remove_run(run_uid);

--- a/crates/sn2-validator/src/validator_loop/maintenance.rs
+++ b/crates/sn2-validator/src/validator_loop/maintenance.rs
@@ -148,6 +148,9 @@ impl ValidatorLoop {
                 .cache_dir()
                 .join(format!("model_{circuit_id}"));
             sn2_verify::evict_circuit_cache(&prefix.to_string_lossy());
+            if self.disabled_slices.remove(circuit_id).is_some() {
+                info!(circuit = %circuit_id, "cleared disabled slice set for deactivated circuit");
+            }
             let evicted = self.run_manager.evict_by_circuit(circuit_id);
             if !evicted.is_empty() {
                 info!(circuit = %circuit_id, runs = ?evicted, "evicted in-flight runs for deactivated circuit");

--- a/crates/sn2-validator/src/validator_loop/mod.rs
+++ b/crates/sn2-validator/src/validator_loop/mod.rs
@@ -5,7 +5,7 @@ mod relay;
 mod results;
 mod verification;
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::net::Ipv4Addr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -159,6 +159,7 @@ pub struct ValidatorLoop {
     pub(super) pending_verifications: VecDeque<TaskResult>,
     pub(super) verification_concurrency: usize,
     pub(super) dslice_input_scales: HashMap<(String, String), f64>,
+    pub(super) disabled_slices: HashMap<String, HashSet<String>>,
 }
 
 impl ValidatorLoop {
@@ -348,6 +349,7 @@ impl ValidatorLoop {
             pending_verifications: VecDeque::new(),
             verification_concurrency,
             dslice_input_scales: HashMap::new(),
+            disabled_slices: HashMap::new(),
         })
     }
 


### PR DESCRIPTION
## Summary
- Validator now tracks slices that finish a combined run with zero verified tiles and records them in an in-memory `circuit_id -> {slice_id}` map.
- Subsequent runs for the same circuit skip those slices at enqueue time and mark them failed immediately so the run can progress without redispatch.
- Blocklist is process-local and cleared on restart; no on-disk persistence.

## Test plan
- [ ] Run a combined run against a circuit with a slice guaranteed to fail all tiles; confirm `disabled slices with zero verified tiles` log line is emitted on finalize.
- [ ] Start a second run against the same circuit; confirm the disabled slice is skipped via the `skipping slices previously disabled for this circuit` log line and does not produce retry spam.
- [ ] Restart the validator; confirm the blocklist is empty and slices are re-attempted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added slice-disabling to avoid reprocessing consistently failed slices per circuit.
  * Track and report disabled-slice counts per circuit with informational logging.
  * Exposed run → circuit lookup to correlate runs with their circuit IDs.
  * Track verified tile counts per run/slice and remove them when runs or circuits are evicted to prevent stale data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->