### PR TITLE
Introduce release security gating and supply-chain attestation

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -51,7 +51,7 @@ jobs:
 
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
-      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cargo/registry
@@ -72,7 +72,7 @@ jobs:
 
       - name: Sync lockfile after version injection
         if: startsWith(inputs.ref || github.ref, 'refs/tags/')
-        run: cargo update -w
+        run: cargo update -w --offline
 
       - name: Build release binaries
         run: cargo build --release --locked --bin sn2-validator --bin sn2-miner
@@ -132,7 +132,7 @@ jobs:
 
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
-      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cargo/registry
@@ -153,7 +153,7 @@ jobs:
 
       - name: Sync lockfile after version injection
         if: startsWith(inputs.ref || github.ref, 'refs/tags/')
-        run: cargo update -w
+        run: cargo update -w --offline
 
       - name: Build release binaries
         run: cargo build --release --locked --bin sn2-validator --bin sn2-miner

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -202,7 +202,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Security tab
         if: steps.trivy-release.conclusion == 'success'
-        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           sarif_file: trivy-results.sarif
           category: trivy-image-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,12 +42,10 @@ jobs:
         with:
           path: artifacts
 
-      - name: Collect binaries and generate SHA256SUMS
+      - name: Collect binaries
         run: |
           cd artifacts
           find . -type f -name 'sn2-*' -exec cp {} ../ \;
-          cd ..
-          sha256sum sn2-validator-linux-x86_64 sn2-miner-linux-x86_64 sn2-validator-linux-aarch64 sn2-miner-linux-aarch64 sn2-validator-macos-aarch64 sn2-miner-macos-aarch64 > SHA256SUMS
 
       - name: Generate SBOM
         uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d # v0.23.1
@@ -56,6 +54,9 @@ jobs:
           format: cyclonedx-json
           output-file: sbom.cdx.json
           artifact-name: sbom-release
+
+      - name: Generate SHA256SUMS
+        run: sha256sum sn2-validator-linux-x86_64 sn2-miner-linux-x86_64 sn2-validator-linux-aarch64 sn2-miner-linux-aarch64 sn2-validator-macos-aarch64 sn2-miner-macos-aarch64 sbom.cdx.json > SHA256SUMS
 
       - name: Attest release binaries
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
@@ -72,7 +73,7 @@ jobs:
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
 
       - name: Sign SHA256SUMS with cosign keyless
-        run: cosign sign-blob --yes --output-signature SHA256SUMS.sig --output-certificate SHA256SUMS.pem SHA256SUMS
+        run: cosign sign-blob --yes --bundle SHA256SUMS.sigstore.json SHA256SUMS
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
@@ -86,8 +87,7 @@ jobs:
             sn2-validator-macos-aarch64
             sn2-miner-macos-aarch64
             SHA256SUMS
-            SHA256SUMS.sig
-            SHA256SUMS.pem
+            SHA256SUMS.sigstore.json
             sbom.cdx.json
 
   release-testnet:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,14 @@ permissions:
   contents: read
 
 jobs:
+  security-gate:
+    if: startsWith(github.ref, 'refs/tags/')
+    uses: ./.github/workflows/security.yml
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
   build:
     if: startsWith(github.ref, 'refs/tags/') || contains(github.event.pull_request.labels.*.name, 'run-build') || github.ref == 'refs/heads/testnet'
     uses: ./.github/workflows/build-binaries.yml
@@ -20,8 +28,9 @@ jobs:
   release:
     name: Create Release
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [build]
+    needs: [build, security-gate]
     runs-on: ubuntu-latest
+    environment: mainnet-release
     permissions:
       contents: write
       attestations: write
@@ -49,7 +58,7 @@ jobs:
           output-file: sbom.cdx.json
           artifact-name: sbom-release
 
-      - name: Attest Linux binaries
+      - name: Attest release binaries
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: |
@@ -57,6 +66,14 @@ jobs:
             sn2-miner-linux-x86_64
             sn2-validator-linux-aarch64
             sn2-miner-linux-aarch64
+            sn2-validator-macos-aarch64
+            sn2-miner-macos-aarch64
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+      - name: Sign SHA256SUMS with cosign keyless
+        run: cosign sign-blob --yes --output-signature SHA256SUMS.sig --output-certificate SHA256SUMS.pem SHA256SUMS
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
@@ -70,6 +87,8 @@ jobs:
             sn2-validator-macos-aarch64
             sn2-miner-macos-aarch64
             SHA256SUMS
+            SHA256SUMS.sig
+            SHA256SUMS.pem
             sbom.cdx.json
 
   release-testnet:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,6 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     needs: [build, security-gate]
     runs-on: ubuntu-latest
-    environment: mainnet-release
     permissions:
       contents: write
       attestations: write

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -31,7 +31,7 @@ jobs:
           publish_results: false
 
       - name: Upload SARIF results
-        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           sarif_file: results.sarif
           category: scorecard

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,6 +7,7 @@ on:
     branches: [main, testnet]
   schedule:
     - cron: "0 6 * * 1"
+  workflow_call: {}
 
 permissions:
   actions: read
@@ -25,7 +26,7 @@ jobs:
 
       - name: Cache cargo-audit binary
         id: cache-audit
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cargo/bin/cargo-audit
           key: cargo-audit-${{ env.CARGO_AUDIT_VERSION }}
@@ -81,7 +82,7 @@ jobs:
 
       - name: Upload SARIF results to GitHub
         if: always() && hashFiles('semgrep-results.sarif') != ''
-        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           sarif_file: semgrep-results.sarif
           category: semgrep
@@ -138,7 +139,7 @@ jobs:
 
       - name: TruffleHog OSS (Pull Request)
         if: github.event_name == 'pull_request'
-        uses: trufflesecurity/trufflehog@47e7b7cd74f578e1e3145d48f669f22fd1330ca6 # v3.94.3
+        uses: trufflesecurity/trufflehog@17456f8c7d042d8c82c9a8ca9e937231f9f42e26 # v3.95.2
         with:
           path: ./
           base: ${{ github.event.pull_request.base.sha }}
@@ -147,7 +148,7 @@ jobs:
 
       - name: TruffleHog OSS (Push)
         if: github.event_name == 'push'
-        uses: trufflesecurity/trufflehog@47e7b7cd74f578e1e3145d48f669f22fd1330ca6 # v3.94.3
+        uses: trufflesecurity/trufflehog@17456f8c7d042d8c82c9a8ca9e937231f9f42e26 # v3.95.2
         with:
           path: ./
           base: ${{ github.event.before }}
@@ -156,7 +157,7 @@ jobs:
 
       - name: TruffleHog OSS (Schedule)
         if: github.event_name == 'schedule'
-        uses: trufflesecurity/trufflehog@47e7b7cd74f578e1e3145d48f669f22fd1330ca6 # v3.94.3
+        uses: trufflesecurity/trufflehog@17456f8c7d042d8c82c9a8ca9e937231f9f42e26 # v3.95.2
         with:
           path: ./
           extra_args: --debug --only-verified

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -162,6 +162,13 @@ jobs:
           path: ./
           extra_args: --debug --only-verified
 
+      - name: TruffleHog OSS (Release gate)
+        if: github.event_name == 'workflow_call'
+        uses: trufflesecurity/trufflehog@17456f8c7d042d8c82c9a8ca9e937231f9f42e26 # v3.95.2
+        with:
+          path: ./
+          extra_args: --debug --only-verified
+
   security-summary:
     name: Security Summary
     runs-on: ubuntu-latest

--- a/docs/verifying_releases.md
+++ b/docs/verifying_releases.md
@@ -6,7 +6,7 @@ Every release artifact — binaries and Docker images — can be independently v
 
 | Channel | Tag | Trigger | Verification |
 |---|---|---|---|
-| **Mainnet** | semver (e.g. `0.3.0`) | Git tag push | SHA256SUMS |
+| **Mainnet** | semver (e.g. `0.3.0`) | Git tag push | SHA256SUMS + cosign keyless bundle + build provenance attestation |
 | **Testnet latest** | `testnet-latest` | Push to `testnet` branch | SHA256SUMS |
 | **Testnet nightly** | `testnet-nightly` | Nightly cron after E2E passes | SHA256SUMS |
 | **Docker (release)** | `:latest`, `:<tag>` | GitHub Release created | SLSA provenance attestation |
@@ -33,6 +33,44 @@ shasum -a 256 --check --ignore-missing SHA256SUMS
 ```
 
 Both should print `sn2-miner-linux-x86_64: OK`. A mismatch indicates the binary was tampered with or corrupted in transit.
+
+For mainnet (semver) releases, `SHA256SUMS` additionally covers `sbom.cdx.json`, so verifying the checksum file also attests the published SBOM.
+
+## Verifying the Mainnet SHA256SUMS Signature
+
+Mainnet releases (semver tags) ship a cosign keyless signature bundle alongside `SHA256SUMS`. The bundle embeds the Fulcio-issued certificate and the Rekor transparency log entry, so verification confirms both that the checksum file was produced by the release workflow on the expected tag and that the signing event is publicly logged.
+
+Verification requires [cosign](https://github.com/sigstore/cosign) v2.5 or newer:
+
+```console
+TAG="0.3.0"
+curl -fLO "https://github.com/inference-labs-inc/subnet-2/releases/download/${TAG}/SHA256SUMS"
+curl -fLO "https://github.com/inference-labs-inc/subnet-2/releases/download/${TAG}/SHA256SUMS.sigstore.json"
+
+cosign verify-blob \
+  --bundle SHA256SUMS.sigstore.json \
+  --certificate-identity "https://github.com/inference-labs-inc/subnet-2/.github/workflows/release.yml@refs/tags/${TAG}" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  SHA256SUMS
+```
+
+A successful run prints `Verified OK`. The `--certificate-identity` flag pins verification to this repository's release workflow at the exact tag, so a signature produced by any other workflow or repository will fail.
+
+## Verifying Binary Build Provenance
+
+Mainnet binaries (Linux x86_64, Linux aarch64, macOS aarch64 for both `sn2-validator` and `sn2-miner`) carry SLSA build provenance attestations issued by the release workflow. These attestations bind each binary to the source commit and workflow that produced it.
+
+Verification requires the [GitHub CLI](https://cli.github.com/) (`gh >= 2.49.0`):
+
+```console
+TAG="0.3.0"
+curl -fLO "https://github.com/inference-labs-inc/subnet-2/releases/download/${TAG}/sn2-validator-linux-x86_64"
+
+gh attestation verify sn2-validator-linux-x86_64 \
+  --repo inference-labs-inc/subnet-2
+```
+
+Repeat for each binary you intend to run. A successful run reports the workflow, the commit SHA, and the Sigstore bundle used.
 
 ## Verifying Docker Image Attestations
 


### PR DESCRIPTION
## Summary

- Gate tagged releases on the security analysis workflow via `workflow_call`; the `release` job now `needs: [build, security-gate]` so any failure in cargo-audit, cargo-deny, semgrep, trivy, or secrets-detection stops the release before artifacts publish.
- Require a protected `environment: mainnet-release` on the release job so tag pushes pause for manual approval (configure required reviewers in repo settings to activate).
- Extend `actions/attest-build-provenance` to cover `sn2-*-macos-aarch64` binaries; previously macOS shipped without build attestation.
- Install `sigstore/cosign-installer` and sign `SHA256SUMS` keyless, publishing `SHA256SUMS.sig` and `SHA256SUMS.pem` alongside the release so consumers can verify against the Rekor transparency log.
- Replace `cargo update -w` with `cargo update -w --offline` on tag builds. The unbounded form defeated the `--locked` guarantee that audited transitive dependencies matched what actually compiled; the offline form only rewrites workspace-local version entries.

## Dependency investigations (supersedes #459, #460, #461)

Rolled in the three pending Dependabot investigations after cross-verifying pinned commit SHAs against upstream tag objects and inspecting the diffs for supply-chain indicators (unexpected action-surface changes, new network endpoints, unfamiliar contributors, entrypoint mutations):

- `actions/cache` 5.0.4 → 5.0.5 — scope: `@typespec/ts-http-runtime` 0.3.2 → 0.3.5, rebuilt vendored dist. Single maintainer (yacaovsnc, long-standing). npm integrity hashes match.
- `github/codeql-action` 4.34.1 → 4.35.2 — 158 commits, contributors all GitHub employees or GitHub bot accounts. `action.yml` changes are internal release tooling only; public action surface unchanged.
- `trufflesecurity/trufflehog` 3.94.3 → 3.95.2 — analyzer code + manpage additions. `action.yml`, `Dockerfile`, and `entrypoint.sh` untouched; action surface identical.

## Test plan

- [ ] Merge, then observe `Security Analysis` workflow runs on push to testnet
- [ ] Dry-run a tag push to confirm `security-gate` blocks the release job on failure
- [ ] Confirm `mainnet-release` environment is configured with required reviewers in repo settings before next mainnet tag
- [ ] Verify `cosign verify-blob --certificate SHA256SUMS.pem --signature SHA256SUMS.sig SHA256SUMS` on the next release artifact set
- [ ] Verify `gh attestation verify sn2-validator-macos-aarch64 --repo inference-labs-inc/subnet-2` succeeds

Closes #459
Closes #460
Closes #461

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow tooling and action pins for improved security and reliability.
  * Added a release security-gate, split checksum generation, enabled keyless signing of checksums, and expanded binary provenance attestation.
  * Made the security workflow reusable and strengthened scheduled secret-detection jobs.

* **Documentation**
  * Expanded release verification guide with cosign signature verification, provenance verification steps, and SBOM checksum notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->