### PR TITLE
Migrate docker/login-action to v4.1.0 with verified SHA pin

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -161,7 +161,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to container registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}


### PR DESCRIPTION
## Summary
- Bumps `docker/login-action` from v4.0.0 → v4.1.0 in `publish-docker.yaml`.
- SHA `4907a6ddec9925e35a0a9e82d7399ccc52663121` verified against upstream `docker/login-action` tag `v4.1.0` (GitHub-signed merge commit by maintainer `crazy-max`, release published 2026-04-02).

## Supersedes
- Closes dependabot PR #431 (identical SHA; taking ownership for verified-pin audit trail).

## Not included (tracked separately)
- Dependabot #444 (`rand 0.8.5 → 0.10.0`) rejected: alert #99 flags `rand 0.10.0` itself as vulnerable (patched in 0.10.1); also requires API migration in `validator_loop/{dslice.rs,dispatch.rs}`.
- Transitive alerts (`wasmtime <24.0.7` via `sp-core`, `rustls-webpki <0.103.10` via `subxt 0.37`, `rand 0.10.0` via `tract` fork) require deeper changes and will be addressed in follow-ups.

## Test plan
- [ ] Workflow `publish-docker.yaml` runs successfully on next release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container registry login workflow to the latest stable version of the authentication tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->