### PR TITLE
Introduce holographic GKR verifying key dispatch across miner and validator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3263,9 +3263,10 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 [[package]]
 name = "dsperse"
 version = "0.0.0"
-source = "git+https://github.com/inference-labs-inc/dsperse?rev=8ab6f325#8ab6f3257857a273a852a288974a41739d414328"
+source = "git+https://github.com/inference-labs-inc/dsperse?rev=472ca8f0#472ca8f054475c5130363e0df288ca056d794e18"
 dependencies = [
  "clap",
+ "jstprove-io",
  "jstprove_circuits",
  "libc",
  "ndarray 0.17.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3263,7 +3263,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 [[package]]
 name = "dsperse"
 version = "0.0.0"
-source = "git+https://github.com/inference-labs-inc/dsperse?rev=744c3839#744c38393bdf4017b108ee37b28e4117084d1a7e"
+source = "git+https://github.com/inference-labs-inc/dsperse?rev=a71f618e#a71f618e5cd5e99a45831a4489aa0970bab213f5"
 dependencies = [
  "clap",
  "jstprove-io",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3263,7 +3263,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 [[package]]
 name = "dsperse"
 version = "0.0.0"
-source = "git+https://github.com/inference-labs-inc/dsperse?rev=472ca8f0#472ca8f054475c5130363e0df288ca056d794e18"
+source = "git+https://github.com/inference-labs-inc/dsperse?rev=744c3839#744c38393bdf4017b108ee37b28e4117084d1a7e"
 dependencies = [
  "clap",
  "jstprove-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ futures-util = "0.3"
 shellexpand = "3.1.2"
 openssl = { version = "0.10", features = ["vendored"] }
 flate2 = "1"
-dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "744c3839" }
+dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "a71f618e" }
 ndarray = { version = "0.17", features = ["serde"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 bittensor-drand = { git = "https://github.com/inference-labs-inc/bittensor-drand.git", rev = "e55ed98", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ futures-util = "0.3"
 shellexpand = "3.1.2"
 openssl = { version = "0.10", features = ["vendored"] }
 flate2 = "1"
-dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "472ca8f0" }
+dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "744c3839" }
 ndarray = { version = "0.17", features = ["serde"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 bittensor-drand = { git = "https://github.com/inference-labs-inc/bittensor-drand.git", rev = "e55ed98", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ futures-util = "0.3"
 shellexpand = "3.1.2"
 openssl = { version = "0.10", features = ["vendored"] }
 flate2 = "1"
-dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "8ab6f325" }
+dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "472ca8f0" }
 ndarray = { version = "0.17", features = ["serde"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 bittensor-drand = { git = "https://github.com/inference-labs-inc/bittensor-drand.git", rev = "e55ed98", default-features = false }

--- a/crates/sn2-miner/src/dsperse.rs
+++ b/crates/sn2-miner/src/dsperse.rs
@@ -62,9 +62,16 @@ fn prove_and_build_response(
     witness_bytes: &[u8],
     effective_input_dims: Option<usize>,
 ) -> Result<serde_json::Value> {
-    let proof_bytes = backend
-        .prove(circuit_path, witness_bytes)
-        .map_err(|e| anyhow::anyhow!("proof generation: {e}"))?;
+    let holographic = circuit_path.join("vk.bin").is_file();
+    let proof_bytes = if holographic {
+        backend
+            .prove_holographic(circuit_path, witness_bytes)
+            .map_err(|e| anyhow::anyhow!("holographic proof generation: {e}"))?
+    } else {
+        backend
+            .prove(circuit_path, witness_bytes)
+            .map_err(|e| anyhow::anyhow!("proof generation: {e}"))?
+    };
 
     let computed_outputs = if let Some(num_model_inputs) = effective_input_dims {
         match backend.extract_outputs(witness_bytes, num_model_inputs) {
@@ -87,6 +94,7 @@ fn prove_and_build_response(
         witness_size = witness_bytes.len(),
         proof_size = proof_bytes.len(),
         num_outputs = computed_outputs.len(),
+        holographic,
         "witness and proof generated"
     );
 

--- a/crates/sn2-verify/src/reconstruct.rs
+++ b/crates/sn2-verify/src/reconstruct.rs
@@ -43,7 +43,7 @@ mod tests {
 
         let result = grid_reconstruct(&tiles, 2, 2, 1, 2, 2);
 
-        assert_eq!(result.len(), 1 * 4 * 4);
+        assert_eq!(result.len(), 4 * 4);
         #[rustfmt::skip]
         let expected = vec![
             1.0,  2.0,  5.0,  6.0,

--- a/crates/sn2-verify/src/verify.rs
+++ b/crates/sn2-verify/src/verify.rs
@@ -154,6 +154,15 @@ fn verify_holographic_path(
     //      back to the values the validator actually sent, closing
     //      the gap that a miner could otherwise exploit by producing
     //      a valid proof for a different input vector.
+    // Expected inputs are mandatory on this path; without them there
+    // is nothing to bind the witness against and the validator would
+    // attest to miner-chosen outputs for miner-chosen inputs.
+    let expected = expected_inputs.ok_or_else(|| {
+        anyhow::anyhow!(
+            "holographic verification requires expected_inputs; refusing to attest against a miner-supplied witness with no validator-side anchor"
+        )
+    })?;
+
     let valid = backend
         .verify_holographic(circuit_path, proof_bytes)
         .context("holographic verification")?;
@@ -165,27 +174,24 @@ fn verify_holographic_path(
         .extract_outputs_full(witness_bytes, num_inputs)
         .context("holographic output extraction")?;
 
-    if let Some(expected) = expected_inputs {
+    anyhow::ensure!(
+        expected.len() == extracted.inputs.len(),
+        "holographic input cross-check: expected_inputs len {} does not match witness inputs len {}",
+        expected.len(),
+        extracted.inputs.len()
+    );
+    // Allow a small tolerance for the floating-point quantization
+    // round-trip performed by the witness deserializer. The same
+    // tolerance is effectively what verify_and_extract applies when
+    // it compares scaled field representations; here we apply it
+    // directly in f64 space because extract_outputs_full has already
+    // descaled both sides.
+    const INPUT_TOLERANCE: f64 = 1e-6;
+    for (idx, (lhs, rhs)) in expected.iter().zip(extracted.inputs.iter()).enumerate() {
         anyhow::ensure!(
-            expected.len() == extracted.inputs.len(),
-            "holographic input cross-check: expected_inputs len {} does not match witness inputs len {}",
-            expected.len(),
-            extracted.inputs.len()
+            (lhs - rhs).abs() <= INPUT_TOLERANCE,
+            "holographic input cross-check failed at index {idx}: expected {lhs}, witness declared {rhs}"
         );
-        // Allow a small tolerance for the floating-point
-        // quantization round-trip performed by the witness
-        // deserializer. The same tolerance is effectively what
-        // verify_and_extract applies when it compares scaled field
-        // representations; here we apply it directly in f64 space
-        // because extract_outputs_full has already descaled both
-        // sides.
-        const INPUT_TOLERANCE: f64 = 1e-6;
-        for (idx, (lhs, rhs)) in expected.iter().zip(extracted.inputs.iter()).enumerate() {
-            anyhow::ensure!(
-                (lhs - rhs).abs() <= INPUT_TOLERANCE,
-                "holographic input cross-check failed at index {idx}: expected {lhs}, witness declared {rhs}"
-            );
-        }
     }
 
     Ok(VerifyResult {

--- a/crates/sn2-verify/src/verify.rs
+++ b/crates/sn2-verify/src/verify.rs
@@ -65,15 +65,26 @@ pub async fn verify_inner(
         // the two reads.
         let gen_before = EVICTION_GENERATION.load(Ordering::SeqCst);
 
-        let verified = backend
-            .verify_and_extract(
+        let holographic = circuit_path.join("vk.bin").is_file();
+
+        let result = if holographic {
+            verify_holographic_path(
+                &backend,
+                &circuit_path,
+                &witness_bytes,
+                &proof_bytes,
+                num_inputs,
+            )?
+        } else {
+            verify_plain_path(
+                &backend,
                 &circuit_path,
                 &witness_bytes,
                 &proof_bytes,
                 num_inputs,
                 expected_inputs.as_deref(),
-            )
-            .context("verification")?;
+            )?
+        };
 
         let gen_after = EVICTION_GENERATION.load(Ordering::SeqCst);
         if gen_before != gen_after {
@@ -82,18 +93,75 @@ pub async fn verify_inner(
             );
         }
 
-        if !verified.valid {
-            anyhow::bail!("proof verification failed");
-        }
-
-        Ok(VerifyResult {
-            rescaled_outputs: verified.outputs,
-            scale_base: verified.scale_base,
-            scale_exponent: verified.scale_exponent,
-        })
+        Ok(result)
     })
     .await
     .context("verification task panicked")?
+}
+
+fn verify_plain_path(
+    backend: &JstproveBackend,
+    circuit_path: &std::path::Path,
+    witness_bytes: &[u8],
+    proof_bytes: &[u8],
+    num_inputs: usize,
+    expected_inputs: Option<&[f64]>,
+) -> Result<VerifyResult> {
+    let verified = backend
+        .verify_and_extract(
+            circuit_path,
+            witness_bytes,
+            proof_bytes,
+            num_inputs,
+            expected_inputs,
+        )
+        .context("verification")?;
+
+    if !verified.valid {
+        anyhow::bail!("proof verification failed");
+    }
+
+    Ok(VerifyResult {
+        rescaled_outputs: verified.outputs,
+        scale_base: verified.scale_base,
+        scale_exponent: verified.scale_exponent,
+    })
+}
+
+fn verify_holographic_path(
+    backend: &JstproveBackend,
+    circuit_path: &std::path::Path,
+    witness_bytes: &[u8],
+    proof_bytes: &[u8],
+    num_inputs: usize,
+) -> Result<VerifyResult> {
+    let valid = backend
+        .verify_holographic(circuit_path, proof_bytes)
+        .context("holographic verification")?;
+    if !valid {
+        anyhow::bail!("holographic proof verification failed");
+    }
+
+    // Scale parameters are stamped authoritatively in the bundle's
+    // CircuitParams at compile time; the holographic vk was set up
+    // against those same params, so they are the trusted root here.
+    // Reading scale from the witness stream the miner supplied would
+    // leave the field unchecked against any bound in the holographic
+    // proof, so prefer the compile-time stamp.
+    let params = backend
+        .load_params(circuit_path)
+        .context("loading circuit params for scale")?
+        .context("circuit bundle missing metadata")?;
+
+    let outputs = backend
+        .extract_outputs(witness_bytes, num_inputs)
+        .context("output extraction")?;
+
+    Ok(VerifyResult {
+        rescaled_outputs: outputs,
+        scale_base: u64::from(params.scale_base),
+        scale_exponent: u64::from(params.scale_exponent),
+    })
 }
 
 pub async fn handle_request(req: VerifyRequest) -> VerifyResponse {

--- a/crates/sn2-verify/src/verify.rs
+++ b/crates/sn2-verify/src/verify.rs
@@ -66,6 +66,11 @@ pub async fn verify_inner(
         let gen_before = EVICTION_GENERATION.load(Ordering::SeqCst);
 
         let holographic = circuit_path.join("vk.bin").is_file();
+        tracing::debug!(
+            circuit_path = %circuit_path.display(),
+            holographic,
+            "dispatching verification path"
+        );
 
         let result = if holographic {
             verify_holographic_path(
@@ -74,6 +79,7 @@ pub async fn verify_inner(
                 &witness_bytes,
                 &proof_bytes,
                 num_inputs,
+                expected_inputs.as_deref(),
             )?
         } else {
             verify_plain_path(
@@ -134,7 +140,20 @@ fn verify_holographic_path(
     witness_bytes: &[u8],
     proof_bytes: &[u8],
     num_inputs: usize,
+    expected_inputs: Option<&[f64]>,
 ) -> Result<VerifyResult> {
+    // Soundness for the holographic path rests on two separate
+    // checks, because jstprove's `verify_holographic(vk, proof)` does
+    // not itself consult the miner-supplied witness:
+    //   1. `verify_holographic` establishes that the proof is
+    //      internally consistent with the circuit committed in the
+    //      vk, and that the public inputs committed inside the proof
+    //      satisfy the circuit constraints (so declared outputs are
+    //      bound to declared inputs).
+    //   2. The witness cross-check below binds the declared inputs
+    //      back to the values the validator actually sent, closing
+    //      the gap that a miner could otherwise exploit by producing
+    //      a valid proof for a different input vector.
     let valid = backend
         .verify_holographic(circuit_path, proof_bytes)
         .context("holographic verification")?;
@@ -142,25 +161,37 @@ fn verify_holographic_path(
         anyhow::bail!("holographic proof verification failed");
     }
 
-    // Scale parameters are stamped authoritatively in the bundle's
-    // CircuitParams at compile time; the holographic vk was set up
-    // against those same params, so they are the trusted root here.
-    // Reading scale from the witness stream the miner supplied would
-    // leave the field unchecked against any bound in the holographic
-    // proof, so prefer the compile-time stamp.
-    let params = backend
-        .load_params(circuit_path)
-        .context("loading circuit params for scale")?
-        .context("circuit bundle missing metadata")?;
+    let extracted = backend
+        .extract_outputs_full(witness_bytes, num_inputs)
+        .context("holographic output extraction")?;
 
-    let outputs = backend
-        .extract_outputs(witness_bytes, num_inputs)
-        .context("output extraction")?;
+    if let Some(expected) = expected_inputs {
+        anyhow::ensure!(
+            expected.len() == extracted.inputs.len(),
+            "holographic input cross-check: expected_inputs len {} does not match witness inputs len {}",
+            expected.len(),
+            extracted.inputs.len()
+        );
+        // Allow a small tolerance for the floating-point
+        // quantization round-trip performed by the witness
+        // deserializer. The same tolerance is effectively what
+        // verify_and_extract applies when it compares scaled field
+        // representations; here we apply it directly in f64 space
+        // because extract_outputs_full has already descaled both
+        // sides.
+        const INPUT_TOLERANCE: f64 = 1e-6;
+        for (idx, (lhs, rhs)) in expected.iter().zip(extracted.inputs.iter()).enumerate() {
+            anyhow::ensure!(
+                (lhs - rhs).abs() <= INPUT_TOLERANCE,
+                "holographic input cross-check failed at index {idx}: expected {lhs}, witness declared {rhs}"
+            );
+        }
+    }
 
     Ok(VerifyResult {
-        rescaled_outputs: outputs,
-        scale_base: u64::from(params.scale_base),
-        scale_exponent: u64::from(params.scale_exponent),
+        rescaled_outputs: extracted.outputs,
+        scale_base: extracted.scale_base,
+        scale_exponent: extracted.scale_exponent,
     })
 }
 

--- a/crates/sn2-verify/src/verify.rs
+++ b/crates/sn2-verify/src/verify.rs
@@ -66,7 +66,7 @@ pub async fn verify_inner(
         let gen_before = EVICTION_GENERATION.load(Ordering::SeqCst);
 
         let holographic = circuit_path.join("vk.bin").is_file();
-        tracing::debug!(
+        tracing::info!(
             circuit_path = %circuit_path.display(),
             holographic,
             "dispatching verification path"
@@ -170,6 +170,23 @@ fn verify_holographic_path(
         anyhow::bail!("holographic proof verification failed");
     }
 
+    // Load scale from the bundle's stamped CircuitParams rather than
+    // trusting the witness header. The holographic proof binds the
+    // circuit evaluation to the scale values that appear in the
+    // witness's public-input tail, but those values are miner-chosen
+    // and only constrain arithmetic internal to the circuit. A miner
+    // could therefore ship a witness whose scale fields are
+    // self-consistent yet disagree with what the bundle was compiled
+    // against, producing descaled outputs that reflect a different
+    // quantization than the model's stamped contract. Sourcing scale
+    // from CircuitParams (set at compile time, bound to the same
+    // bundle the holographic vk was set up against) keeps the
+    // descaled outputs tied to the model's real quantization.
+    let params = backend
+        .load_params(circuit_path)
+        .context("loading circuit params for scale")?
+        .context("circuit bundle missing metadata")?;
+
     let extracted = backend
         .extract_outputs_full(witness_bytes, num_inputs)
         .context("holographic output extraction")?;
@@ -196,8 +213,8 @@ fn verify_holographic_path(
 
     Ok(VerifyResult {
         rescaled_outputs: extracted.outputs,
-        scale_base: extracted.scale_base,
-        scale_exponent: extracted.scale_exponent,
+        scale_base: u64::from(params.scale_base),
+        scale_exponent: u64::from(params.scale_exponent),
     })
 }
 


### PR DESCRIPTION
## Summary

- Composable models from dsperse now package a per-slice holographic verifying key (`vk.bin`) inside the `circuit.bundle` directory, but the subnet miner and validator still routed every slice through the non-holographic `prove` / `verify_and_extract` path. Holographic bundles shipped to the network were never actually verified with `verify_holographic`, so the stronger soundness guarantee was unavailable end-to-end.
- The miner's `prove_and_build_response` now checks for `circuit.bundle/vk.bin` and dispatches to `JstproveBackend::prove_holographic` when present. The validator's `verify_inner` performs the same detection and splits into `verify_plain_path` / `verify_holographic_path`. The holographic branch sources `scale_base` / `scale_exponent` from the bundle's stamped `CircuitParams` (authoritative at compile time) rather than the witness stream, because the holographic ZK path does not re-verify witness-encoded scale values against the proof.
- Bumps the `dsperse` git revision to `472ca8f0` so `prove_holographic`, `verify_holographic`, and `setup_holographic_vk` are available. Detection is purely local to each party's on-disk bundle, so there is no miner-to-validator protocol change and existing non-holographic bundles are routed through the unchanged path.
- Cross-repo: dsperse PR #199 (https://github.com/inference-labs-inc/dsperse/pull/199) resolves a content-addressed signature collision that would otherwise stop the registry from accepting the `vk.bin`-bearing component when a non-holographic variant of the same ONNX was previously uploaded. That PR is independent of this one at the code level, but publishing holographic models to the registry in practice depends on it landing.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p sn2-miner -p sn2-verify --all-targets -- -D warnings`
- [x] `cargo build -p sn2-miner -p sn2-verify`
- [x] `cargo test -p sn2-miner -p sn2-verify --lib`
- [ ] Testnet integration: publish a holographic model via dsperse, deploy a miner and a validator from this branch, confirm the miner logs `holographic=true` on prove and the validator verifies via `verify_holographic` (no `verify_and_extract` trace)
- [ ] Regression: deploy against an existing non-holographic model, confirm miner/validator behaviour is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a Git-sourced core dependency to a newer pinned revision

* **Improvements**
  * Proof generation now auto-selects between standard and holographic proof paths based on available circuit parameters
  * Verification now supports two distinct verification modes with separate error handling and input cross-checks for holographic proofs
  * Logging enhanced to indicate which proof and verification path was used

* **Tests**
  * Adjusted a unit test expectation for reconstructed output length
<!-- end of auto-generated comment: release notes by coderabbit.ai -->