### PR TITLE
Consolidate weekly dependabot bumps for debian base and cargo-deny-action

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2.0.17
+      - uses: EmbarkStudios/cargo-deny-action@6c8f9facfa5047ec02d8485b6bf52b587b7777d1 # v2.0.18
 
   secrets-detection:
     name: Secret Detection

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN CARGO_VERSION="${SN2_VERSION#v}" && \
     cargo build --release --locked --bin sn2-validator --bin sn2-miner
 
 ARG SN2_PLATFORM=linux/amd64
-FROM --platform=$SN2_PLATFORM debian:bookworm-20260421-slim@sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252 AS runtime
+FROM --platform=$SN2_PLATFORM debian:bookworm-20260505-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3 AS runtime
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     jq \


### PR DESCRIPTION
## Summary

Supersedes #491 and #492.

| Target | From | To |
| --- | --- | --- |
| debian base image | `bookworm-20260421-slim` @ `sha256:f9c6a2f…` | `bookworm-20260505-slim` @ `sha256:67b30a6…` |
| EmbarkStudios/cargo-deny-action | `v2.0.17` @ `91bf2b62…` | `v2.0.18` @ `6c8f9fac…` |

Both replacement digests were verified against their upstream registries before pinning. The cargo-deny-action SHA was obtained by dereferencing the annotated tag object via `gh api repos/EmbarkStudios/cargo-deny-action/git/tags/<tag-sha>`.

## Test plan

- [ ] CI green on the security workflow (which runs cargo-deny).
- [ ] Container image builds on the new debian base without runtime regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning tooling to the latest version for enhanced vulnerability detection.
  * Updated container base image to the latest Debian Bookworm slim release for improved stability and security patches.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inference-labs-inc/subnet-2/pull/493)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->