### PR TITLE
Introduce prove_pct partial-proof sampling in dsperse submission path

### DIFF
--- a/crates/sn2-validator/src/incremental_runner.rs
+++ b/crates/sn2-validator/src/incremental_runner.rs
@@ -81,7 +81,8 @@ pub struct ActiveRun {
 }
 
 struct TileCounter {
-    total: usize,
+    grid_total: usize,
+    expected: HashSet<u32>,
     received: HashSet<u32>,
 }
 
@@ -221,18 +222,34 @@ impl IncrementalRunManager {
         run_uid: &str,
         slice_id: &str,
         tiling: &TilingInfo,
+        expected_indices: HashSet<u32>,
     ) -> anyhow::Result<()> {
-        let expected = tiling.tiles_y * tiling.tiles_x;
-        if tiling.num_tiles != expected {
+        let grid_total = tiling.tiles_y * tiling.tiles_x;
+        if tiling.num_tiles != grid_total {
             return Err(anyhow::anyhow!(
-                "TilingInfo.num_tiles inconsistent for run {run_uid}, slice {slice_id}: num_tiles={}, tiles_y*tiles_x={expected}",
+                "TilingInfo.num_tiles inconsistent for run {run_uid}, slice {slice_id}: num_tiles={}, tiles_y*tiles_x={grid_total}",
                 tiling.num_tiles,
             ));
         }
+        if expected_indices.is_empty() {
+            return Err(anyhow::anyhow!(
+                "tile counter init requires at least one expected tile for run {run_uid}, slice {slice_id}"
+            ));
+        }
+        if let Some(&max_idx) = expected_indices.iter().max() {
+            if (max_idx as usize) >= tiling.num_tiles {
+                return Err(anyhow::anyhow!(
+                    "expected tile index {max_idx} exceeds tiling.num_tiles {} for run {run_uid}, slice {slice_id}",
+                    tiling.num_tiles,
+                ));
+            }
+        }
+        let expected_count = expected_indices.len();
         info!(
             run_uid = %run_uid,
             slice = %slice_id,
             num_tiles = tiling.num_tiles,
+            expected = expected_count,
             "initialized tile counter"
         );
         let key = (run_uid.to_string(), slice_id.to_string());
@@ -240,8 +257,9 @@ impl IncrementalRunManager {
         match self.tile_counters.entry(key) {
             Entry::Vacant(e) => {
                 e.insert(TileCounter {
-                    total: tiling.num_tiles,
-                    received: HashSet::with_capacity(tiling.num_tiles),
+                    grid_total: tiling.num_tiles,
+                    expected: expected_indices,
+                    received: HashSet::with_capacity(expected_count),
                 });
             }
             Entry::Occupied(_) => {
@@ -276,11 +294,22 @@ impl IncrementalRunManager {
             }
         };
 
-        if (tile_idx as usize) >= counter.total {
+        if (tile_idx as usize) >= counter.grid_total {
             return TileBufferOutcome::Failed(format!(
-                "tile_idx {tile_idx} out of range (expected < {}) for run={run_uid} slice={slice_id}",
-                counter.total
+                "tile_idx {tile_idx} out of range (grid_total {}) for run={run_uid} slice={slice_id}",
+                counter.grid_total
             ));
+        }
+
+        if !counter.expected.contains(&tile_idx) {
+            debug!(
+                run_uid = %run_uid,
+                slice = %slice_id,
+                tile_idx,
+                expected = counter.expected.len(),
+                "tile proof for non-sampled tile_idx, ignoring"
+            );
+            return TileBufferOutcome::Waiting;
         }
 
         if !counter.received.insert(tile_idx) {
@@ -298,11 +327,11 @@ impl IncrementalRunManager {
             slice = %slice_id,
             tile_idx = tile_idx,
             received = counter.received.len(),
-            total = counter.total,
+            expected = counter.expected.len(),
             "recorded tile proof"
         );
 
-        if counter.received.len() < counter.total {
+        if counter.received.len() < counter.expected.len() {
             return TileBufferOutcome::Waiting;
         }
 

--- a/crates/sn2-validator/src/relay.rs
+++ b/crates/sn2-validator/src/relay.rs
@@ -73,6 +73,9 @@ pub struct DsperseSubmission {
     pub inputs: serde_json::Value,
     pub tensor_data: Option<Vec<u8>>,
     pub request_id: Option<u32>,
+    /// Fraction of eligible tile proofs the caller requires; values outside
+    /// (0.0, 1.0] are clamped to 1.0 so legacy callers behave as before.
+    pub prove_pct: f64,
     #[allow(dead_code)]
     pub permit: tokio::sync::OwnedSemaphorePermit,
 }
@@ -337,6 +340,17 @@ impl RelayManager {
         Some((circuit_id, inputs))
     }
 
+    fn parse_prove_pct(meta: &serde_json::Value) -> f64 {
+        let raw = match meta.get("prove_pct").and_then(|v| v.as_f64()) {
+            Some(value) => value,
+            None => return 1.0,
+        };
+        if !raw.is_finite() || raw <= 0.0 || raw > 1.0 {
+            return 1.0;
+        }
+        raw
+    }
+
     #[allow(clippy::too_many_arguments)]
     async fn handle_binary_message(
         msg_type: u8,
@@ -398,6 +412,7 @@ impl RelayManager {
             }
         };
 
+        let prove_pct = Self::parse_prove_pct(&meta);
         let req_id_opt = if req_id > 0 { Some(req_id) } else { None };
 
         let submission = DsperseSubmission {
@@ -405,6 +420,7 @@ impl RelayManager {
             inputs,
             tensor_data: tensor_data.map(|d| d.to_vec()),
             request_id: req_id_opt,
+            prove_pct,
             permit,
         };
 

--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -167,7 +167,7 @@ impl ValidatorLoop {
         self.stacked_dslice_queue.clear();
         self.dsperse_benchmark_backoff_until = Instant::now() + Duration::from_secs(120);
 
-        self.enqueue_all_dslices(&run_uid, &circuit, RunSource::Api)
+        self.enqueue_all_dslices(&run_uid, &circuit, RunSource::Api, submission.prove_pct)
             .await;
     }
 
@@ -217,7 +217,13 @@ impl ValidatorLoop {
         run_uid: &str,
         circuit: &Circuit,
         run_source: RunSource,
+        prove_pct: f64,
     ) {
+        let clamped_prove_pct = if !prove_pct.is_finite() || prove_pct <= 0.0 || prove_pct > 1.0 {
+            1.0
+        } else {
+            prove_pct
+        };
         let work_items = match self.run_manager.all_circuit_work(run_uid) {
             Ok(items) => items,
             Err(e) => {
@@ -290,6 +296,7 @@ impl ValidatorLoop {
                     tiling,
                     input_tensor,
                     run_source,
+                    clamped_prove_pct,
                 ) {
                     Some(n) => n,
                     None => {
@@ -335,6 +342,7 @@ impl ValidatorLoop {
         );
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn stage_tiled_work(
         staged: &mut StagedWork,
         run_manager: &mut crate::incremental_runner::IncrementalRunManager,
@@ -346,6 +354,7 @@ impl ValidatorLoop {
         tiling: &dsperse::schema::tiling::TilingInfo,
         input_tensor: ndarray::ArrayD<f64>,
         run_source: RunSource,
+        prove_pct: f64,
     ) -> Option<usize> {
         let tiles = match dsperse::pipeline::split_for_tiling(&input_tensor, tiling) {
             Ok(t) => t,
@@ -367,12 +376,32 @@ impl ValidatorLoop {
             return None;
         }
 
-        if let Err(e) = run_manager.init_tile_counter(run_uid, slice_id, tiling) {
+        let sampled_indices =
+            Self::sample_tile_indices(num_tiles, prove_pct, run_source, run_uid, slice_id);
+        if sampled_indices.is_empty() {
+            warn!(
+                run_uid = %run_uid,
+                slice = %slice_id,
+                "prove_pct sampled zero tiles, aborting slice stage"
+            );
+            return None;
+        }
+
+        let mut expected_indices: std::collections::HashSet<u32> =
+            std::collections::HashSet::with_capacity(sampled_indices.len());
+        for &idx in &sampled_indices {
+            expected_indices.insert(idx as u32);
+        }
+
+        if let Err(e) = run_manager.init_tile_counter(run_uid, slice_id, tiling, expected_indices) {
             warn!(run_uid = %run_uid, slice = %slice_id, error = %e, "init_tile_counter failed");
             return None;
         }
 
         for (idx, tile) in tiles.into_iter().enumerate() {
+            if !sampled_indices.contains(&idx) {
+                continue;
+            }
             let tile_json = serde_json::json!({
                 "input_data": crate::tensor::arrayd_to_json(&tile.into_dyn())
             });
@@ -394,7 +423,40 @@ impl ValidatorLoop {
             });
         }
 
-        Some(num_tiles)
+        Some(sampled_indices.len())
+    }
+
+    fn sample_tile_indices(
+        num_tiles: usize,
+        prove_pct: f64,
+        run_source: RunSource,
+        run_uid: &str,
+        slice_id: &str,
+    ) -> std::collections::HashSet<usize> {
+        if run_source == RunSource::Benchmark || prove_pct >= 1.0 || num_tiles <= 1 {
+            return (0..num_tiles).collect();
+        }
+        let target = ((num_tiles as f64) * prove_pct).ceil() as usize;
+        let target = target.clamp(1, num_tiles);
+        if target >= num_tiles {
+            return (0..num_tiles).collect();
+        }
+        let mut indices: Vec<usize> = (0..num_tiles).collect();
+        let mut rng = rand::rng();
+        for i in 0..target {
+            let j = rng.random_range(i..num_tiles);
+            indices.swap(i, j);
+        }
+        indices.truncate(target);
+        info!(
+            run_uid = %run_uid,
+            slice = %slice_id,
+            num_tiles,
+            sampled = target,
+            prove_pct,
+            "sampled subset of tiles for partial proof run"
+        );
+        indices.into_iter().collect()
     }
 
     pub(super) async fn finalize_combined_run(&mut self, run_uid: &str) {
@@ -564,7 +626,7 @@ impl ValidatorLoop {
         }
 
         let circuit = circuit.clone();
-        self.enqueue_all_dslices(&run_uid, &circuit, RunSource::Benchmark)
+        self.enqueue_all_dslices(&run_uid, &circuit, RunSource::Benchmark, 1.0)
             .await;
     }
 }


### PR DESCRIPTION
## Summary
- Adds an optional \`prove_pct\` field to the dsperse submission payload. Values outside \`(0, 1]\` (including missing) fall back to \`1.0\`, preserving the existing full-proof contract.
- API runs pass the value through to tile dispatch; benchmarks always run at \`prove_pct = 1.0\`.
- For each slice in a partial-proof run, the validator picks \`ceil(prove_pct * slice_tiles)\` tile indices uniformly at random via Fisher-Yates and stages only those requests for miner dispatch. Non-sampled indices never leave the validator.
- \`TileCounter\` is reshaped to \`{ grid_total, expected, received }\`. \`grid_total\` is the tiling grid size and is still used to reject out-of-range \`tile_idx\` values as protocol violations. \`expected\` is the sampled set; the per-slice completion check fires when \`received == expected\`, so the existing combined-run completion logic composes without extra bookkeeping.
- Sampling preserves per-slice coverage: every eligible slice contributes at least one tile proof, so no slice is silently skipped even at small \`prove_pct\` values.

## Test plan
- [ ] Submit a tiled dsperse request with \`prove_pct = 0.01\` and confirm the validator stages \`ceil(0.01 * slice_tiles)\` per-slice rather than the full tiling and completes the run after those arrive.
- [ ] Submit with no \`prove_pct\` field and confirm every tile is staged (backward compatibility).
- [ ] Submit with \`prove_pct\` out of range (e.g. \`-1.0\`, \`2.0\`, \`NaN\`) and confirm the validator clamps to \`1.0\`.
- [ ] \`cargo clippy -p sn2-validator -- -D warnings\` + \`cargo test -p sn2-validator\` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented selective tile sampling based on a configurable prove percentage, enabling optimized processing workflows.
  * Enhanced submission handling to include and manage a prove percentage parameter throughout the validation pipeline.
  * Improved tile counter validation with support for explicit tile index sets for more precise tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->