### PR TITLE
Migrate dsperse pin to 149bffa7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,7 +352,7 @@ dependencies = [
 [[package]]
 name = "arith"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "ark-std 0.4.0",
  "criterion",
@@ -1075,7 +1075,7 @@ dependencies = [
 [[package]]
 name = "babybear"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -1167,7 +1167,7 @@ dependencies = [
 [[package]]
 name = "bin"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "babybear",
@@ -1957,7 +1957,7 @@ dependencies = [
 [[package]]
 name = "circuit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -1975,7 +1975,7 @@ dependencies = [
 [[package]]
 name = "circuit-std-rs"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "ark-bls12-381",
@@ -2103,7 +2103,7 @@ dependencies = [
 [[package]]
 name = "config_macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "gkr_engine",
  "gkr_hashers",
@@ -2463,7 +2463,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 [[package]]
 name = "crosslayer_prototype"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "env_logger 0.11.10",
@@ -3270,7 +3270,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 [[package]]
 name = "dsperse"
 version = "0.0.0"
-source = "git+https://github.com/inference-labs-inc/dsperse?rev=68d94dc6#68d94dc63f2c19bf054b69a327e5ff0f27ac53aa"
+source = "git+https://github.com/inference-labs-inc/dsperse?rev=149bffa7#149bffa767c423313d4564f43f486c9b503ecd31"
 dependencies = [
  "clap",
  "jstprove_circuits",
@@ -3688,7 +3688,7 @@ dependencies = [
 [[package]]
 name = "expander_compiler"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -4442,7 +4442,7 @@ dependencies = [
 [[package]]
 name = "gf2"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -4459,7 +4459,7 @@ dependencies = [
 [[package]]
 name = "gf2_128"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -4509,7 +4509,7 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 [[package]]
 name = "gkr"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -4535,13 +4535,14 @@ dependencies = [
  "sumcheck",
  "thiserror 2.0.18",
  "transcript",
+ "tree",
  "utils",
 ]
 
 [[package]]
 name = "gkr_engine"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "babybear",
@@ -4559,7 +4560,7 @@ dependencies = [
 [[package]]
 name = "gkr_hashers"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "halo2curves",
@@ -4571,7 +4572,7 @@ dependencies = [
 [[package]]
 name = "goldilocks"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -5796,7 +5797,7 @@ dependencies = [
 [[package]]
 name = "jstprove-io"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "anyhow",
  "crc32c",
@@ -5808,7 +5809,7 @@ dependencies = [
 [[package]]
 name = "jstprove-onnx"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "anyhow",
  "prost 0.13.5",
@@ -5819,17 +5820,21 @@ dependencies = [
 [[package]]
 name = "jstprove_circuits"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "anyhow",
  "arith",
  "ark-std 0.4.0",
  "chrono",
+ "circuit",
  "circuit-std-rs",
  "clap",
  "console 0.15.11",
  "ethnum",
  "expander_compiler",
+ "gkr",
+ "gkr_engine",
+ "goldilocks",
  "halo2curves",
  "indicatif",
  "jstprove-io",
@@ -5840,6 +5845,8 @@ dependencies = [
  "num-traits",
  "once_cell",
  "openssl",
+ "poly_commit",
+ "polynomials",
  "rand 0.8.5",
  "rayon",
  "rmp-serde",
@@ -5847,12 +5854,15 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "serdes",
  "strum 0.27.2",
  "strum_macros 0.27.2",
+ "sumcheck",
  "tempfile",
  "thiserror 2.0.18",
  "tiny-keccak",
  "tracing",
+ "transcript",
  "zstd 0.13.3",
 ]
 
@@ -6187,7 +6197,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6300,7 +6310,7 @@ dependencies = [
 [[package]]
 name = "mersenne31"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -9857,7 +9867,7 @@ dependencies = [
 [[package]]
 name = "poly_commit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -9883,7 +9893,7 @@ dependencies = [
 [[package]]
 name = "polynomials"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -10111,8 +10121,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.12.1",
+ "heck 0.4.1",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -10132,7 +10142,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10145,7 +10155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11831,7 +11841,7 @@ dependencies = [
 [[package]]
 name = "serdes"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "ethnum",
  "halo2curves",
@@ -11842,7 +11852,7 @@ dependencies = [
 [[package]]
 name = "serdes_derive"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14207,7 +14217,7 @@ dependencies = [
 [[package]]
 name = "sumcheck"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "circuit",
@@ -15083,7 +15093,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "gkr_engine",
@@ -15106,7 +15116,7 @@ dependencies = [
 [[package]]
 name = "tree"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "ark-std 0.4.0",
@@ -15365,7 +15375,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ futures-util = "0.3"
 shellexpand = "3.1.2"
 openssl = { version = "0.10", features = ["vendored"] }
 flate2 = "1"
-dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "68d94dc6" }
+dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "149bffa7" }
 ndarray = { version = "0.17", features = ["serde"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 bittensor-drand = { git = "https://github.com/inference-labs-inc/bittensor-drand.git", rev = "e55ed98", default-features = false }


### PR DESCRIPTION
## Summary
- Bumps `dsperse` git rev `68d94dc6` -> `149bffa7` (PR #193 merged to dsperse main: "Introduce constant-folding evaluators and inline-LayerNorm fusion in slicer").
- Transitively pulls `jstprove_circuits` `819875bd` -> `fc3eae08` (PR #278 merged: "Resolve non-contiguous tensor intolerance in LayerNorm, Reshape, GatherElements").

## What the new pin adds
- **Topological dtype propagation in the materializer**: INT64 indices flowing through Tile / Slice / Reshape / Concat / Gather* are stamped INT64 in slice value_info instead of defaulting to FLOAT. Resolves the `gather_elements_hint: resolved index 138_149_888 out of bounds` failure surface on attention / TopK chains.
- **Per-op slice isolation + per-group dim-split templates** with op-aware shape rewriting (elementwise rewrites all matching, MatMul/Gemm name-only). Transformer attention blocks now split cleanly across the seq dim without contaminating reductions.
- **Inline-LayerNorm fusion**: rewrites the `ReduceMean -> Sub -> Pow^2 -> ReduceMean -> Add -> Sqrt -> Div -> Mul -> Add` pattern to the spec `LayerNormalization` op.
- **ONNX constant-folding evaluators** for ConstantOfShape, Where, Range, Equal/Less/Greater, Not, And/Or, Transpose, Pow, Reduce*, Resize cubic/linear/nearest, Expand, Tile, multi-D Concat, ScatterND, Split, multi-axis Slice (with BOOL typing preservation and INT64 paths for cmp ops).
- **Witness alpha-quantisation fix** (jstprove side): integer-typed inputs (UINT8 / INT8 / UINT16 / INT16 / INT32 / INT64 / BOOL / UINT32 / UINT64) route through `convert_val_to_field_element` instead of `quantize_f64_to_field`, with validated f64 -> i64 conversion that rejects non-finite, non-integral, and out-of-2^53 values up front.
- **Single-leaf Merkle tree early-return** (jstprove side): unblocks tens of thousands of rayon worker panics during proving when slice witnesses compress to one PackF leaf.

## Compatibility
- dsperse public API and TilingInfo schema **unchanged**.
- Metadata gains optional `traced_types: Option<HashMap<String, i32>>` with serde defaults; old packages deserialize unchanged on the new binary, new packages carrying the field deserialize unchanged on older binaries.
- jstprove circuit serialisation **has changed across the version span** (819875bd -> fc3eae08): proofs and serialised circuits do not round-trip across the dsperse upgrade boundary. **Existing on-registry packages should be republished with the new dsperse before this pin is the only one running.**

## Verification
- `cargo build --release` workspace-wide: clean.
- `cargo clippy --workspace --release -- -D warnings`: clean.
- End-to-end run on a 32 GFLOP / 460-slice transformer model using a binary at this rev:
  - 153 / 153 slice circuits proved + verified (zero errors, zero panics).
  - Output matches onnxruntime to 6e-5 max abs (0.005% rel) on the bbox head and 9e-5 (0.001% rel) on the class head.
  - 0.5 % std weight perturbation across 10 transformer MatMuls reproduces the perturbed-ORT output to 5e-4 (0.04%) with no over/underflow in the alpha-quantised field arithmetic.

## Test plan
- [ ] CI: workspace build + clippy + tests pass on `migrate/dsperse-149bffa7`.
- [ ] Validator + miner binaries built from this rev start cleanly against an existing testnet package (read-only metadata path; no proof generation cross-version).
- [ ] Republish at least one canonical model via `dsperse package + publish` from the new binary.
- [ ] Verify the republished package round-trips through validator verification under the new binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a core internal dependency to the latest version for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->