### PR TITLE
Investigate metagraph sync stall and introduce failure-driven reconnect

### DIFF
--- a/crates/sn2-validator/src/validator_loop/maintenance.rs
+++ b/crates/sn2-validator/src/validator_loop/maintenance.rs
@@ -226,18 +226,17 @@ impl ValidatorLoop {
                     classified_disconnect = sn2_chain::is_rpc_disconnect(e),
                     "chain RPC unresponsive, forcing reconnect",
                 );
+                self.consecutive_metagraph_failures = 0;
                 self.config.reconnect_chain_client().await?;
                 let chain_client = self
                     .config
                     .chain_client
                     .as_ref()
                     .context("chain_client missing after reconnect")?;
-                self.config
-                    .metagraph
-                    .sync(chain_client)
-                    .await
-                    .context("metagraph sync after reconnect")?;
-                self.consecutive_metagraph_failures = 0;
+                if let Err(retry_err) = self.config.metagraph.sync(chain_client).await {
+                    self.consecutive_metagraph_failures = 1;
+                    return Err(retry_err).context("metagraph sync after reconnect");
+                }
             } else {
                 self.consecutive_metagraph_failures += 1;
                 sync_result.context("metagraph sync")?;

--- a/crates/sn2-validator/src/validator_loop/maintenance.rs
+++ b/crates/sn2-validator/src/validator_loop/maintenance.rs
@@ -217,8 +217,15 @@ impl ValidatorLoop {
             .context("sync_metagraph requires chain_client")?;
         let sync_result = self.config.metagraph.sync(chain_client).await;
         if let Err(ref e) = sync_result {
-            if sn2_chain::is_rpc_disconnect(e) {
-                warn!(error = ?e, "chain RPC connection dead, reconnecting");
+            let force_reconnect = self.consecutive_metagraph_failures + 1
+                >= super::METAGRAPH_FAILURE_RECONNECT_THRESHOLD;
+            if sn2_chain::is_rpc_disconnect(e) || force_reconnect {
+                warn!(
+                    error = ?e,
+                    consecutive_failures = self.consecutive_metagraph_failures + 1,
+                    classified_disconnect = sn2_chain::is_rpc_disconnect(e),
+                    "chain RPC unresponsive, forcing reconnect",
+                );
                 self.config.reconnect_chain_client().await?;
                 let chain_client = self
                     .config
@@ -230,9 +237,13 @@ impl ValidatorLoop {
                     .sync(chain_client)
                     .await
                     .context("metagraph sync after reconnect")?;
+                self.consecutive_metagraph_failures = 0;
             } else {
+                self.consecutive_metagraph_failures += 1;
                 sync_result.context("metagraph sync")?;
             }
+        } else {
+            self.consecutive_metagraph_failures = 0;
         }
 
         let uids = self.config.metagraph.uids();

--- a/crates/sn2-validator/src/validator_loop/mod.rs
+++ b/crates/sn2-validator/src/validator_loop/mod.rs
@@ -163,7 +163,10 @@ pub struct ValidatorLoop {
     pub(super) rsv: RsvManager,
     pub(super) current_block: u64,
     pub(super) blocks_per_tempo: u64,
+    pub(super) consecutive_metagraph_failures: u32,
 }
+
+pub(super) const METAGRAPH_FAILURE_RECONNECT_THRESHOLD: u32 = 3;
 
 impl ValidatorLoop {
     pub async fn new(config: ValidatorConfig) -> Result<Self> {
@@ -363,6 +366,7 @@ impl ValidatorLoop {
             rsv,
             current_block: 0,
             blocks_per_tempo: 360,
+            consecutive_metagraph_failures: 0,
         })
     }
 
@@ -415,7 +419,7 @@ impl ValidatorLoop {
             tokio::select! {
                 _ = tick.tick() => {
                     if let Err(e) = self.step().await {
-                        error!(error = %e, "validator step error");
+                        error!(error = ?e, "validator step error");
                         tick.reset_after(Duration::from_secs(EXCEPTION_DELAY_SECONDS));
                     }
                 }


### PR DESCRIPTION
## Summary

- Investigate a mainnet validator stall where `sync_metagraph` returned errors every 10s for ~17 minutes without ever invoking `reconnect_chain_client`. Live `ss` inspection showed the subtensor RPC TCP connection idle in `ESTABLISHED` with no kernel keepalive — a half-open WebSocket whose error variant did not satisfy `sn2_chain::is_rpc_disconnect`.
- Introduce `consecutive_metagraph_failures` on `ValidatorLoop`, gated by `METAGRAPH_FAILURE_RECONNECT_THRESHOLD = 3`. After three consecutive sync failures the validator now forces `reconnect_chain_client()` regardless of disconnect classification, bounding stall duration to ~30s (3 * `EXCEPTION_DELAY_SECONDS`). Counter resets on every successful sync to prevent flapping on isolated transient errors.
- Switch the top-level `validator step error` log from `%e` to `?e` so the full anyhow cause chain is surfaced. The original log discarded everything below the outermost `context("metagraph sync")`, which is what made the incident diagnostically opaque.

## Test plan

- [ ] `cargo build -p sn2-validator` — passes locally.
- [ ] `cargo clippy -p sn2-validator -- -D warnings` — clean.
- [ ] `cargo fmt --check` — clean.
- [ ] Deploy to testnet validator and confirm `chain RPC unresponsive, forcing reconnect` fires under induced stall (e.g. iptables-drop the WS endpoint) and recovers without process restart.
- [ ] Confirm normal-path logs show `metagraph synced` and counter stays at 0 (no log emission unless triggered).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metagraph synchronization resilience: the validator now auto-reconnects the chain client after repeated sync failures and resets its failure counter on successful sync, reducing downtime.
  * Reduced noisy error logging by switching to more concise debug-style error output during periodic checks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inference-labs-inc/subnet-2/pull/488)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->