### PR TITLE
Pre-fetch dependencies before lockfile version injection

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -58,6 +58,10 @@ jobs:
             ~/.cargo/git
           key: linux-registry-${{ hashFiles('Cargo.lock') }}-${{ matrix.arch }}
 
+      - name: Pre-fetch dependencies for offline lockfile sync
+        if: startsWith(inputs.ref || github.ref, 'refs/tags/')
+        run: cargo fetch --locked
+
       - name: Set crate versions
         if: startsWith(inputs.ref || github.ref, 'refs/tags/')
         uses: inference-labs-inc/set-toml-version@ff9a4b64df4ce91067737822d2811a69597bf688 # v1
@@ -72,9 +76,7 @@ jobs:
 
       - name: Sync lockfile after version injection
         if: startsWith(inputs.ref || github.ref, 'refs/tags/')
-        run: |
-          cargo fetch --locked
-          cargo update -w --offline
+        run: cargo update -w --offline
 
       - name: Build release binaries
         run: cargo build --release --locked --bin sn2-validator --bin sn2-miner
@@ -141,6 +143,10 @@ jobs:
             ~/.cargo/git
           key: macos-aarch64-registry-${{ hashFiles('Cargo.lock') }}
 
+      - name: Pre-fetch dependencies for offline lockfile sync
+        if: startsWith(inputs.ref || github.ref, 'refs/tags/')
+        run: cargo fetch --locked
+
       - name: Set crate versions
         if: startsWith(inputs.ref || github.ref, 'refs/tags/')
         uses: inference-labs-inc/set-toml-version@ff9a4b64df4ce91067737822d2811a69597bf688 # v1
@@ -155,9 +161,7 @@ jobs:
 
       - name: Sync lockfile after version injection
         if: startsWith(inputs.ref || github.ref, 'refs/tags/')
-        run: |
-          cargo fetch --locked
-          cargo update -w --offline
+        run: cargo update -w --offline
 
       - name: Build release binaries
         run: cargo build --release --locked --bin sn2-validator --bin sn2-miner


### PR DESCRIPTION
## Summary

Fixes the release build failure on tag pushes. PR #473 added \`cargo fetch --locked\` before the offline lockfile sync, but placed it *after* the \`set-toml-version\` step. set-toml-version edits Cargo.toml workspace versions to the tag string, which desyncs Cargo.lock — \`cargo fetch --locked\` then refuses because the lockfile no longer matches.

Splits the step in two:

1. \`cargo fetch --locked\` against the unmodified lockfile (populates the cache, --locked is satisfied)
2. \`set-toml-version\` rewrites workspace versions
3. \`cargo update -w --offline\` resolves the version drift using the now-warm cache

## Test plan

- [ ] Tag a build and confirm Build Linux x86_64 / aarch64 / macOS aarch64 all reach the build step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build workflow by restructuring dependency fetching to occur earlier in the process, reducing redundant operations and improving build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->