### PR TITLE
Resolve multi-input tiled wire dispatch and tighten preflight

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3191,7 +3191,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 [[package]]
 name = "dsperse"
 version = "0.0.0"
-source = "git+https://github.com/inference-labs-inc/dsperse?rev=a71f618e#a71f618e5cd5e99a45831a4489aa0970bab213f5"
+source = "git+https://github.com/inference-labs-inc/dsperse?rev=3fa80813#3fa80813f7ea21e33b8909c8049b72aa5651a2ca"
 dependencies = [
  "clap",
  "jstprove-io",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3191,7 +3191,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 [[package]]
 name = "dsperse"
 version = "0.0.0"
-source = "git+https://github.com/inference-labs-inc/dsperse?rev=f88c380d#f88c380d8cfc0f455f27c821313190d2c8c07df5"
+source = "git+https://github.com/inference-labs-inc/dsperse?rev=54f00006#54f0000600bbb1e2c99ac54dc4d0c3381b3f8b63"
 dependencies = [
  "clap",
  "jstprove-io",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3191,7 +3191,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 [[package]]
 name = "dsperse"
 version = "0.0.0"
-source = "git+https://github.com/inference-labs-inc/dsperse?rev=54f00006#54f0000600bbb1e2c99ac54dc4d0c3381b3f8b63"
+source = "git+https://github.com/inference-labs-inc/dsperse?rev=6af459e8#6af459e8ccdaf49b48991f7e0f383ac75878e5f7"
 dependencies = [
  "clap",
  "jstprove-io",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3191,7 +3191,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 [[package]]
 name = "dsperse"
 version = "0.0.0"
-source = "git+https://github.com/inference-labs-inc/dsperse?rev=3fa80813#3fa80813f7ea21e33b8909c8049b72aa5651a2ca"
+source = "git+https://github.com/inference-labs-inc/dsperse?rev=f88c380d#f88c380d8cfc0f455f27c821313190d2c8c07df5"
 dependencies = [
  "clap",
  "jstprove-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ futures-util = "0.3"
 shellexpand = "3.1.2"
 openssl = { version = "0.10", features = ["vendored"] }
 flate2 = "1"
-dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "54f00006" }
+dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "6af459e8" }
 ndarray = { version = "0.17", features = ["serde"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 bittensor-drand = { git = "https://github.com/inference-labs-inc/bittensor-drand.git", rev = "e55ed98", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ futures-util = "0.3"
 shellexpand = "3.1.2"
 openssl = { version = "0.10", features = ["vendored"] }
 flate2 = "1"
-dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "3fa80813" }
+dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "f88c380d" }
 ndarray = { version = "0.17", features = ["serde"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 bittensor-drand = { git = "https://github.com/inference-labs-inc/bittensor-drand.git", rev = "e55ed98", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ futures-util = "0.3"
 shellexpand = "3.1.2"
 openssl = { version = "0.10", features = ["vendored"] }
 flate2 = "1"
-dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "f88c380d" }
+dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "54f00006" }
 ndarray = { version = "0.17", features = ["serde"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 bittensor-drand = { git = "https://github.com/inference-labs-inc/bittensor-drand.git", rev = "e55ed98", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ futures-util = "0.3"
 shellexpand = "3.1.2"
 openssl = { version = "0.10", features = ["vendored"] }
 flate2 = "1"
-dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "a71f618e" }
+dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "3fa80813" }
 ndarray = { version = "0.17", features = ["serde"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 bittensor-drand = { git = "https://github.com/inference-labs-inc/bittensor-drand.git", rev = "e55ed98", default-features = false }

--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -26,6 +26,12 @@ struct BundleDispatchMismatch {
     strategy: &'static str,
 }
 
+struct PreflightOutcome {
+    kept: Vec<dsperse::pipeline::SliceWork>,
+    failed: Vec<String>,
+    unsatisfiable: usize,
+}
+
 impl TiledPayload {
     fn len(&self) -> usize {
         match self {
@@ -303,6 +309,69 @@ impl ValidatorLoop {
         }
     }
 
+    /// Synchronous preflight loop, intended to be called from inside a
+    /// `tokio::task::spawn_blocking` scope. Each work item is validated
+    /// against (a) its model-level aggregate input shape and (b) its
+    /// compiled circuit's per-witness expected payload size; mismatches
+    /// produce a slice-id entry in `failed` and are dropped from `kept`.
+    fn preflight_work_items(
+        run_uid: &str,
+        work_items: Vec<dsperse::pipeline::SliceWork>,
+    ) -> PreflightOutcome {
+        let mut kept = Vec::with_capacity(work_items.len());
+        let mut failed: Vec<String> = Vec::new();
+        let mut unsatisfiable = 0usize;
+        for work in work_items {
+            match Self::expected_input_elements(&work.slice_meta.input_shape) {
+                ExpectedInputs::Count(expected) if expected != work.input.len() => {
+                    warn!(
+                        run_uid = %run_uid,
+                        slice = %work.slice_id,
+                        expected,
+                        actual = work.input.len(),
+                        "preflight: slice input activation count does not match circuit expectation, skipping"
+                    );
+                    failed.push(work.slice_id.clone());
+                    unsatisfiable += 1;
+                    continue;
+                }
+                ExpectedInputs::Invalid => {
+                    warn!(
+                        run_uid = %run_uid,
+                        slice = %work.slice_id,
+                        input_shape = ?work.slice_meta.input_shape,
+                        "preflight: slice input shape metadata is invalid (non-positive, overflow, or out-of-range), skipping"
+                    );
+                    failed.push(work.slice_id.clone());
+                    unsatisfiable += 1;
+                    continue;
+                }
+                ExpectedInputs::Count(_) | ExpectedInputs::NoMetadata => {}
+            }
+
+            if let Some(mismatch) = Self::bundle_dispatch_mismatch(&work) {
+                warn!(
+                    run_uid = %run_uid,
+                    slice = %work.slice_id,
+                    bundle_expected = mismatch.bundle_expected,
+                    per_request_actual = mismatch.per_request_actual,
+                    strategy = mismatch.strategy,
+                    "preflight: per-request payload size will not match the slice's compiled circuit, skipping"
+                );
+                failed.push(work.slice_id.clone());
+                unsatisfiable += 1;
+                continue;
+            }
+
+            kept.push(work);
+        }
+        PreflightOutcome {
+            kept,
+            failed,
+            unsatisfiable,
+        }
+    }
+
     fn expected_input_elements(input_shape: &[Vec<i64>]) -> ExpectedInputs {
         if input_shape.is_empty() {
             return ExpectedInputs::NoMetadata;
@@ -392,63 +461,39 @@ impl ValidatorLoop {
             }
         };
 
-        let work_items: Vec<_> = {
-            let mut kept = Vec::with_capacity(work_items.len());
-            let mut unsatisfiable = 0usize;
-            for work in work_items {
-                match Self::expected_input_elements(&work.slice_meta.input_shape) {
-                    ExpectedInputs::Count(expected) if expected != work.input.len() => {
-                        warn!(
-                            run_uid = %run_uid,
-                            slice = %work.slice_id,
-                            expected,
-                            actual = work.input.len(),
-                            "preflight: slice input activation count does not match circuit expectation, skipping"
-                        );
-                        self.run_manager.mark_slice_failed(run_uid, &work.slice_id);
-                        unsatisfiable += 1;
-                        continue;
-                    }
-                    ExpectedInputs::Invalid => {
-                        warn!(
-                            run_uid = %run_uid,
-                            slice = %work.slice_id,
-                            input_shape = ?work.slice_meta.input_shape,
-                            "preflight: slice input shape metadata is invalid (non-positive, overflow, or out-of-range), skipping"
-                        );
-                        self.run_manager.mark_slice_failed(run_uid, &work.slice_id);
-                        unsatisfiable += 1;
-                        continue;
-                    }
-                    ExpectedInputs::Count(_) | ExpectedInputs::NoMetadata => {}
-                }
-
-                if let Some(mismatch) = Self::bundle_dispatch_mismatch(&work) {
-                    warn!(
-                        run_uid = %run_uid,
-                        slice = %work.slice_id,
-                        bundle_expected = mismatch.bundle_expected,
-                        per_request_actual = mismatch.per_request_actual,
-                        strategy = mismatch.strategy,
-                        "preflight: per-request payload size will not match the slice's compiled circuit, skipping"
-                    );
-                    self.run_manager.mark_slice_failed(run_uid, &work.slice_id);
-                    unsatisfiable += 1;
-                    continue;
-                }
-
-                kept.push(work);
+        // Bundle preflight reads each slice's manifest.msgpack and (for WAI
+        // bundles) the slice's onnx graph; those are synchronous disk reads
+        // that must not run on the async reactor. Move the entire preflight
+        // loop into a blocking task and rejoin afterwards to drive
+        // run_manager updates from the async context.
+        let preflight_run_uid = run_uid.to_string();
+        let preflight = tokio::task::spawn_blocking(move || {
+            Self::preflight_work_items(&preflight_run_uid, work_items)
+        })
+        .await;
+        let PreflightOutcome {
+            kept: work_items,
+            failed: preflight_failed,
+            unsatisfiable,
+        } = match preflight {
+            Ok(outcome) => outcome,
+            Err(e) => {
+                warn!(run_uid = %run_uid, error = %e, "preflight task panicked");
+                self.teardown_run(run_uid).await;
+                return;
             }
-            if unsatisfiable > 0 {
-                info!(
-                    run_uid = %run_uid,
-                    circuit_id = %circuit.id,
-                    unsatisfiable,
-                    "preflight filtered slices due to mismatched activation sizes or invalid metadata"
-                );
-            }
-            kept
         };
+        for slice_id in &preflight_failed {
+            self.run_manager.mark_slice_failed(run_uid, slice_id);
+        }
+        if unsatisfiable > 0 {
+            info!(
+                run_uid = %run_uid,
+                circuit_id = %circuit.id,
+                unsatisfiable,
+                "preflight filtered slices due to mismatched activation sizes or invalid metadata"
+            );
+        }
 
         if work_items.is_empty() {
             info!(run_uid = %run_uid, "no circuit slices to dispatch, completing run");
@@ -636,17 +681,21 @@ impl ValidatorLoop {
                     if !sampled_indices.contains(&idx) {
                         continue;
                     }
+                    // The 1-D shape `[flat.len()]` always matches the
+                    // length of `flat`, so `from_shape_vec` cannot return
+                    // `Err` here. If it ever does, an upstream invariant
+                    // has been violated and panicking with full context
+                    // is preferable to silently dropping the tile.
+                    let len = flat.len();
                     let tile_arr =
-                        ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&[flat.len()]), flat).ok();
-                    let Some(tile_arr) = tile_arr else {
-                        warn!(
-                            run_uid = %run_uid,
-                            slice = %slice_id,
-                            tile_idx = idx,
-                            "failed to reshape multi-input tile payload"
+                        ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&[len]), flat).unwrap_or_else(
+                            |e| {
+                                panic!(
+                                    "ndarray::ArrayD::from_shape_vec rejected 1-D shape [{len}] \
+                                     for multi-input tile (run_uid={run_uid} slice={slice_id} tile_idx={idx}): {e}"
+                                )
+                            },
                         );
-                        return None;
-                    };
                     let tile_json = serde_json::json!({
                         "input_data": crate::tensor::arrayd_to_json(&tile_arr)
                     });

--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -15,6 +15,26 @@ enum ExpectedInputs {
     Invalid,
 }
 
+enum TiledPayload {
+    SingleInput(Vec<ndarray::ArrayD<f64>>),
+    MultiInput(Vec<Vec<f64>>),
+}
+
+struct BundleDispatchMismatch {
+    bundle_expected: usize,
+    per_request_actual: usize,
+    strategy: &'static str,
+}
+
+impl TiledPayload {
+    fn len(&self) -> usize {
+        match self {
+            Self::SingleInput(v) => v.len(),
+            Self::MultiInput(v) => v.len(),
+        }
+    }
+}
+
 struct StagedWork {
     requests: VecDeque<DSliceRequest>,
     events: Vec<(String, String, usize)>,
@@ -201,6 +221,88 @@ impl ValidatorLoop {
         }
     }
 
+    /// Compare the per-request payload size that this work item will dispatch
+    /// against what the slice's compiled circuit actually consumes per witness.
+    /// Returns `Some(mismatch)` only when both can be determined and they
+    /// disagree; `None` means the check could not be performed (no bundle, no
+    /// onnx, etc.) or the sizes match.
+    ///
+    /// The bundle's `params.inputs` declare the witness-side shape contract.
+    /// `params.weights_as_inputs` slices reserve the trailing entries for
+    /// onnx initializers; the activation prefix length is
+    /// `params.inputs.len() - initializers.len()`. The sum of shape products
+    /// over that prefix is what the witness solver enforces.
+    fn bundle_dispatch_mismatch(
+        work: &dsperse::pipeline::SliceWork,
+    ) -> Option<BundleDispatchMismatch> {
+        let circuit_path = work.circuit_path.as_ref()?;
+        let backend = dsperse::backend::jstprove::JstproveBackend::new();
+        let params = match backend.load_params(std::path::Path::new(circuit_path)) {
+            Ok(Some(p)) => p,
+            _ => return None,
+        };
+
+        let initializer_count = if params.weights_as_inputs {
+            let onnx = work.onnx_path.as_ref()?;
+            match dsperse::pipeline::extract_onnx_initializers(std::path::Path::new(onnx), &params)
+            {
+                Ok(v) => v.len(),
+                Err(_) => return None,
+            }
+        } else {
+            0
+        };
+
+        let activation_entries = params.inputs.len().checked_sub(initializer_count)?;
+        let bundle_expected: usize = params.inputs[..activation_entries]
+            .iter()
+            .map(|io| io.shape.iter().product::<usize>())
+            .sum();
+        if bundle_expected == 0 {
+            return None;
+        }
+
+        let (per_request_actual, strategy) = if let Some(tiling) = &work.tiling {
+            let n = std::cmp::max(work.named_inputs.len(), 1);
+            let per_input = if tiling.ndim == 1 {
+                tiling.segment_size.unwrap_or(0)
+            } else {
+                let tiles = if work.named_inputs.len() > 1 {
+                    dsperse::pipeline::split_for_multi_input_dispatch(&work.named_inputs, tiling)
+                        .ok()
+                        .and_then(|v| v.into_iter().next())
+                        .map(|flat| flat.len() / n)
+                } else {
+                    dsperse::pipeline::split_for_tiling(&work.input, tiling)
+                        .ok()
+                        .and_then(|v| v.into_iter().next())
+                        .map(|t| t.len())
+                };
+                tiles.unwrap_or(0)
+            };
+            (
+                per_input.checked_mul(n).unwrap_or(0),
+                if work.named_inputs.len() > 1 {
+                    "tiled-multi-input"
+                } else {
+                    "tiled-single-input"
+                },
+            )
+        } else {
+            (work.input.len(), "single")
+        };
+
+        if per_request_actual == 0 || per_request_actual == bundle_expected {
+            None
+        } else {
+            Some(BundleDispatchMismatch {
+                bundle_expected,
+                per_request_actual,
+                strategy,
+            })
+        }
+    }
+
     fn expected_input_elements(input_shape: &[Vec<i64>]) -> ExpectedInputs {
         if input_shape.is_empty() {
             return ExpectedInputs::NoMetadata;
@@ -305,6 +407,7 @@ impl ValidatorLoop {
                         );
                         self.run_manager.mark_slice_failed(run_uid, &work.slice_id);
                         unsatisfiable += 1;
+                        continue;
                     }
                     ExpectedInputs::Invalid => {
                         warn!(
@@ -315,9 +418,26 @@ impl ValidatorLoop {
                         );
                         self.run_manager.mark_slice_failed(run_uid, &work.slice_id);
                         unsatisfiable += 1;
+                        continue;
                     }
-                    ExpectedInputs::Count(_) | ExpectedInputs::NoMetadata => kept.push(work),
+                    ExpectedInputs::Count(_) | ExpectedInputs::NoMetadata => {}
                 }
+
+                if let Some(mismatch) = Self::bundle_dispatch_mismatch(&work) {
+                    warn!(
+                        run_uid = %run_uid,
+                        slice = %work.slice_id,
+                        bundle_expected = mismatch.bundle_expected,
+                        per_request_actual = mismatch.per_request_actual,
+                        strategy = mismatch.strategy,
+                        "preflight: per-request payload size will not match the slice's compiled circuit, skipping"
+                    );
+                    self.run_manager.mark_slice_failed(run_uid, &work.slice_id);
+                    unsatisfiable += 1;
+                    continue;
+                }
+
+                kept.push(work);
             }
             if unsatisfiable > 0 {
                 info!(
@@ -340,6 +460,7 @@ impl ValidatorLoop {
 
         for work in work_items {
             let mut input_tensor = work.input;
+            let named_inputs = work.named_inputs;
 
             if input_tensor.iter().any(|v| !v.is_finite()) {
                 warn!(
@@ -368,6 +489,7 @@ impl ValidatorLoop {
                     comp_sha,
                     tiling,
                     input_tensor,
+                    &named_inputs,
                     run_source,
                     clamped_prove_pct,
                 ) {
@@ -426,18 +548,35 @@ impl ValidatorLoop {
         component_sha: Option<&str>,
         tiling: &dsperse::schema::tiling::TilingInfo,
         input_tensor: ndarray::ArrayD<f64>,
+        named_inputs: &[(String, ndarray::ArrayD<f64>)],
         run_source: RunSource,
         prove_pct: f64,
     ) -> Option<usize> {
-        let tiles = match dsperse::pipeline::split_for_tiling(&input_tensor, tiling) {
-            Ok(t) => t,
-            Err(e) => {
-                warn!(run_uid = %run_uid, slice = %slice_id, error = %e, "split_for_tiling failed");
-                return None;
+        let multi_input = named_inputs.len() > 1;
+        let tiles_payload = if multi_input {
+            match dsperse::pipeline::split_for_multi_input_dispatch(named_inputs, tiling) {
+                Ok(per_tile) => TiledPayload::MultiInput(per_tile),
+                Err(e) => {
+                    warn!(
+                        run_uid = %run_uid,
+                        slice = %slice_id,
+                        error = %e,
+                        "split_for_multi_input_dispatch failed"
+                    );
+                    return None;
+                }
+            }
+        } else {
+            match dsperse::pipeline::split_for_tiling(&input_tensor, tiling) {
+                Ok(t) => TiledPayload::SingleInput(t),
+                Err(e) => {
+                    warn!(run_uid = %run_uid, slice = %slice_id, error = %e, "split_for_tiling failed");
+                    return None;
+                }
             }
         };
 
-        let num_tiles = tiles.len();
+        let num_tiles = tiles_payload.len();
         if num_tiles == 0 || num_tiles != tiling.num_tiles {
             warn!(
                 run_uid = %run_uid,
@@ -471,32 +610,90 @@ impl ValidatorLoop {
             return None;
         }
 
-        for (idx, tile) in tiles.into_iter().enumerate() {
-            if !sampled_indices.contains(&idx) {
-                continue;
+        match tiles_payload {
+            TiledPayload::SingleInput(tiles) => {
+                for (idx, tile) in tiles.into_iter().enumerate() {
+                    if !sampled_indices.contains(&idx) {
+                        continue;
+                    }
+                    let tile_json = serde_json::json!({
+                        "input_data": crate::tensor::arrayd_to_json(&tile.into_dyn())
+                    });
+                    staged.stage_request(Self::build_tile_request(
+                        circuit,
+                        slice_id,
+                        run_uid,
+                        tile_json,
+                        idx as u32,
+                        run_source,
+                        circuit_path,
+                        component_sha,
+                    ));
+                }
             }
-            let tile_json = serde_json::json!({
-                "input_data": crate::tensor::arrayd_to_json(&tile.into_dyn())
-            });
-            staged.stage_request(DSliceRequest {
-                circuit: circuit.clone(),
-                inputs: tile_json,
-                request_type: RequestType::DSlice,
-                proof_system: circuit.proof_system,
-                slice_num: slice_id.to_string(),
-                run_uid: run_uid.to_string(),
-                outputs: None,
-                is_tile: true,
-                tile_idx: Some(idx as u32),
-                task_id: None,
-                run_source,
-                retry_count: 0,
-                circuit_path: circuit_path.map(String::from),
-                component_sha: component_sha.map(String::from),
-            });
+            TiledPayload::MultiInput(per_tile) => {
+                for (idx, flat) in per_tile.into_iter().enumerate() {
+                    if !sampled_indices.contains(&idx) {
+                        continue;
+                    }
+                    let tile_arr =
+                        ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&[flat.len()]), flat).ok();
+                    let Some(tile_arr) = tile_arr else {
+                        warn!(
+                            run_uid = %run_uid,
+                            slice = %slice_id,
+                            tile_idx = idx,
+                            "failed to reshape multi-input tile payload"
+                        );
+                        return None;
+                    };
+                    let tile_json = serde_json::json!({
+                        "input_data": crate::tensor::arrayd_to_json(&tile_arr)
+                    });
+                    staged.stage_request(Self::build_tile_request(
+                        circuit,
+                        slice_id,
+                        run_uid,
+                        tile_json,
+                        idx as u32,
+                        run_source,
+                        circuit_path,
+                        component_sha,
+                    ));
+                }
+            }
         }
 
         Some(sampled_indices.len())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn build_tile_request(
+        circuit: &Circuit,
+        slice_id: &str,
+        run_uid: &str,
+        tile_json: serde_json::Value,
+        tile_idx: u32,
+        run_source: RunSource,
+        circuit_path: Option<&str>,
+        component_sha: Option<&str>,
+    ) -> DSliceRequest {
+        DSliceRequest {
+            circuit: circuit.clone(),
+            inputs: tile_json,
+            request_type: RequestType::DSlice,
+            proof_system: circuit.proof_system,
+            slice_num: slice_id.to_string(),
+            run_uid: run_uid.to_string(),
+            outputs: None,
+            is_tile: true,
+            tile_idx: Some(tile_idx),
+            task_id: None,
+            run_source,
+            retry_count: 0,
+            circuit_path: circuit_path.map(String::from),
+            component_sha: component_sha.map(String::from),
+        }
     }
 
     fn sample_tile_indices(

--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -264,9 +264,6 @@ impl ValidatorLoop {
             .iter()
             .map(|io| io.shape.iter().product::<usize>())
             .sum();
-        if bundle_expected == 0 {
-            return None;
-        }
 
         let (per_request_actual, strategy) = if let Some(tiling) = &work.tiling {
             let n = std::cmp::max(work.named_inputs.len(), 1);
@@ -298,7 +295,11 @@ impl ValidatorLoop {
             (work.input.len(), "single")
         };
 
-        if per_request_actual == 0 || per_request_actual == bundle_expected {
+        // The only safe early-out is "both sides agree on zero". Treating
+        // either side's zero independently as a free pass would let an
+        // asymmetric configuration (compiled for empty activations but
+        // dispatched with N elements, or vice versa) slip through preflight.
+        if per_request_actual == bundle_expected {
             None
         } else {
             Some(BundleDispatchMismatch {


### PR DESCRIPTION
## Summary

Two coordinated changes that close a structural failure mode where the validator dispatched a per-request payload the miner's compiled circuit could not consume:

1. **Multi-input tiled dispatch.** Pins dsperse to `3fa80813` (PR inference-labs-inc/dsperse#201) which gathers `tiling.all_input_names()` into `SliceWork.named_inputs` and exposes `split_for_multi_input_dispatch`. `stage_tiled_work` now branches on `named_inputs.len()`: single-input keeps `split_for_tiling`; multi-input builds per-tile payloads of `N * tile_size` flat elements and dispatches each via the new helper.

2. **Bundle-aware preflight.** `bundle_dispatch_mismatch` loads each slice's compiled circuit params via `JstproveBackend::load_params`, computes the witness-side activation prefix sum (discounting initializers via `extract_onnx_initializers` when `weights_as_inputs`), and compares to the actual per-request payload size resolved from the strategy. Mismatches are marked unsatisfiable and never dispatched. The check is a no-op when params or onnx aren't loadable, so it can't introduce regressions for circuits that previously worked.

## Why

Slices with `tiling.input_names.len() > 1` (attention QKV concatenations, residual+sublayer combinations, etc.) compile a per-witness circuit that expects `N` concatenated input segments per tile. The validator's wire path read only the singular `tiling.input_name`, sent `tile_size` elements per request, and the miner's witness solver rejected the undersized payload at `jstprove_circuits/src/onnx.rs:426` — `Witness generation failed: activation length mismatch: expected N*tile_size, got tile_size`. The local-prove path in `tiled.rs` already iterates `all_input_names`; the wire path was simply missing the same handling.

The aggregate preflight present today (`expected_input_elements` over `slice_meta.input_shape`) compares model-level totals; it does not reject per-request mismatches. The new bundle-based preflight is per-witness: whatever the bundle declares as its activation prefix sum is the only acceptable per-request payload size, regardless of strategy. Any future slicer/runner/compiler drift that produces a different per-request shape is now caught at the validator and never reaches the miner.

## Compatibility

- Single-input tiled slices: behaviour unchanged. `named_inputs.len() <= 1` retains the existing `split_for_tiling` + `arrayd_to_json` dispatch.
- Slices with no compiled bundle on disk or unreadable params: the new preflight returns early; aggregate preflight continues to apply. No regression.
- WAI bundles: `extract_onnx_initializers` resolves the initializer count using the slice's onnx; if onnx is unavailable the new check returns early.

## Test plan

- [x] `cargo build` (workspace) clean against dsperse `3fa80813`
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Run validator + miner against rfdetr-nano (`33894054…`); confirm slice_48 (3 inputs) and slice_56 (2 inputs) now dispatch with `1152` and `768` element payloads respectively and produce successful witness/proof
- [ ] Plant a manifest with deliberately mismatched `params.inputs` shapes; confirm the new preflight rejects those slices at enqueue time with the structured warning rather than letting the miner surface a witness error

## Coordination

- Depends on inference-labs-inc/dsperse#201 (multi-input tiled wire helpers + missing-input validation). Cargo.toml pin updated to the post-validation tip `3fa80813`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preflight validation to detect and skip requests with mismatched payload and activation sizes, plus moved heavy preflight work to background processing to reduce runtime errors and improve stability and request handling for tiled/multi-input payloads.

* **Chores**
  * Updated a workspace dependency to a newer pinned upstream commit to keep builds consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->