### PR TITLE
Introduce preflight satisfiability check on submission dispatch

### DIFF
--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -324,7 +324,7 @@ impl ValidatorLoop {
                     run_uid = %run_uid,
                     circuit_id = %circuit.id,
                     unsatisfiable,
-                    "preflight filtered slices with mismatched activation sizes"
+                    "preflight filtered slices due to mismatched activation sizes or invalid metadata"
                 );
             }
             kept

--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -195,6 +195,31 @@ impl ValidatorLoop {
         }
     }
 
+    /// Sum of per-input element counts declared in slice metadata.
+    /// Returns None when the metadata does not advertise input shapes so the
+    /// caller falls through to dispatch untouched.
+    fn expected_input_elements(input_shape: &[Vec<i64>]) -> Option<usize> {
+        if input_shape.is_empty() {
+            return None;
+        }
+        let mut total: usize = 0;
+        for shape in input_shape {
+            if shape.is_empty() {
+                return None;
+            }
+            let mut product: usize = 1;
+            for &dim in shape {
+                if dim <= 0 {
+                    return None;
+                }
+                let dim_usize = usize::try_from(dim).ok()?;
+                product = product.checked_mul(dim_usize)?;
+            }
+            total = total.checked_add(product)?;
+        }
+        Some(total)
+    }
+
     fn flush_staged(&mut self, staged: StagedWork) {
         for request in staged.requests {
             match request.run_source {
@@ -255,6 +280,36 @@ impl ValidatorLoop {
                 }
                 _ => work_items,
             }
+        };
+
+        let work_items: Vec<_> = {
+            let mut kept = Vec::with_capacity(work_items.len());
+            let mut unsatisfiable = 0usize;
+            for work in work_items {
+                match Self::expected_input_elements(&work.slice_meta.input_shape) {
+                    Some(expected) if expected != work.input.len() => {
+                        warn!(
+                            run_uid = %run_uid,
+                            slice = %work.slice_id,
+                            expected,
+                            actual = work.input.len(),
+                            "preflight: slice input activation count does not match circuit expectation, skipping"
+                        );
+                        self.run_manager.mark_slice_failed(run_uid, &work.slice_id);
+                        unsatisfiable += 1;
+                    }
+                    _ => kept.push(work),
+                }
+            }
+            if unsatisfiable > 0 {
+                info!(
+                    run_uid = %run_uid,
+                    circuit_id = %circuit.id,
+                    unsatisfiable,
+                    "preflight filtered slices with mismatched activation sizes"
+                );
+            }
+            kept
         };
 
         if work_items.is_empty() {

--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -9,6 +9,12 @@ use tracing::{info, warn};
 use super::ValidatorLoop;
 use crate::relay::DsperseSubmission;
 
+enum ExpectedInputs {
+    NoMetadata,
+    Count(usize),
+    Invalid,
+}
+
 struct StagedWork {
     requests: VecDeque<DSliceRequest>,
     events: Vec<(String, String, usize)>,
@@ -195,29 +201,34 @@ impl ValidatorLoop {
         }
     }
 
-    /// Sum of per-input element counts declared in slice metadata.
-    /// Returns None when the metadata does not advertise input shapes so the
-    /// caller falls through to dispatch untouched.
-    fn expected_input_elements(input_shape: &[Vec<i64>]) -> Option<usize> {
+    fn expected_input_elements(input_shape: &[Vec<i64>]) -> ExpectedInputs {
         if input_shape.is_empty() {
-            return None;
+            return ExpectedInputs::NoMetadata;
         }
         let mut total: usize = 0;
         for shape in input_shape {
             if shape.is_empty() {
-                return None;
+                return ExpectedInputs::NoMetadata;
             }
             let mut product: usize = 1;
             for &dim in shape {
                 if dim <= 0 {
-                    return None;
+                    return ExpectedInputs::Invalid;
                 }
-                let dim_usize = usize::try_from(dim).ok()?;
-                product = product.checked_mul(dim_usize)?;
+                let Ok(dim_usize) = usize::try_from(dim) else {
+                    return ExpectedInputs::Invalid;
+                };
+                let Some(next) = product.checked_mul(dim_usize) else {
+                    return ExpectedInputs::Invalid;
+                };
+                product = next;
             }
-            total = total.checked_add(product)?;
+            let Some(next_total) = total.checked_add(product) else {
+                return ExpectedInputs::Invalid;
+            };
+            total = next_total;
         }
-        Some(total)
+        ExpectedInputs::Count(total)
     }
 
     fn flush_staged(&mut self, staged: StagedWork) {
@@ -287,7 +298,7 @@ impl ValidatorLoop {
             let mut unsatisfiable = 0usize;
             for work in work_items {
                 match Self::expected_input_elements(&work.slice_meta.input_shape) {
-                    Some(expected) if expected != work.input.len() => {
+                    ExpectedInputs::Count(expected) if expected != work.input.len() => {
                         warn!(
                             run_uid = %run_uid,
                             slice = %work.slice_id,
@@ -298,7 +309,17 @@ impl ValidatorLoop {
                         self.run_manager.mark_slice_failed(run_uid, &work.slice_id);
                         unsatisfiable += 1;
                     }
-                    _ => kept.push(work),
+                    ExpectedInputs::Invalid => {
+                        warn!(
+                            run_uid = %run_uid,
+                            slice = %work.slice_id,
+                            input_shape = ?work.slice_meta.input_shape,
+                            "preflight: slice input shape metadata is invalid (non-positive, overflow, or out-of-range), skipping"
+                        );
+                        self.run_manager.mark_slice_failed(run_uid, &work.slice_id);
+                        unsatisfiable += 1;
+                    }
+                    ExpectedInputs::Count(_) | ExpectedInputs::NoMetadata => kept.push(work),
                 }
             }
             if unsatisfiable > 0 {

--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -207,9 +207,6 @@ impl ValidatorLoop {
         }
         let mut total: usize = 0;
         for shape in input_shape {
-            if shape.is_empty() {
-                return ExpectedInputs::NoMetadata;
-            }
             let mut product: usize = 1;
             for &dim in shape {
                 if dim <= 0 {


### PR DESCRIPTION
## Summary
- Adds a per-slice activation-length preflight between work enumeration and dispatch on the API submission path.
- For each \`SliceWork\` the run manager produced, sum \`slice_meta.input_shape\`'s element counts and compare against \`work.input.len()\`. A mismatch marks the slice failed up front and filters it out of the dispatch queue; dispatch to miners never happens.
- Behavior is opt-in via metadata presence: slices whose \`input_shape\` is empty or non-positive fall through to the existing dispatch path untouched.

## Motivation
Miners were surfacing \`witness_f64: Witness generation failed: activation length mismatch: expected N, got M\` during proof generation on circuits whose donor weights were inconsistent with the compiled slice inputs. That failure mode penalised miners for a validator-side circuit fault. Detecting the mismatch at the validator stops the dispatch and logs the specific slice + expected vs actual counts before any miner work happens.

## Test plan
- [ ] Submit against a circuit with a known-good donor and confirm preflight is a no-op and all slices dispatch as before.
- [ ] Tamper with a slice's tensor_cache seeding (or use a recorded bad donor circuit) and confirm the run marks the offending slice failed, logs the expected/actual counts, and does not dispatch any tiles for that slice.
- [ ] \`cargo clippy -p sn2-validator -- -D warnings\` + \`cargo test -p sn2-validator\` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for batch slice processing: input shapes are checked before dispatch. Slices with mismatched activation counts or invalid shape metadata are detected early, marked failed, and skipped.

* **Logging**
  * Added per-slice warnings for mismatches/invalid shapes and an aggregate info log when one or more slices are filtered for easier troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->