### PR TITLE
Introduce capacity statistics stream alongside existing flushes

### DIFF
--- a/crates/sn2-validator/src/performance.rs
+++ b/crates/sn2-validator/src/performance.rs
@@ -23,6 +23,7 @@ pub enum CapDirection {
 #[derive(Clone, Debug)]
 pub struct CapEvent {
     pub uid: u16,
+    pub hotkey: String,
     pub direction: CapDirection,
     pub cap_from: usize,
     pub cap_to: usize,
@@ -66,13 +67,28 @@ impl PerformanceTracker {
         tracker
     }
 
-    pub fn record(&mut self, uid: u16, success: bool, response_time: f64, was_at_capacity: bool) {
-        self.record_with_time(uid, success, response_time, was_at_capacity, Instant::now());
+    pub fn record(
+        &mut self,
+        uid: u16,
+        hotkey: &str,
+        success: bool,
+        response_time: f64,
+        was_at_capacity: bool,
+    ) {
+        self.record_with_time(
+            uid,
+            hotkey,
+            success,
+            response_time,
+            was_at_capacity,
+            Instant::now(),
+        );
     }
 
     pub fn record_with_time(
         &mut self,
         uid: u16,
+        hotkey: &str,
         success: bool,
         response_time: f64,
         was_at_capacity: bool,
@@ -88,7 +104,7 @@ impl PerformanceTracker {
             if results.len() > CAPACITY_WINDOW_SIZE {
                 results.pop_front();
             }
-            self.update_adaptive_cap(uid);
+            self.update_adaptive_cap(uid, hotkey);
         }
     }
 
@@ -347,13 +363,14 @@ impl PerformanceTracker {
         (total / w.len() as f64).max(0.0)
     }
 
-    pub fn reset_uid(&mut self, uid: u16) {
+    pub fn reset_uid(&mut self, uid: u16, hotkey: &str) {
         self.windows.remove(&uid);
         self.adaptive_caps.remove(&uid);
         self.at_cap_results.remove(&uid);
+        self.cap_events.retain(|e| e.hotkey != hotkey);
     }
 
-    fn update_adaptive_cap(&mut self, uid: u16) {
+    fn update_adaptive_cap(&mut self, uid: u16, hotkey: &str) {
         let success_rate = match self.at_cap_results.get(&uid) {
             Some(r) if r.len() >= CAPACITY_MIN_AT_CAP => {
                 r.iter().filter(|&&s| s).count() as f64 / r.len() as f64
@@ -383,6 +400,7 @@ impl PerformanceTracker {
             let cap_to = *current;
             self.cap_events.push(CapEvent {
                 uid,
+                hotkey: hotkey.to_string(),
                 direction,
                 cap_from,
                 cap_to,
@@ -428,8 +446,8 @@ mod tests {
     #[test]
     fn record_populates_window() {
         let mut tracker = test_tracker();
-        tracker.record(1, true, 5.0, false);
-        tracker.record(1, true, 6.0, false);
+        tracker.record(1, "hk", true, 5.0, false);
+        tracker.record(1, "hk", true, 6.0, false);
         assert_eq!(tracker.windows.get(&1).unwrap().len(), 2);
     }
 
@@ -447,9 +465,9 @@ mod tests {
     #[test]
     fn reset_uid_clears_all_state() {
         let mut tracker = test_tracker();
-        tracker.record(1, true, 5.0, true);
+        tracker.record(1, "hk", true, 5.0, true);
         tracker.adaptive_caps.insert(1, 4);
-        tracker.reset_uid(1);
+        tracker.reset_uid(1, "hk");
         assert!(!tracker.windows.contains_key(&1));
         assert!(!tracker.adaptive_caps.contains_key(&1));
         assert!(!tracker.at_cap_results.contains_key(&1));
@@ -459,7 +477,7 @@ mod tests {
     fn adaptive_timeout_calculates_percentile_and_clamps() {
         let mut tracker = test_tracker();
         for i in 0..ADAPTIVE_TIMEOUT_MIN_SAMPLES {
-            tracker.record(1, true, (i + 1) as f64, false);
+            tracker.record(1, "hk", true, (i + 1) as f64, false);
         }
         let timeout = tracker.adaptive_timeout();
         let mut sorted: Vec<f64> = (1..=ADAPTIVE_TIMEOUT_MIN_SAMPLES)
@@ -477,7 +495,7 @@ mod tests {
 
         let mut tracker2 = test_tracker();
         for _ in 0..ADAPTIVE_TIMEOUT_MIN_SAMPLES {
-            tracker2.record(1, true, 500.0, false);
+            tracker2.record(1, "hk", true, 500.0, false);
         }
         assert_eq!(
             tracker2.adaptive_timeout(),
@@ -489,7 +507,7 @@ mod tests {
     #[test]
     fn miner_capacities_default_to_one() {
         let mut tracker = test_tracker();
-        tracker.record(1, true, 5.0, false);
+        tracker.record(1, "hk", true, 5.0, false);
         let caps = tracker.miner_capacities();
         assert_eq!(caps.get(&1).copied().unwrap_or(0), 1);
     }
@@ -501,8 +519,8 @@ mod tests {
         let stale = now
             .checked_sub(window_ttl() + Duration::from_secs(60))
             .expect("Instant arithmetic");
-        tracker.record_with_time(1, true, 5.0, false, stale);
-        tracker.record_with_time(1, true, 6.0, false, now);
+        tracker.record_with_time(1, "hk", true, 5.0, false, stale);
+        tracker.record_with_time(1, "hk", true, 6.0, false, now);
         let window = tracker.windows.get(&1).unwrap();
         assert_eq!(window.len(), 1);
         assert_eq!(window[0].2, 6.0);
@@ -512,7 +530,7 @@ mod tests {
     fn cap_ramp_emits_event_with_from_to_and_rate() {
         let mut tracker = test_tracker();
         for _ in 0..CAPACITY_MIN_AT_CAP {
-            tracker.record(1, true, 1.0, true);
+            tracker.record(1, "hk", true, 1.0, true);
         }
         let events = tracker.drain_cap_events();
         assert_eq!(events.len(), 1);
@@ -526,11 +544,11 @@ mod tests {
     fn cap_backoff_emits_event_when_already_above_one() {
         let mut tracker = test_tracker();
         for _ in 0..CAPACITY_MIN_AT_CAP {
-            tracker.record(1, true, 1.0, true);
+            tracker.record(1, "hk", true, 1.0, true);
         }
         tracker.cap_events.clear();
         for _ in 0..CAPACITY_MIN_AT_CAP {
-            tracker.record(1, false, 1.0, true);
+            tracker.record(1, "hk", false, 1.0, true);
         }
         let events = tracker.drain_cap_events();
         assert_eq!(events.len(), 1);
@@ -543,7 +561,7 @@ mod tests {
     fn drain_cap_events_clears_buffer() {
         let mut tracker = test_tracker();
         for _ in 0..CAPACITY_MIN_AT_CAP {
-            tracker.record(1, true, 1.0, true);
+            tracker.record(1, "hk", true, 1.0, true);
         }
         assert_eq!(tracker.drain_cap_events().len(), 1);
         assert!(tracker.drain_cap_events().is_empty());
@@ -554,9 +572,41 @@ mod tests {
         let mut tracker = test_tracker();
         for _ in 0..(MAX_BUFFERED_CAP_EVENTS + 50) {
             for _ in 0..CAPACITY_MIN_AT_CAP {
-                tracker.record(1, true, 1.0, true);
+                tracker.record(1, "hk", true, 1.0, true);
             }
         }
         assert!(tracker.cap_events.len() <= MAX_BUFFERED_CAP_EVENTS);
+    }
+
+    #[test]
+    fn reset_uid_purges_buffered_cap_events_for_that_hotkey() {
+        let mut tracker = test_tracker();
+        for _ in 0..CAPACITY_MIN_AT_CAP {
+            tracker.record(1, "hk_a", true, 1.0, true);
+        }
+        for _ in 0..CAPACITY_MIN_AT_CAP {
+            tracker.record(2, "hk_b", true, 1.0, true);
+        }
+        assert_eq!(tracker.cap_events.len(), 2);
+        tracker.reset_uid(1, "hk_a");
+        let remaining = tracker.drain_cap_events();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].hotkey, "hk_b");
+    }
+
+    #[test]
+    fn reset_uid_purge_is_keyed_by_hotkey_not_uid_slot() {
+        let mut tracker = test_tracker();
+        for _ in 0..CAPACITY_MIN_AT_CAP {
+            tracker.record(1, "hk_old", true, 1.0, true);
+        }
+        for _ in 0..CAPACITY_MIN_AT_CAP {
+            tracker.record(1, "hk_new", true, 1.0, true);
+        }
+        assert_eq!(tracker.cap_events.len(), 2);
+        tracker.reset_uid(1, "hk_old");
+        let remaining = tracker.drain_cap_events();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].hotkey, "hk_new");
     }
 }

--- a/crates/sn2-validator/src/performance.rs
+++ b/crates/sn2-validator/src/performance.rs
@@ -12,10 +12,29 @@ use tracing::warn;
 
 type WindowEntry = (Instant, bool, f64);
 
+const MAX_BUFFERED_CAP_EVENTS: usize = 4096;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CapDirection {
+    Ramp,
+    Backoff,
+}
+
+#[derive(Clone, Debug)]
+pub struct CapEvent {
+    pub uid: u16,
+    pub direction: CapDirection,
+    pub cap_from: usize,
+    pub cap_to: usize,
+    pub success_rate: f64,
+    pub at: Instant,
+}
+
 pub struct PerformanceTracker {
     windows: HashMap<u16, VecDeque<WindowEntry>>,
     adaptive_caps: HashMap<u16, usize>,
     at_cap_results: HashMap<u16, VecDeque<bool>>,
+    cap_events: Vec<CapEvent>,
     persistence_path: Option<PathBuf>,
 }
 
@@ -40,6 +59,7 @@ impl PerformanceTracker {
             windows: HashMap::new(),
             adaptive_caps: HashMap::new(),
             at_cap_results: HashMap::new(),
+            cap_events: Vec::new(),
             persistence_path: Some(path),
         };
         tracker.load();
@@ -342,18 +362,46 @@ impl PerformanceTracker {
         };
 
         let current = self.adaptive_caps.entry(uid).or_insert(1);
+        let cap_from = *current;
+        let mut direction: Option<CapDirection> = None;
 
         if success_rate >= CAPACITY_RAMP_THRESHOLD {
             *current += 1;
+            direction = Some(CapDirection::Ramp);
             if let Some(r) = self.at_cap_results.get_mut(&uid) {
                 r.clear();
             }
         } else if success_rate < CAPACITY_BACKOFF_THRESHOLD && *current > 1 {
             *current -= 1;
+            direction = Some(CapDirection::Backoff);
             if let Some(r) = self.at_cap_results.get_mut(&uid) {
                 r.clear();
             }
         }
+
+        if let Some(direction) = direction {
+            let cap_to = *current;
+            self.cap_events.push(CapEvent {
+                uid,
+                direction,
+                cap_from,
+                cap_to,
+                success_rate,
+                at: Instant::now(),
+            });
+            if self.cap_events.len() > MAX_BUFFERED_CAP_EVENTS {
+                let drop = self.cap_events.len() - MAX_BUFFERED_CAP_EVENTS;
+                self.cap_events.drain(0..drop);
+            }
+        }
+    }
+
+    pub fn cap_snapshot(&self) -> HashMap<u16, usize> {
+        self.adaptive_caps.clone()
+    }
+
+    pub fn drain_cap_events(&mut self) -> Vec<CapEvent> {
+        std::mem::take(&mut self.cap_events)
     }
 }
 
@@ -366,6 +414,7 @@ mod tests {
             windows: HashMap::new(),
             adaptive_caps: HashMap::new(),
             at_cap_results: HashMap::new(),
+            cap_events: Vec::new(),
             persistence_path: None,
         }
     }
@@ -457,5 +506,57 @@ mod tests {
         let window = tracker.windows.get(&1).unwrap();
         assert_eq!(window.len(), 1);
         assert_eq!(window[0].2, 6.0);
+    }
+
+    #[test]
+    fn cap_ramp_emits_event_with_from_to_and_rate() {
+        let mut tracker = test_tracker();
+        for _ in 0..CAPACITY_MIN_AT_CAP {
+            tracker.record(1, true, 1.0, true);
+        }
+        let events = tracker.drain_cap_events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].direction, CapDirection::Ramp);
+        assert_eq!(events[0].cap_from, 1);
+        assert_eq!(events[0].cap_to, 2);
+        assert!((events[0].success_rate - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn cap_backoff_emits_event_when_already_above_one() {
+        let mut tracker = test_tracker();
+        for _ in 0..CAPACITY_MIN_AT_CAP {
+            tracker.record(1, true, 1.0, true);
+        }
+        tracker.cap_events.clear();
+        for _ in 0..CAPACITY_MIN_AT_CAP {
+            tracker.record(1, false, 1.0, true);
+        }
+        let events = tracker.drain_cap_events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].direction, CapDirection::Backoff);
+        assert_eq!(events[0].cap_from, 2);
+        assert_eq!(events[0].cap_to, 1);
+    }
+
+    #[test]
+    fn drain_cap_events_clears_buffer() {
+        let mut tracker = test_tracker();
+        for _ in 0..CAPACITY_MIN_AT_CAP {
+            tracker.record(1, true, 1.0, true);
+        }
+        assert_eq!(tracker.drain_cap_events().len(), 1);
+        assert!(tracker.drain_cap_events().is_empty());
+    }
+
+    #[test]
+    fn cap_event_buffer_is_bounded() {
+        let mut tracker = test_tracker();
+        for _ in 0..(MAX_BUFFERED_CAP_EVENTS + 50) {
+            for _ in 0..CAPACITY_MIN_AT_CAP {
+                tracker.record(1, true, 1.0, true);
+            }
+        }
+        assert!(tracker.cap_events.len() <= MAX_BUFFERED_CAP_EVENTS);
     }
 }

--- a/crates/sn2-validator/src/stats_reporter.rs
+++ b/crates/sn2-validator/src/stats_reporter.rs
@@ -227,7 +227,13 @@ impl StatsReporter {
         }
 
         let mut events: Vec<CapEvent> = {
-            let mut pending = self.pending_cap_events.lock().expect("pending lock");
+            let mut pending = match self.pending_cap_events.lock() {
+                Ok(g) => g,
+                Err(e) => {
+                    warn!(error = %e, "cap event pending lock poisoned, skipping flush");
+                    return;
+                }
+            };
             let mut combined: Vec<CapEvent> = pending.drain(..).collect();
             combined.extend(new_events);
             combined
@@ -374,11 +380,11 @@ fn requeue_cap_events(pending: &Mutex<VecDeque<CapEvent>>, events: Vec<CapEvent>
         }
     };
     let count = events.len();
-    for e in events.into_iter().rev() {
-        p.push_front(e);
+    for e in events {
+        p.push_back(e);
     }
     while p.len() > PENDING_CAP_EVENTS_MAX {
-        p.pop_back();
+        p.pop_front();
     }
     warn!(
         count,
@@ -634,24 +640,31 @@ mod tests {
     }
 
     #[test]
-    fn requeue_prepends_so_older_failures_drain_first() {
+    fn requeue_appends_so_older_failures_drain_first() {
         let pending = Mutex::new(VecDeque::new());
         requeue_cap_events(&pending, vec![ev(10, "a")]);
         requeue_cap_events(&pending, vec![ev(11, "b")]);
         let p = pending.lock().unwrap();
-        assert_eq!(p[0].uid, 11, "most recent re-queue lands at the front");
-        assert_eq!(p[1].uid, 10);
+        assert_eq!(p[0].uid, 10, "earlier failure stays at the front");
+        assert_eq!(p[1].uid, 11);
     }
 
     #[test]
     fn requeue_drops_oldest_when_buffer_full() {
         let pending = Mutex::new(VecDeque::new());
-        let big: Vec<CapEvent> = (0..(PENDING_CAP_EVENTS_MAX + 50))
-            .map(|i| ev(i as u16, "a"))
-            .collect();
+        let total = PENDING_CAP_EVENTS_MAX + 50;
+        let big: Vec<CapEvent> = (0..total).map(|i| ev(i as u16, "a")).collect();
         requeue_cap_events(&pending, big);
         let p = pending.lock().unwrap();
         assert_eq!(p.len(), PENDING_CAP_EVENTS_MAX);
+        let actual: Vec<u16> = p.iter().map(|e| e.uid).collect();
+        let expected: Vec<u16> = ((total - PENDING_CAP_EVENTS_MAX)..total)
+            .map(|i| i as u16)
+            .collect();
+        assert_eq!(
+            actual, expected,
+            "buffer should retain the most recent PENDING_CAP_EVENTS_MAX entries in original order"
+        );
     }
 
     #[test]

--- a/crates/sn2-validator/src/stats_reporter.rs
+++ b/crates/sn2-validator/src/stats_reporter.rs
@@ -6,6 +6,8 @@ use base64::Engine;
 use sn2_chain::Wallet;
 use sn2_types::{MinerResponse, DEFAULT_API_URL, SOFTWARE_VERSION};
 use tracing::{info, warn};
+
+use crate::performance::{CapDirection, CapEvent};
 pub(crate) const STATS_FLUSH_INTERVAL_SECS: u64 = 60;
 const REQUEST_TIMEOUT_SECS: u64 = 5;
 
@@ -13,6 +15,7 @@ pub(crate) enum FlushOffset {
     ResponseLog = 0,
     Health = 20,
     DsperseEvents = 40,
+    Capacity = 50,
 }
 const MAX_RETRIES: u32 = 3;
 const BACKOFF_BASE_MS: u64 = 500;
@@ -26,6 +29,7 @@ pub struct StatsReporter {
     last_response_log: Instant,
     health_samples: Vec<HealthSample>,
     last_health_flush: Instant,
+    last_capacity_flush: Instant,
     validator_uid: u16,
 }
 
@@ -63,6 +67,8 @@ impl StatsReporter {
             Duration::from_secs(STATS_FLUSH_INTERVAL_SECS - FlushOffset::ResponseLog as u64);
         let health_offset =
             Duration::from_secs(STATS_FLUSH_INTERVAL_SECS - FlushOffset::Health as u64);
+        let capacity_offset =
+            Duration::from_secs(STATS_FLUSH_INTERVAL_SECS - FlushOffset::Capacity as u64);
         Self {
             http: reqwest::Client::builder()
                 .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
@@ -74,6 +80,7 @@ impl StatsReporter {
             last_response_log: now - response_offset,
             health_samples: Vec::new(),
             last_health_flush: now - health_offset,
+            last_capacity_flush: now - capacity_offset,
             validator_uid,
         }
     }
@@ -195,6 +202,78 @@ impl StatsReporter {
         });
 
         self.spawn_post("/statistics/health/log/", body, |_| {});
+    }
+
+    pub fn flush_capacity(
+        &mut self,
+        block: u64,
+        snapshot: HashMap<u16, usize>,
+        events: Vec<CapEvent>,
+        uid_hotkeys: &HashMap<u16, String>,
+    ) {
+        let now = Instant::now();
+        if now.duration_since(self.last_capacity_flush)
+            < Duration::from_secs(STATS_FLUSH_INTERVAL_SECS)
+        {
+            return;
+        }
+        if snapshot.is_empty() && events.is_empty() {
+            self.last_capacity_flush = now;
+            return;
+        }
+        self.last_capacity_flush = now;
+
+        let snapshots_payload: Vec<serde_json::Value> = snapshot
+            .into_iter()
+            .map(|(uid, cap)| {
+                serde_json::json!({
+                    "miner_uid": uid,
+                    "miner_key": uid_hotkeys.get(&uid).cloned().unwrap_or_default(),
+                    "cap": cap,
+                })
+            })
+            .collect();
+
+        let events_payload: Vec<serde_json::Value> = events
+            .into_iter()
+            .map(|e| {
+                let direction = match e.direction {
+                    CapDirection::Ramp => "ramp",
+                    CapDirection::Backoff => "backoff",
+                };
+                let elapsed_ms = now.saturating_duration_since(e.at).as_millis() as u64;
+                serde_json::json!({
+                    "miner_uid": e.uid,
+                    "miner_key": uid_hotkeys.get(&e.uid).cloned().unwrap_or_default(),
+                    "direction": direction,
+                    "cap_from": e.cap_from,
+                    "cap_to": e.cap_to,
+                    "success_rate": e.success_rate,
+                    "elapsed_ms": elapsed_ms,
+                })
+            })
+            .collect();
+
+        let snapshot_count = snapshots_payload.len();
+        let event_count = events_payload.len();
+        let body = serde_json::json!({
+            "validator_key": self.wallet.hotkey_ss58(),
+            "validator_uid": self.validator_uid,
+            "block": block,
+            "snapshots": snapshots_payload,
+            "events": events_payload,
+            "software_version": SOFTWARE_VERSION,
+        });
+
+        self.spawn_post("/statistics/capacity/log/", body, move |ok| {
+            if ok {
+                info!(
+                    snapshots = snapshot_count,
+                    events = event_count,
+                    "submitted capacity stats"
+                );
+            }
+        });
     }
 
     pub fn report_dsperse_run(&self, report: DsperseRunReport) {

--- a/crates/sn2-validator/src/stats_reporter.rs
+++ b/crates/sn2-validator/src/stats_reporter.rs
@@ -204,6 +204,11 @@ impl StatsReporter {
         self.spawn_post("/statistics/health/log/", body, |_| {});
     }
 
+    pub fn capacity_flush_due(&self) -> bool {
+        Instant::now().duration_since(self.last_capacity_flush)
+            >= Duration::from_secs(STATS_FLUSH_INTERVAL_SECS)
+    }
+
     pub fn flush_capacity(
         &mut self,
         block: u64,
@@ -218,7 +223,6 @@ impl StatsReporter {
             return;
         }
         if snapshot.is_empty() && events.is_empty() {
-            self.last_capacity_flush = now;
             return;
         }
         self.last_capacity_flush = now;
@@ -244,7 +248,7 @@ impl StatsReporter {
                 let elapsed_ms = now.saturating_duration_since(e.at).as_millis() as u64;
                 serde_json::json!({
                     "miner_uid": e.uid,
-                    "miner_key": uid_hotkeys.get(&e.uid).cloned().unwrap_or_default(),
+                    "miner_key": e.hotkey,
                     "direction": direction,
                     "cap_from": e.cap_from,
                     "cap_to": e.cap_to,

--- a/crates/sn2-validator/src/stats_reporter.rs
+++ b/crates/sn2-validator/src/stats_reporter.rs
@@ -69,8 +69,9 @@ impl StatsReporter {
             Duration::from_secs(STATS_FLUSH_INTERVAL_SECS - FlushOffset::ResponseLog as u64);
         let health_offset =
             Duration::from_secs(STATS_FLUSH_INTERVAL_SECS - FlushOffset::Health as u64);
-        let capacity_offset =
-            Duration::from_secs(STATS_FLUSH_INTERVAL_SECS - FlushOffset::Capacity as u64);
+        let capacity_offset = Duration::from_secs(
+            STATS_FLUSH_INTERVAL_SECS.saturating_sub(FlushOffset::Capacity as u64),
+        );
         Self {
             http: reqwest::Client::builder()
                 .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))

--- a/crates/sn2-validator/src/stats_reporter.rs
+++ b/crates/sn2-validator/src/stats_reporter.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant};
 use base64::Engine;
 use sn2_chain::Wallet;
 use sn2_types::{MinerResponse, DEFAULT_API_URL, SOFTWARE_VERSION};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::performance::{CapDirection, CapEvent};
 pub(crate) const STATS_FLUSH_INTERVAL_SECS: u64 = 60;
@@ -229,7 +229,11 @@ impl StatsReporter {
             // Caller drained the tracker but the rate-limit window has not
             // elapsed; persist the events so the next flush picks them up
             // instead of dropping a discrete state transition on the floor.
-            requeue_cap_events(&self.pending_cap_events, new_events);
+            requeue_cap_events(
+                &self.pending_cap_events,
+                new_events,
+                RequeueReason::RateLimited,
+            );
             return;
         }
 
@@ -304,7 +308,7 @@ impl StatsReporter {
                     "submitted capacity stats"
                 );
             } else {
-                requeue_cap_events(&pending, inflight);
+                requeue_cap_events(&pending, inflight, RequeueReason::PostFailure);
             }
         });
     }
@@ -375,7 +379,17 @@ impl StatsReporter {
     }
 }
 
-fn requeue_cap_events(pending: &Mutex<VecDeque<CapEvent>>, events: Vec<CapEvent>) {
+#[derive(Clone, Copy, Debug)]
+enum RequeueReason {
+    PostFailure,
+    RateLimited,
+}
+
+fn requeue_cap_events(
+    pending: &Mutex<VecDeque<CapEvent>>,
+    events: Vec<CapEvent>,
+    reason: RequeueReason,
+) {
     if events.is_empty() {
         return;
     }
@@ -393,11 +407,19 @@ fn requeue_cap_events(pending: &Mutex<VecDeque<CapEvent>>, events: Vec<CapEvent>
     while p.len() > PENDING_CAP_EVENTS_MAX {
         p.pop_front();
     }
-    warn!(
-        count,
-        pending = p.len(),
-        "cap event POST failed, re-queued for next flush"
-    );
+    let pending_len = p.len();
+    match reason {
+        RequeueReason::PostFailure => warn!(
+            count,
+            pending = pending_len,
+            "cap event POST failed, re-queued for next flush"
+        ),
+        RequeueReason::RateLimited => debug!(
+            count,
+            pending = pending_len,
+            "cap event flush deferred by rate limit, re-queued"
+        ),
+    }
 }
 
 pub(crate) async fn sign_and_post(
@@ -638,7 +660,7 @@ mod tests {
     fn requeue_preserves_order() {
         let pending = Mutex::new(VecDeque::new());
         let batch = vec![ev(1, "a"), ev(2, "b"), ev(3, "c")];
-        requeue_cap_events(&pending, batch);
+        requeue_cap_events(&pending, batch, RequeueReason::PostFailure);
         let p = pending.lock().unwrap();
         assert_eq!(p.len(), 3);
         assert_eq!(p[0].uid, 1);
@@ -649,8 +671,8 @@ mod tests {
     #[test]
     fn requeue_appends_so_older_failures_drain_first() {
         let pending = Mutex::new(VecDeque::new());
-        requeue_cap_events(&pending, vec![ev(10, "a")]);
-        requeue_cap_events(&pending, vec![ev(11, "b")]);
+        requeue_cap_events(&pending, vec![ev(10, "a")], RequeueReason::PostFailure);
+        requeue_cap_events(&pending, vec![ev(11, "b")], RequeueReason::PostFailure);
         let p = pending.lock().unwrap();
         assert_eq!(p[0].uid, 10, "earlier failure stays at the front");
         assert_eq!(p[1].uid, 11);
@@ -661,7 +683,7 @@ mod tests {
         let pending = Mutex::new(VecDeque::new());
         let total = PENDING_CAP_EVENTS_MAX + 50;
         let big: Vec<CapEvent> = (0..total).map(|i| ev(i as u16, "a")).collect();
-        requeue_cap_events(&pending, big);
+        requeue_cap_events(&pending, big, RequeueReason::PostFailure);
         let p = pending.lock().unwrap();
         assert_eq!(p.len(), PENDING_CAP_EVENTS_MAX);
         let actual: Vec<u16> = p.iter().map(|e| e.uid).collect();
@@ -677,7 +699,7 @@ mod tests {
     #[test]
     fn requeue_no_op_on_empty_input() {
         let pending = Mutex::new(VecDeque::new());
-        requeue_cap_events(&pending, Vec::new());
+        requeue_cap_events(&pending, Vec::new(), RequeueReason::PostFailure);
         assert!(pending.lock().unwrap().is_empty());
     }
 }

--- a/crates/sn2-validator/src/stats_reporter.rs
+++ b/crates/sn2-validator/src/stats_reporter.rs
@@ -65,10 +65,12 @@ pub struct DsperseSliceReport {
 impl StatsReporter {
     pub fn new(wallet: Arc<Wallet>, api_base_url: Option<String>, validator_uid: u16) -> Self {
         let now = Instant::now();
-        let response_offset =
-            Duration::from_secs(STATS_FLUSH_INTERVAL_SECS - FlushOffset::ResponseLog as u64);
-        let health_offset =
-            Duration::from_secs(STATS_FLUSH_INTERVAL_SECS - FlushOffset::Health as u64);
+        let response_offset = Duration::from_secs(
+            STATS_FLUSH_INTERVAL_SECS.saturating_sub(FlushOffset::ResponseLog as u64),
+        );
+        let health_offset = Duration::from_secs(
+            STATS_FLUSH_INTERVAL_SECS.saturating_sub(FlushOffset::Health as u64),
+        );
         let capacity_offset = Duration::from_secs(
             STATS_FLUSH_INTERVAL_SECS.saturating_sub(FlushOffset::Capacity as u64),
         );
@@ -224,6 +226,10 @@ impl StatsReporter {
         if now.duration_since(self.last_capacity_flush)
             < Duration::from_secs(STATS_FLUSH_INTERVAL_SECS)
         {
+            // Caller drained the tracker but the rate-limit window has not
+            // elapsed; persist the events so the next flush picks them up
+            // instead of dropping a discrete state transition on the floor.
+            requeue_cap_events(&self.pending_cap_events, new_events);
             return;
         }
 

--- a/crates/sn2-validator/src/stats_reporter.rs
+++ b/crates/sn2-validator/src/stats_reporter.rs
@@ -229,9 +229,9 @@ impl StatsReporter {
         let mut events: Vec<CapEvent> = {
             let mut pending = match self.pending_cap_events.lock() {
                 Ok(g) => g,
-                Err(e) => {
-                    warn!(error = %e, "cap event pending lock poisoned, skipping flush");
-                    return;
+                Err(poisoned) => {
+                    warn!(error = %poisoned, "cap event pending lock poisoned, recovering");
+                    poisoned.into_inner()
                 }
             };
             let mut combined: Vec<CapEvent> = pending.drain(..).collect();
@@ -374,9 +374,9 @@ fn requeue_cap_events(pending: &Mutex<VecDeque<CapEvent>>, events: Vec<CapEvent>
     }
     let mut p = match pending.lock() {
         Ok(g) => g,
-        Err(e) => {
-            warn!(error = %e, "cap event re-queue lock poisoned");
-            return;
+        Err(poisoned) => {
+            warn!(error = %poisoned, "cap event re-queue lock poisoned, recovering");
+            poisoned.into_inner()
         }
     };
     let count = events.len();

--- a/crates/sn2-validator/src/stats_reporter.rs
+++ b/crates/sn2-validator/src/stats_reporter.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use base64::Engine;
@@ -10,6 +10,7 @@ use tracing::{info, warn};
 use crate::performance::{CapDirection, CapEvent};
 pub(crate) const STATS_FLUSH_INTERVAL_SECS: u64 = 60;
 const REQUEST_TIMEOUT_SECS: u64 = 5;
+const PENDING_CAP_EVENTS_MAX: usize = 4096;
 
 pub(crate) enum FlushOffset {
     ResponseLog = 0,
@@ -30,6 +31,7 @@ pub struct StatsReporter {
     health_samples: Vec<HealthSample>,
     last_health_flush: Instant,
     last_capacity_flush: Instant,
+    pending_cap_events: Arc<Mutex<VecDeque<CapEvent>>>,
     validator_uid: u16,
 }
 
@@ -81,6 +83,7 @@ impl StatsReporter {
             health_samples: Vec::new(),
             last_health_flush: now - health_offset,
             last_capacity_flush: now - capacity_offset,
+            pending_cap_events: Arc::new(Mutex::new(VecDeque::new())),
             validator_uid,
         }
     }
@@ -213,7 +216,7 @@ impl StatsReporter {
         &mut self,
         block: u64,
         snapshot: HashMap<u16, usize>,
-        events: Vec<CapEvent>,
+        new_events: Vec<CapEvent>,
         uid_hotkeys: &HashMap<u16, String>,
     ) {
         let now = Instant::now();
@@ -222,6 +225,14 @@ impl StatsReporter {
         {
             return;
         }
+
+        let mut events: Vec<CapEvent> = {
+            let mut pending = self.pending_cap_events.lock().expect("pending lock");
+            let mut combined: Vec<CapEvent> = pending.drain(..).collect();
+            combined.extend(new_events);
+            combined
+        };
+
         if snapshot.is_empty() && events.is_empty() {
             return;
         }
@@ -239,7 +250,7 @@ impl StatsReporter {
             .collect();
 
         let events_payload: Vec<serde_json::Value> = events
-            .into_iter()
+            .iter()
             .map(|e| {
                 let direction = match e.direction {
                     CapDirection::Ramp => "ramp",
@@ -269,6 +280,9 @@ impl StatsReporter {
             "software_version": SOFTWARE_VERSION,
         });
 
+        let pending = Arc::clone(&self.pending_cap_events);
+        events.shrink_to_fit();
+        let inflight = std::mem::take(&mut events);
         self.spawn_post("/statistics/capacity/log/", body, move |ok| {
             if ok {
                 info!(
@@ -276,6 +290,8 @@ impl StatsReporter {
                     events = event_count,
                     "submitted capacity stats"
                 );
+            } else {
+                requeue_cap_events(&pending, inflight);
             }
         });
     }
@@ -344,6 +360,31 @@ impl StatsReporter {
             on_done(sign_and_post(&http, &wallet, &url, &body, &path_owned).await);
         });
     }
+}
+
+fn requeue_cap_events(pending: &Mutex<VecDeque<CapEvent>>, events: Vec<CapEvent>) {
+    if events.is_empty() {
+        return;
+    }
+    let mut p = match pending.lock() {
+        Ok(g) => g,
+        Err(e) => {
+            warn!(error = %e, "cap event re-queue lock poisoned");
+            return;
+        }
+    };
+    let count = events.len();
+    for e in events.into_iter().rev() {
+        p.push_front(e);
+    }
+    while p.len() > PENDING_CAP_EVENTS_MAX {
+        p.pop_back();
+    }
+    warn!(
+        count,
+        pending = p.len(),
+        "cap event POST failed, re-queued for next flush"
+    );
 }
 
 pub(crate) async fn sign_and_post(
@@ -560,5 +601,63 @@ fn get_rss_mb() -> f64 {
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     {
         0.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::performance::CapDirection;
+
+    fn ev(uid: u16, hotkey: &str) -> CapEvent {
+        CapEvent {
+            uid,
+            hotkey: hotkey.to_string(),
+            direction: CapDirection::Ramp,
+            cap_from: 1,
+            cap_to: 2,
+            success_rate: 1.0,
+            at: Instant::now(),
+        }
+    }
+
+    #[test]
+    fn requeue_preserves_order() {
+        let pending = Mutex::new(VecDeque::new());
+        let batch = vec![ev(1, "a"), ev(2, "b"), ev(3, "c")];
+        requeue_cap_events(&pending, batch);
+        let p = pending.lock().unwrap();
+        assert_eq!(p.len(), 3);
+        assert_eq!(p[0].uid, 1);
+        assert_eq!(p[1].uid, 2);
+        assert_eq!(p[2].uid, 3);
+    }
+
+    #[test]
+    fn requeue_prepends_so_older_failures_drain_first() {
+        let pending = Mutex::new(VecDeque::new());
+        requeue_cap_events(&pending, vec![ev(10, "a")]);
+        requeue_cap_events(&pending, vec![ev(11, "b")]);
+        let p = pending.lock().unwrap();
+        assert_eq!(p[0].uid, 11, "most recent re-queue lands at the front");
+        assert_eq!(p[1].uid, 10);
+    }
+
+    #[test]
+    fn requeue_drops_oldest_when_buffer_full() {
+        let pending = Mutex::new(VecDeque::new());
+        let big: Vec<CapEvent> = (0..(PENDING_CAP_EVENTS_MAX + 50))
+            .map(|i| ev(i as u16, "a"))
+            .collect();
+        requeue_cap_events(&pending, big);
+        let p = pending.lock().unwrap();
+        assert_eq!(p.len(), PENDING_CAP_EVENTS_MAX);
+    }
+
+    #[test]
+    fn requeue_no_op_on_empty_input() {
+        let pending = Mutex::new(VecDeque::new());
+        requeue_cap_events(&pending, Vec::new());
+        assert!(pending.lock().unwrap().is_empty());
     }
 }

--- a/crates/sn2-validator/src/validator_loop/maintenance.rs
+++ b/crates/sn2-validator/src/validator_loop/maintenance.rs
@@ -138,14 +138,16 @@ impl ValidatorLoop {
                 self.config.metagraph.n,
                 self.score_manager.scores_snapshot(),
             );
-            let cap_snapshot = self.performance_tracker.cap_snapshot();
-            let cap_events = self.performance_tracker.drain_cap_events();
-            reporter.flush_capacity(
-                self.current_block,
-                cap_snapshot,
-                cap_events,
-                &self.uid_hotkeys,
-            );
+            if reporter.capacity_flush_due() {
+                let cap_snapshot = self.performance_tracker.cap_snapshot();
+                let cap_events = self.performance_tracker.drain_cap_events();
+                reporter.flush_capacity(
+                    self.current_block,
+                    cap_snapshot,
+                    cap_events,
+                    &self.uid_hotkeys,
+                );
+            }
         }
 
         Ok(())
@@ -274,10 +276,10 @@ impl ValidatorLoop {
         }
 
         for neuron in &self.config.metagraph.neurons {
-            if let Some(prev_hotkey) = self.uid_hotkeys.get(&neuron.uid) {
-                if *prev_hotkey != neuron.hotkey {
+            if let Some(prev_hotkey) = self.uid_hotkeys.get(&neuron.uid).cloned() {
+                if prev_hotkey != neuron.hotkey {
                     info!(uid = neuron.uid, "hotkey changed, resetting performance");
-                    self.performance_tracker.reset_uid(neuron.uid);
+                    self.performance_tracker.reset_uid(neuron.uid, &prev_hotkey);
                     self.score_manager.update_score(
                         neuron.uid,
                         false,

--- a/crates/sn2-validator/src/validator_loop/maintenance.rs
+++ b/crates/sn2-validator/src/validator_loop/maintenance.rs
@@ -138,6 +138,14 @@ impl ValidatorLoop {
                 self.config.metagraph.n,
                 self.score_manager.scores_snapshot(),
             );
+            let cap_snapshot = self.performance_tracker.cap_snapshot();
+            let cap_events = self.performance_tracker.drain_cap_events();
+            reporter.flush_capacity(
+                self.current_block,
+                cap_snapshot,
+                cap_events,
+                &self.uid_hotkeys,
+            );
         }
 
         Ok(())

--- a/crates/sn2-validator/src/validator_loop/results.rs
+++ b/crates/sn2-validator/src/validator_loop/results.rs
@@ -14,8 +14,9 @@ impl ValidatorLoop {
         was_at_capacity: bool,
     ) {
         let elapsed = response.response_time;
+        let hotkey = self.uid_hotkeys.get(&uid).cloned().unwrap_or_default();
         self.performance_tracker
-            .record(uid, true, elapsed, was_at_capacity);
+            .record(uid, &hotkey, true, elapsed, was_at_capacity);
         self.score_manager.update_score(
             uid,
             true,


### PR DESCRIPTION
## Summary

Extends the validator's stats-flush cadence with a per-miner adaptive-capacity signal. The existing reporter already streams response logs, health samples, and dsperse events on a 60-second flush; this adds capacity as a fourth lane.

Each ramp or backoff in \`PerformanceTracker::update_adaptive_cap\` is recorded as a \`CapEvent\` carrying the prior cap, the new cap, the at-cap success rate that triggered the decision, and a wall-clock instant. A bounded buffer (4096 entries) prevents unbounded growth if the downstream collector is unavailable. The current cap snapshot and the drained event buffer are sent together on each tick.

The signal lets operators distinguish a steady miner from one whose cap is hunting (oscillating around its hardware ceiling) — which informs whether \`CAPACITY_MIN_AT_CAP\` should be raised or lowered.

## Test plan

- [ ] \`cargo test -p sn2-validator\` — 81 passed locally including new ramp/backoff/drain/bounded-buffer cases
- [ ] \`cargo clippy -p sn2-validator -p sn2-types -- -D warnings\` — clean
- [ ] \`cargo fmt --check\` — clean
- [ ] Soak on testnet and confirm cap snapshots and ramp events appear at the expected cadence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Buffers bounded capacity-adjustment events and emits structured events with direction, from/to, elapsed and success rate.
  * Adds snapshot and drain APIs to retrieve and clear capacity data.
  * Periodic reporting flushes capacity events on an interval, skips empty submissions, and requeues on send failure with size limiting.

* **Bug Fixes**
  * Reset and recording operations are scoped by hotkey to prevent cross-owner interference.

* **Tests**
  * Updated and extended tests for signatures, event emission, drain/requeue behavior and bounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->