### PR TITLE
Resolve RUSTSEC-2026-0104 and unblock cargo-audit on CVSS 4.0 advisories

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 env:
-  CARGO_AUDIT_VERSION: "0.21.2"
+  CARGO_AUDIT_VERSION: "0.22.1"
 
 jobs:
   cargo-audit:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9722,7 +9722,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -10559,9 +10559,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

Unblocks the release-gate workflow on tag pushes.

- Bumps \`rustls-webpki\` 0.103.12 → 0.103.13 to clear **RUSTSEC-2026-0104** (reachable panic in CRL parsing). Patched range: \`>= 0.103.13, < 0.104.0-alpha.1\`.
- Bumps workflow-pinned \`cargo-audit\` 0.21.2 → 0.22.1 so the advisory-db loader can parse entries carrying CVSS 4.0 vectors. The 0.21.2 binary fails on **RUSTSEC-2026-0038** (\`rssn\` crate, unrelated to us) with \`unsupported CVSS version: 4.0\`, which aborts the security-gate stage before any other check can run.

Both findings appeared between the testnet release at 17:52 (passing) and the 14.8.0 tag push at 18:20 (failing) — advisory-db updates added the new entries in that window.

## Test plan

- [ ] \`cargo build -p sn2-validator -p sn2-types\` — passes locally
- [ ] \`cargo test -p sn2-validator\` — 77 passed locally
- [ ] \`cargo clippy -p sn2-validator -p sn2-types -- -D warnings\` — clean locally
- [ ] \`cargo fmt --check\` — clean locally
- [ ] Confirm Release workflow security-gate stage passes on this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the security audit tool in the CI/CD pipeline to a newer version for enhanced vulnerability detection and improved scanning capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->