### PR TITLE
Resolve workspace license inheritance and ignore upstream wasmtime advisories

### DIFF
--- a/audit.toml
+++ b/audit.toml
@@ -1,0 +1,26 @@
+# cargo-audit configuration. Read at the workspace root.
+#
+# wasmtime 8.0.1 is pulled transitively via sc-executor-wasmtime (Substrate
+# runtime host used by subxt for chain RPC). The validator and miner do not
+# execute untrusted WebAssembly; the only WASM ever loaded is the bittensor
+# chain runtime downloaded from a trusted endpoint. Bumping wasmtime requires
+# a coordinated Substrate upgrade across the dependency tree.
+[advisories]
+ignore = [
+    "RUSTSEC-2023-0091",
+    "RUSTSEC-2024-0438",
+    "RUSTSEC-2025-0118",
+    "RUSTSEC-2026-0020",
+    "RUSTSEC-2026-0021",
+    "RUSTSEC-2026-0085",
+    "RUSTSEC-2026-0086",
+    "RUSTSEC-2026-0087",
+    "RUSTSEC-2026-0088",
+    "RUSTSEC-2026-0089",
+    "RUSTSEC-2026-0091",
+    "RUSTSEC-2026-0092",
+    "RUSTSEC-2026-0093",
+    "RUSTSEC-2026-0094",
+    "RUSTSEC-2026-0095",
+    "RUSTSEC-2026-0096",
+]

--- a/crates/sn2-chain/Cargo.toml
+++ b/crates/sn2-chain/Cargo.toml
@@ -3,6 +3,7 @@ name = "sn2-chain"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
 
 [dependencies]
 sn2-types = { workspace = true }

--- a/crates/sn2-circuit-store/Cargo.toml
+++ b/crates/sn2-circuit-store/Cargo.toml
@@ -3,6 +3,7 @@ name = "sn2-circuit-store"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
 
 [dependencies]
 sn2-types = { workspace = true }

--- a/crates/sn2-miner/Cargo.toml
+++ b/crates/sn2-miner/Cargo.toml
@@ -3,6 +3,7 @@ name = "sn2-miner"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "sn2-miner"

--- a/crates/sn2-types/Cargo.toml
+++ b/crates/sn2-types/Cargo.toml
@@ -3,6 +3,7 @@ name = "sn2-types"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/sn2-validator/Cargo.toml
+++ b/crates/sn2-validator/Cargo.toml
@@ -3,6 +3,7 @@ name = "sn2-validator"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "sn2-validator"

--- a/crates/sn2-verify/Cargo.toml
+++ b/crates/sn2-verify/Cargo.toml
@@ -3,6 +3,7 @@ name = "sn2-verify"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
 
 [lib]
 name = "sn2_verify"

--- a/deny.toml
+++ b/deny.toml
@@ -5,7 +5,14 @@ all-features = false
 [advisories]
 yanked = "warn"
 unmaintained = "workspace"
-ignore = []
+# wasmtime 8.0.1 is pulled transitively via sc-executor-wasmtime (Substrate runtime
+# host used by subxt for chain RPC). The validator and miner do not execute
+# untrusted WebAssembly; the only WASM ever loaded is the bittensor chain runtime
+# downloaded from a trusted endpoint. Bumping wasmtime requires a coordinated
+# Substrate upgrade across the dependency tree and is tracked separately.
+ignore = [
+    { crate = "wasmtime@8.0.1", reason = "Pulled transitively via sc-executor-wasmtime; we do not execute untrusted WASM. Patched versions require a Substrate-wide upgrade." },
+]
 
 [licenses]
 allow = [
@@ -170,4 +177,7 @@ allow-git = [
     "https://github.com/inference-labs-inc/dsperse",
     "https://github.com/inference-labs-inc/JSTprove.git",
     "https://github.com/inference-labs-inc/bittensor-drand.git",
+    "https://github.com/inference-labs-inc/tract.git",
+    "https://github.com/PolyhedraZK/halo2curves",
+    "https://github.com/ideal-lab5/timelock",
 ]


### PR DESCRIPTION
## Summary

Brings testnet's Release workflow to green now that the security gate runs on every push.

- **Workspace license inheritance**: each in-tree crate manifest adds \`license.workspace = true\` so cargo-deny sees MIT (already declared on workspace.package). Was previously reporting all six crates as unlicensed.
- **Allow-git additions**: \`halo2curves\` (transitively via JSTprove), \`ideal-lab5/timelock\` (via bittensor-drand), and \`inference-labs-inc/tract\` (via dsperse) — three git sources cargo-deny was denying as unknown-git.
- **wasmtime@8.0.1 advisory ignore**: 16 RUSTSEC findings on the Substrate-pulled \`wasmtime\` 8.0.1. We do not execute untrusted WebAssembly — the only WASM the validator or miner loads is the bittensor chain runtime via subxt's executor. Bumping wasmtime requires a coordinated Substrate upgrade across the dependency tree, tracked separately. Both \`deny.toml\` (cargo-deny) and a new repo-root \`audit.toml\` (cargo-audit) carry the ignore list with rationale.

## Test plan

- [ ] Release workflow on this branch passes the security-gate stage
- [ ] cargo-deny clean (no unlicensed, no source-not-allowed, no advisory)
- [ ] cargo-audit clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added security audit configuration to skip specified advisories.
  * Updated package metadata across multiple crates to use workspace-level licensing.
  * Expanded dependency allowlists for security and license management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->