### PR TITLE
Introduce per-file content integrity verification in the circuit cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11511,6 +11511,7 @@ dependencies = [
  "futures-util",
  "hex",
  "reqwest 0.12.28",
+ "serde",
  "serde_json",
  "sha2 0.10.9",
  "shellexpand",

--- a/crates/sn2-circuit-store/Cargo.toml
+++ b/crates/sn2-circuit-store/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 [dependencies]
 sn2-types = { workspace = true }
 tokio = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }

--- a/crates/sn2-circuit-store/src/lib.rs
+++ b/crates/sn2-circuit-store/src/lib.rs
@@ -14,6 +14,7 @@ use tracing::{info, warn};
 
 const CIRCUIT_METADATA_FILENAME: &str = "circuit_metadata.json";
 const DSLICE_READY_MARKER: &str = ".dslice_ready";
+const FILE_SHAS_FILENAME: &str = "file_shas.json";
 const REFRESH_INTERVAL_SECS: u64 = 600;
 
 fn is_sha256_hex(s: &str) -> bool {
@@ -721,8 +722,19 @@ impl CircuitStore {
                                 name = comp.name,
                                 "component missing circuit.bin, will re-download"
                             );
+                            true
+                        } else if let Some(divergent) =
+                            Self::sidecar_divergence(&comp_dir, &bundle_dir)
+                        {
+                            info!(
+                                name = comp.name,
+                                file = %divergent,
+                                "component file content diverged from recorded SHA, will re-download"
+                            );
+                            true
+                        } else {
+                            false
                         }
-                        !has_circuit_bin
                     } else {
                         false
                     }
@@ -775,6 +787,75 @@ impl CircuitStore {
         stale
     }
 
+    /// Returns the first bundle filename whose recorded SHA does not match the
+    /// on-disk content. Returns `None` when every entry validates or when no
+    /// sidecar exists yet (legacy caches downloaded before sidecar persistence).
+    fn sidecar_divergence(comp_dir: &Path, bundle_dir: &Path) -> Option<String> {
+        let sidecar = read_file_shas(comp_dir)?;
+        for (filename, recorded) in &sidecar.bundle {
+            let path = bundle_dir.join(filename);
+            if !path.exists() {
+                return Some(filename.clone());
+            }
+            match compute_file_sha256(&path) {
+                Ok(actual) if &actual == recorded => continue,
+                _ => return Some(filename.clone()),
+            }
+        }
+        None
+    }
+
+    /// Walk every cached model directory and quarantine component dirs whose
+    /// bundle files no longer match the content recorded in their sidecar.
+    /// Returns the number of component directories removed.
+    pub async fn rehash_cache(&self) -> Result<usize> {
+        let mut removed = 0usize;
+        let root_entries = match std::fs::read_dir(&self.cache_dir) {
+            Ok(e) => e,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+            Err(e) => return Err(e).context("reading circuit cache root"),
+        };
+        for entry in root_entries.flatten() {
+            let model_dir = entry.path();
+            if !Self::is_model_cache_dir(&model_dir) {
+                continue;
+            }
+            let slices_dir = model_dir.join("slices");
+            let slice_entries = match std::fs::read_dir(&slices_dir) {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+            for slice_entry in slice_entries.flatten() {
+                let comp_dir = slice_entry.path();
+                if !comp_dir.is_dir() {
+                    continue;
+                }
+                let bundle_dir = comp_dir.join("jstprove").join("circuit.bundle");
+                if !bundle_dir.exists() {
+                    continue;
+                }
+                if let Some(divergent) = Self::sidecar_divergence(&comp_dir, &bundle_dir) {
+                    warn!(
+                        component_dir = %comp_dir.display(),
+                        file = %divergent,
+                        "rehash detected divergent bundle file, quarantining component"
+                    );
+                    if let Err(e) = std::fs::remove_dir_all(&comp_dir) {
+                        warn!(
+                            component_dir = %comp_dir.display(),
+                            error = %e,
+                            "failed to remove quarantined component directory"
+                        );
+                        continue;
+                    }
+                    removed += 1;
+                }
+            }
+        }
+        info!(removed, "circuit cache rehash complete");
+        Ok(removed)
+    }
+
     fn ensure_component_dirs(slices_dir: &Path, components: &[ParsedComponent]) -> Result<()> {
         for comp in components {
             let comp_dir = slices_dir.join(&comp.name);
@@ -792,59 +873,89 @@ impl CircuitStore {
         comp: &ParsedComponent,
         force: bool,
     ) -> Result<()> {
+        let comp_dir = slices_dir.join(&comp.name);
+        let mut sidecar = read_file_shas(&comp_dir).unwrap_or_default();
+        let mut bundle_attested = true;
+
         if comp.has_circuit {
-            let bundle_dir = slices_dir
-                .join(&comp.name)
-                .join("jstprove")
-                .join("circuit.bundle");
+            let bundle_dir = comp_dir.join("jstprove").join("circuit.bundle");
             for raw_filename in &comp.files {
                 if raw_filename.is_empty() {
                     continue;
                 }
                 let filename = Self::sanitize_name(raw_filename, "component file")?;
                 let dest = bundle_dir.join(filename);
-                if dest.exists() && !force {
+                if dest.exists() && !force && sidecar.bundle.contains_key(filename) {
                     continue;
                 }
                 if force && dest.exists() {
                     let _ = std::fs::remove_file(&dest);
                 }
-                if Self::try_hardlink_from_component_cache(
+                let relative = PathBuf::from("jstprove/circuit.bundle").join(filename);
+                if let Some(verified) = Self::try_hardlink_from_component_cache(
                     &self.cache_dir,
                     slices_dir,
                     &comp.sha,
-                    &PathBuf::from("jstprove/circuit.bundle").join(filename),
+                    &relative,
+                    filename,
                     &dest,
                 ) {
+                    sidecar.bundle.insert(filename.to_string(), verified);
                     continue;
                 }
                 let url = format!(
                     "{}/components/{}/files/{}",
                     self.api_url, comp.sha, filename
                 );
-                self.download_file(&url, &dest)
+                let outcome = self
+                    .download_file(&url, &dest)
                     .await
                     .with_context(|| format!("downloading {}/{}", comp.name, filename))?;
+                if !outcome.attested {
+                    bundle_attested = false;
+                    warn!(
+                        component = %comp.name,
+                        filename = filename,
+                        "server did not attest x-checksum-sha256 for bundle file; recording locally hashed bytes"
+                    );
+                }
+                sidecar.bundle.insert(filename.to_string(), outcome.sha);
             }
         }
 
-        let payload_dir = slices_dir.join(&comp.name).join("payload");
+        let payload_dir = comp_dir.join("payload");
         for wb in &comp.weights {
             let filename = Self::sanitize_name(&wb.filename, "weight blob file")?;
             let dest = payload_dir.join(filename);
-            if dest.exists() && !force {
+            if dest.exists() && !force && sidecar.payload.contains_key(filename) {
                 continue;
             }
             if force && dest.exists() {
                 let _ = std::fs::remove_file(&dest);
             }
             if Self::try_hardlink_from_weight_cache(&self.cache_dir, slices_dir, &wb.sha, &dest) {
+                sidecar.payload.insert(filename.to_string(), wb.sha.clone());
                 continue;
             }
             let url = format!("{}/models/wb/{}", self.api_url, wb.sha);
-            self.download_file(&url, &dest)
+            let outcome = self
+                .download_file(&url, &dest)
                 .await
                 .with_context(|| format!("downloading weight blob for {}", comp.name))?;
+            anyhow::ensure!(
+                outcome.sha == wb.sha,
+                "weight blob SHA-256 mismatch for {}/{}: expected {}, got {}",
+                comp.name,
+                filename,
+                wb.sha,
+                outcome.sha
+            );
+            sidecar.payload.insert(filename.to_string(), outcome.sha);
+        }
+
+        sidecar.server_attested = bundle_attested || !comp.has_circuit;
+        if let Err(e) = write_file_shas(&comp_dir, &sidecar) {
+            warn!(component = %comp.name, error = %e, "failed to persist file SHA sidecar");
         }
         Ok(())
     }
@@ -865,18 +976,20 @@ impl CircuitStore {
     }
 
     /// Scan sibling cached circuits for a component stamped with the same SHA
-    /// and hard-link the requested file from there. Returns true on success.
+    /// and hard-link the requested file from there after verifying the source's
+    /// recorded SHA matches its actual on-disk content.
+    ///
+    /// Returns the verified file SHA on success so the caller can propagate it
+    /// into the destination component's sidecar without recomputing.
     fn try_hardlink_from_component_cache(
         cache_dir: &Path,
         current_slices_dir: &Path,
         component_sha: &str,
         relative_path: &Path,
+        bundle_filename: &str,
         dest: &Path,
-    ) -> bool {
-        let root_entries = match std::fs::read_dir(cache_dir) {
-            Ok(entries) => entries,
-            Err(_) => return false,
-        };
+    ) -> Option<String> {
+        let root_entries = std::fs::read_dir(cache_dir).ok()?;
         for entry in root_entries.flatten() {
             let path = entry.path();
             if !Self::is_model_cache_dir(&path) {
@@ -892,16 +1005,39 @@ impl CircuitStore {
             };
             for slice_entry in slice_entries.flatten() {
                 let slice_path = slice_entry.path();
-                let stamp = slice_path.join("component.sha");
-                let matches = match std::fs::read_to_string(&stamp) {
-                    Ok(stamp_value) => stamp_value.trim() == component_sha,
-                    Err(_) => false,
-                };
-                if !matches {
+                let stamp_matches = std::fs::read_to_string(slice_path.join("component.sha"))
+                    .map(|s| s.trim() == component_sha)
+                    .unwrap_or(false);
+                if !stamp_matches {
                     continue;
                 }
                 let source = slice_path.join(relative_path);
                 if !source.exists() {
+                    continue;
+                }
+                let recorded = read_file_shas(&slice_path)
+                    .and_then(|s| s.bundle.get(bundle_filename).cloned());
+                let Some(recorded_sha) = recorded else {
+                    continue;
+                };
+                let actual_sha = match compute_file_sha256(&source) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        warn!(
+                            source = %source.display(),
+                            error = %e,
+                            "failed to hash sibling component file, skipping hardlink candidate"
+                        );
+                        continue;
+                    }
+                };
+                if actual_sha != recorded_sha {
+                    warn!(
+                        source = %source.display(),
+                        recorded = recorded_sha,
+                        actual = actual_sha,
+                        "sibling component file content diverges from its recorded SHA, skipping hardlink"
+                    );
                     continue;
                 }
                 if let Some(parent) = dest.parent() {
@@ -912,13 +1048,14 @@ impl CircuitStore {
                         source = %source.display(),
                         dest = %dest.display(),
                         sha = component_sha,
-                        "hard-linked component file from sibling circuit cache",
+                        file_sha = actual_sha,
+                        "hard-linked component file from sibling circuit cache after content verification",
                     );
-                    return true;
+                    return Some(actual_sha);
                 }
             }
         }
-        false
+        None
     }
 
     /// Scan sibling cached circuits for any weight blob whose contents hash to
@@ -1147,12 +1284,21 @@ impl CircuitStore {
         }
     }
 
-    async fn download_file(&self, url: &str, dest: &Path) -> Result<()> {
+    async fn download_file(&self, url: &str, dest: &Path) -> Result<DownloadOutcome> {
         download_file_static(&self.http, url, dest).await
     }
 }
 
-async fn download_file_static(http: &reqwest::Client, url: &str, dest: &Path) -> Result<()> {
+pub struct DownloadOutcome {
+    pub sha: String,
+    pub attested: bool,
+}
+
+async fn download_file_static(
+    http: &reqwest::Client,
+    url: &str,
+    dest: &Path,
+) -> Result<DownloadOutcome> {
     let resp = http
         .get(url)
         .timeout(std::time::Duration::from_secs(300))
@@ -1217,8 +1363,9 @@ async fn download_file_static(http: &reqwest::Client, url: &str, dest: &Path) ->
             .await
             .with_context(|| format!("flushing {}", partial.display()))?;
 
+        let actual = hex::encode(hasher.finalize());
+        let attested = expected_sha256.is_some();
         if let Some(expected) = &expected_sha256 {
-            let actual = hex::encode(hasher.finalize());
             anyhow::ensure!(
                 &actual == expected,
                 "SHA-256 mismatch: expected {expected}, got {actual}"
@@ -1227,7 +1374,12 @@ async fn download_file_static(http: &reqwest::Client, url: &str, dest: &Path) ->
 
         tokio::fs::rename(&partial, dest)
             .await
-            .with_context(|| format!("renaming {} to {}", partial.display(), dest.display()))
+            .with_context(|| format!("renaming {} to {}", partial.display(), dest.display()))?;
+
+        Ok(DownloadOutcome {
+            sha: actual,
+            attested,
+        })
     }
     .await;
 
@@ -1236,6 +1388,26 @@ async fn download_file_static(http: &reqwest::Client, url: &str, dest: &Path) ->
     }
 
     result
+}
+
+#[derive(Default, serde::Serialize, serde::Deserialize)]
+struct FileShaSidecar {
+    bundle: HashMap<String, String>,
+    payload: HashMap<String, String>,
+    server_attested: bool,
+}
+
+fn read_file_shas(comp_dir: &Path) -> Option<FileShaSidecar> {
+    let path = comp_dir.join(FILE_SHAS_FILENAME);
+    let raw = std::fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+fn write_file_shas(comp_dir: &Path, sidecar: &FileShaSidecar) -> Result<()> {
+    let path = comp_dir.join(FILE_SHAS_FILENAME);
+    let json = serde_json::to_string_pretty(sidecar).context("serializing file shas")?;
+    std::fs::write(&path, json)
+        .with_context(|| format!("writing file shas sidecar at {}", path.display()))
 }
 
 fn load_circuit_from_cache(circuit_id: &str, dir: &Path, cache_dir: &Path) -> Result<Circuit> {

--- a/crates/sn2-miner/src/cli.rs
+++ b/crates/sn2-miner/src/cli.rs
@@ -56,6 +56,13 @@ pub struct Cli {
     #[arg(long, value_delimiter = ',')]
     pub additional_circuits: Vec<String>,
 
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Rehash cached circuit bundle files on startup and quarantine any whose content diverges from the recorded SHA-256"
+    )]
+    pub rehash_cache: bool,
+
     #[arg(long, default_value_t = sn2_types::CIRCUIT_TIMEOUT_SECONDS, value_parser = clap::value_parser!(u64).range(1..))]
     pub handler_timeout: u64,
 }

--- a/crates/sn2-miner/src/main.rs
+++ b/crates/sn2-miner/src/main.rs
@@ -95,7 +95,7 @@ async fn main() -> Result<()> {
 
     let dsperse = dsperse::DSperseClient::new();
 
-    let circuit_store = init_circuit_store(false, &cli.additional_circuits).await;
+    let circuit_store = init_circuit_store(false, &cli.additional_circuits, cli.rehash_cache).await;
 
     let handlers = handlers::MinerHandlers::new(dsperse, circuit_store);
     let handlers = std::sync::Arc::new(handlers);
@@ -211,7 +211,7 @@ async fn run_loopback(cli: Cli) -> Result<()> {
 
     let dsperse = dsperse::DSperseClient::new();
 
-    let circuit_store = init_circuit_store(true, &cli.additional_circuits).await;
+    let circuit_store = init_circuit_store(true, &cli.additional_circuits, cli.rehash_cache).await;
 
     let handlers = handlers::MinerHandlers::new(dsperse, circuit_store);
     let handlers = std::sync::Arc::new(handlers);
@@ -263,9 +263,19 @@ async fn run_loopback(cli: Cli) -> Result<()> {
 async fn init_circuit_store(
     loopback: bool,
     additional_circuits: &[String],
+    rehash_cache: bool,
 ) -> sn2_circuit_store::CircuitStore {
     let mut store =
         sn2_circuit_store::CircuitStore::new(None, loopback, additional_circuits.to_vec());
+    if rehash_cache {
+        match store.rehash_cache().await {
+            Ok(removed) => info!(
+                quarantined = removed,
+                "circuit cache rehash completed before load"
+            ),
+            Err(e) => warn!(error = %e, "circuit cache rehash failed"),
+        }
+    }
     if let Err(e) = store.load_circuits().await {
         warn!(error = %e, "failed to load circuits from cache");
     }

--- a/crates/sn2-validator/src/cli.rs
+++ b/crates/sn2-validator/src/cli.rs
@@ -70,4 +70,11 @@ pub struct Cli {
 
     #[arg(long, value_delimiter = ',')]
     pub additional_circuits: Vec<String>,
+
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Rehash cached circuit bundle files on startup and quarantine any whose content diverges from the recorded SHA-256"
+    )]
+    pub rehash_cache: bool,
 }

--- a/crates/sn2-validator/src/config.rs
+++ b/crates/sn2-validator/src/config.rs
@@ -28,6 +28,7 @@ pub struct ValidatorConfig {
     pub disable_metric_logging: bool,
     pub loopback: bool,
     pub additional_circuits: Vec<String>,
+    pub rehash_cache: bool,
 }
 
 impl ValidatorConfig {
@@ -95,6 +96,7 @@ impl ValidatorConfig {
             disable_metric_logging: cli.disable_metric_logging,
             loopback: false,
             additional_circuits: cli.additional_circuits.clone(),
+            rehash_cache: cli.rehash_cache,
         })
     }
 
@@ -156,6 +158,7 @@ impl ValidatorConfig {
             disable_metric_logging: true,
             loopback: true,
             additional_circuits: cli.additional_circuits.clone(),
+            rehash_cache: cli.rehash_cache,
         })
     }
 

--- a/crates/sn2-validator/src/validator_loop/mod.rs
+++ b/crates/sn2-validator/src/validator_loop/mod.rs
@@ -308,6 +308,15 @@ impl ValidatorLoop {
             circuit_store_loopback,
             config.additional_circuits.clone(),
         );
+        if config.rehash_cache {
+            match circuit_store.rehash_cache().await {
+                Ok(removed) => info!(
+                    quarantined = removed,
+                    "circuit cache rehash completed before validator startup"
+                ),
+                Err(e) => warn!(error = %e, "circuit cache rehash failed"),
+            }
+        }
         let run_manager = IncrementalRunManager::new();
 
         let now = Instant::now();


### PR DESCRIPTION
## Summary

Strengthens the circuit-store cache against silent file corruption by recording a per-file SHA-256 sidecar alongside every component, verifying source content before cross-circuit hardlink reuse, and offering an explicit cache rehash on startup. The headline win is that bundle files materialized into the cache are now content-verified at every transition — fresh download, hardlink reuse, and stale detection — instead of relying solely on aggregate component-level stamps.

## What changes

- **`file_shas.json` per component** — each component directory persists `{bundle: {filename → sha256}, payload: {filename → sha256}, server_attested: bool}` on every successful materialization. The aggregate `component.sha` stamp keeps its existing role.
- **Verified hardlink reuse** — `try_hardlink_from_component_cache` now reads the source slice's sidecar, recomputes the source file's SHA, and only links when the recorded and actual hashes match. The verified hash is propagated into the destination component's sidecar so trust is transitive.
- **Sidecar-aware staleness** — `find_stale_components` consults the sidecar; an existing component whose on-disk content has drifted from the recorded hash is treated as stale and re-downloaded.
- **`--rehash-cache` startup flag** on both miner and validator. When set, the circuit store walks the cache root, recomputes SHAs across every component bundle, and removes any component directory whose contents diverge from its sidecar. Subsequent circuit loading refetches the quarantined components.
- **`DownloadOutcome`** return type from the download path carries both the bytes-as-received SHA and an `attested` flag indicating whether a server-side `x-checksum-sha256` header was present. Components without attestation are recorded with locally hashed bytes plus `server_attested: false` so operators can reason about provenance.

## Why

The circuit-store dedup path hardlinks bundle files (`circuit.bin`, `manifest.msgpack`, `witness_solver.bin`) across cached models when they share a component sha. Today that dedup uses only the aggregate stamp as the equivalence test. Once a bundle file diverges from its expected content for any reason — partial download, fs corruption, edge-case write interruption — the divergence has no detector and propagates through hardlinks to every co-installed model that shares the component. The missing per-file content check is a quiet structural hole that this change closes.

The new sidecar makes integrity local and reusable: the same file SHA is the trust anchor at download, hardlink, stale-check, and rehash time.

## Compatibility

- **Forward-compatible with caches downloaded before this change.** Legacy caches with no sidecar fall through to the existing existence-only stale check on first encounter; the sidecar is created opportunistically when components are next materialized.
- **No protocol or wire-format change.** All changes are local to `sn2-circuit-store` and the miner/validator startup wiring.

## Test plan

- [x] `cargo build` (workspace) clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Run miner with `--rehash-cache` against a populated cache; confirm a planted divergent file is quarantined and re-downloaded
- [ ] Run validator with `--rehash-cache`; confirm same behaviour through `validator_loop` startup
- [ ] Run miner without `--rehash-cache` after cold-starting on an existing cache; confirm sidecars are written incrementally as components are touched, no behavioural regressions on hot-path operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--rehash-cache` CLI flag to enable startup validation of cached circuit bundles in miner and validator
  * Implemented SHA256-based integrity verification for circuit cache files

* **Improvements**
  * Enhanced detection of stale or corrupted cached components
  * Automatically quarantine and remove corrupted cache entries to prevent usage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->