### PR TITLE
Resolve cross-circuit dedup regression for stale-stamp re-fetches

### DIFF
--- a/crates/sn2-circuit-store/src/lib.rs
+++ b/crates/sn2-circuit-store/src/lib.rs
@@ -806,15 +806,16 @@ impl CircuitStore {
                 if dest.exists() && !force {
                     continue;
                 }
-                if !force
-                    && Self::try_hardlink_from_component_cache(
-                        &self.cache_dir,
-                        slices_dir,
-                        &comp.sha,
-                        &PathBuf::from("jstprove/circuit.bundle").join(filename),
-                        &dest,
-                    )
-                {
+                if force && dest.exists() {
+                    let _ = std::fs::remove_file(&dest);
+                }
+                if Self::try_hardlink_from_component_cache(
+                    &self.cache_dir,
+                    slices_dir,
+                    &comp.sha,
+                    &PathBuf::from("jstprove/circuit.bundle").join(filename),
+                    &dest,
+                ) {
                     continue;
                 }
                 let url = format!(
@@ -834,9 +835,10 @@ impl CircuitStore {
             if dest.exists() && !force {
                 continue;
             }
-            if !force
-                && Self::try_hardlink_from_weight_cache(&self.cache_dir, slices_dir, &wb.sha, &dest)
-            {
+            if force && dest.exists() {
+                let _ = std::fs::remove_file(&dest);
+            }
+            if Self::try_hardlink_from_weight_cache(&self.cache_dir, slices_dir, &wb.sha, &dest) {
                 continue;
             }
             let url = format!("{}/models/wb/{}", self.api_url, wb.sha);


### PR DESCRIPTION
## Summary
- Re-enables the sibling hard-link path in \`download_component_files\` when the caller passes \`force=true\`. The prior change skipped the helper under force, but \`find_stale_components\` marks every component of a freshly-fetched circuit as stale, which is exactly the case that should benefit from cross-circuit reuse.
- Removes any pre-existing destination file before attempting the hard-link so the syscall succeeds when the destination was repopulated by a previous force pass.
- Preserves verification: component files match against the sibling's stamped \`component.sha\`; weight blobs are content-verified via \`compute_file_sha256\` prior to linking.

## Context
PR #456 introduced cross-circuit dedup but added a force-guard that disabled the hard-link path in the very scenario it was meant to optimize. Empirical run on a testnet validator with two cached composable circuits confirmed zero hard-link events were emitted before this follow-up.

## Test plan
- [ ] Cache a composable circuit, then load a second composable circuit that shares one or more component SHAs and confirm log lines reporting "hard-linked component file from sibling circuit cache" appear during the new download.
- [ ] Mutate a stamped SHA on the original circuit and verify the new load still re-downloads via HTTP rather than reusing a stale link.
- [ ] \`cargo clippy -p sn2-circuit-store -- -D warnings\` clean, \`cargo fmt --all -- --check\` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of forced component file downloads to properly refresh cached files and ensure the latest versions are retrieved when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->