### PR TITLE
Investigate and wire on-chain validator permit enforcement into stock miner

### DIFF
--- a/crates/sn2-miner/src/lightning_server.rs
+++ b/crates/sn2-miner/src/lightning_server.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use btlightning::{typed_async_handler, LightningServer, LightningServerConfig};
+use btlightning::{
+    typed_async_handler, LightningServer, LightningServerConfig, ValidatorPermitResolver,
+};
 use tracing::info;
 
 use sn2_types::*;
@@ -17,17 +19,25 @@ pub async fn run_lightning_server(
     port: u16,
     handler_timeout_secs: u64,
     handlers: Arc<MinerHandlers>,
+    permit_resolver: Option<Box<dyn ValidatorPermitResolver>>,
 ) -> Result<()> {
     let idle_timeout = handler_timeout_secs.saturating_mul(2).max(150);
+    let require_validator_permit = permit_resolver.is_some();
     let config = LightningServerConfig::builder()
         .handler_timeout_secs(handler_timeout_secs)
         .idle_timeout_secs(idle_timeout)
         .max_frame_payload_bytes(sn2_types::TRANSPORT_PAYLOAD_LIMIT)
+        .require_validator_permit(require_validator_permit)
         .build()?;
     let mut server =
         LightningServer::with_config(miner_hotkey.to_string(), host.to_string(), port, config)?;
 
     server.set_miner_wallet(wallet_name, wallet_path, hotkey_name)?;
+
+    if let Some(resolver) = permit_resolver {
+        server.set_validator_permit_resolver(resolver);
+        info!("Validator permit enforcement enabled -- only hotkeys with on-chain validator_permit will be admitted");
+    }
 
     let h = handlers.clone();
     server

--- a/crates/sn2-miner/src/main.rs
+++ b/crates/sn2-miner/src/main.rs
@@ -2,6 +2,7 @@ mod cli;
 mod dsperse;
 mod handlers;
 mod lightning_server;
+mod permit_resolver;
 
 use std::sync::Arc;
 
@@ -100,6 +101,16 @@ async fn main() -> Result<()> {
     let handlers = std::sync::Arc::new(handlers);
 
     let handler_timeout = cli.handler_timeout;
+    let permit_resolver: Option<Box<dyn btlightning::ValidatorPermitResolver>> = if cli
+        .disable_blacklist
+    {
+        warn!("--disable-blacklist set; validator permit enforcement is bypassed (TESTING ONLY)");
+        None
+    } else {
+        Some(Box::new(permit_resolver::MetagraphPermitResolver::new(
+            metagraph.clone(),
+        )))
+    };
     let quic_handle = {
         let handlers = handlers.clone();
         let hotkey = wallet.hotkey_ss58().to_string();
@@ -116,6 +127,7 @@ async fn main() -> Result<()> {
                 quic_port,
                 handler_timeout,
                 handlers,
+                permit_resolver,
             )
             .await
         })
@@ -223,6 +235,7 @@ async fn run_loopback(cli: Cli) -> Result<()> {
                 port,
                 handler_timeout,
                 handlers,
+                None,
             )
             .await
         })

--- a/crates/sn2-miner/src/permit_resolver.rs
+++ b/crates/sn2-miner/src/permit_resolver.rs
@@ -1,0 +1,33 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use btlightning::{LightningError, Result as LightningResult, ValidatorPermitResolver};
+use sn2_chain::Metagraph;
+use tokio::sync::RwLock;
+
+pub struct MetagraphPermitResolver {
+    metagraph: Arc<RwLock<Metagraph>>,
+}
+
+impl MetagraphPermitResolver {
+    pub fn new(metagraph: Arc<RwLock<Metagraph>>) -> Self {
+        Self { metagraph }
+    }
+}
+
+impl ValidatorPermitResolver for MetagraphPermitResolver {
+    fn resolve_permitted_validators(&self) -> LightningResult<HashSet<String>> {
+        let guard = self.metagraph.blocking_read();
+        if guard.neurons.is_empty() {
+            return Err(LightningError::Handler(
+                "metagraph has not been synced; refusing to resolve empty permit set".to_string(),
+            ));
+        }
+        Ok(guard
+            .neurons
+            .iter()
+            .filter(|n| n.validator_permit)
+            .map(|n| n.hotkey.clone())
+            .collect())
+    }
+}


### PR DESCRIPTION
## Summary

- Stock `sn2-miner` declared `--disable-blacklist` in the CLI but never constructed a `ValidatorPermitResolver` or set `require_validator_permit` on the `btlightning` server config. Every stock miner therefore fell into the permissive branch at `lightning/crates/btlightning/src/server/mod.rs:392` and logged `Validator permit checking is disabled -- any hotkey with a valid signature can connect`, regardless of the flag.
- Introduce `MetagraphPermitResolver` in `crates/sn2-miner/src/permit_resolver.rs`, backed by the miner's existing `Arc<RwLock<Metagraph>>`. It returns the set of hotkeys whose on-chain `ValidatorPermit` bit is set on each periodic refresh the `btlightning` server performs via `spawn_blocking`.
- Wire the resolver into `run_lightning_server`: when present, the server builds its `LightningServerConfig` with `require_validator_permit(true)` and registers the resolver before entering the accept loop.
- `--disable-blacklist` is now observed: when set, the resolver is omitted and the legacy open-signature path is preserved (intended for local/integration testing). The loopback path also retains open-signature behaviour since no chain state is available.
- Empty metagraph returns an error from the resolver so the server does not admit anyone during a transient sync gap.

## Behavioural impact

- Stock miners on `testnet` will, after this lands, only admit QUIC handshakes from hotkeys that appear in `ValidatorPermit` for the miner's netuid.
- Operators who need the old behaviour (e.g. during localnet bring-up) can pass `--disable-blacklist` and will see a `WARN` line on startup.
- No interface changes to `btlightning` — this is purely wiring on the consumer side.

## Test plan

- [ ] `cargo build -p sn2-miner` on `testnet` merge-base (passes locally)
- [ ] `cargo clippy -p sn2-miner -- -D warnings` (clean locally)
- [ ] `cargo fmt -p sn2-miner -- --check` (clean locally)
- [ ] Deploy to one testnet miner, confirm startup log reads `Validator permit enforcement enabled -- only hotkeys with on-chain validator_permit will be admitted` instead of the permissive line
- [ ] Confirm a non-permitted hotkey is rejected at handshake against the patched miner
- [ ] Confirm a permitted validator hotkey still completes handshake and dispatches synapses
- [ ] Regression sweep: run existing `btlightning` integration tests (`cargo test -p btlightning`) to confirm no permit-path regressions
- [ ] Smoke-test `--disable-blacklist` still yields the legacy open-signature behaviour for localnet

## Cross-repo impact

- None at the protocol level — validator/relay paths are unchanged. Operators running custom miner builds that already wired their own resolver should drop their patch once this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented validator permit enforcement for the lightning server to restrict access to approved validators
  * Added configuration mechanism to dynamically enable or disable permit validation based on system settings
  * New --disable-blacklist flag available for testing mode, allowing bypass of validator permit checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->