### PR TITLE
Investigate validator throughput ceiling and reshape dispatch hot path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6352,8 +6352,11 @@ name = "sn2-types"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bytes",
  "flate2",
  "ndarray 0.17.2",
+ "rmp-serde",
+ "rmpv",
  "serde",
  "serde_json",
  "tracing-subscriber",
@@ -6366,6 +6369,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "btlightning",
+ "bytes",
  "clap",
  "dirs-next",
  "dsperse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ sn2-verify = { path = "crates/sn2-verify" }
 sn2-circuit-store = { path = "crates/sn2-circuit-store" }
 
 tokio = { version = "1", features = ["full"] }
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 anyhow = "1"
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ clap = { version = "4", features = ["derive"] }
 reqwest = { version = "0.12", features = ["rustls-tls", "json", "stream"], default-features = false }
 axum = "0.7"
 rmp-serde = "1"
+rmpv = "1"
+bytes = "1"
 hex = "0.4"
 sp-core = "34"
 bittensor_wallet = { version = "4.0.1", package = "btwallet", default-features = false }

--- a/crates/sn2-types/Cargo.toml
+++ b/crates/sn2-types/Cargo.toml
@@ -12,3 +12,6 @@ serde_json = { workspace = true }
 tracing-subscriber = { workspace = true }
 flate2 = { workspace = true }
 ndarray = { workspace = true }
+rmp-serde = { workspace = true }
+rmpv = { workspace = true }
+bytes = { workspace = true }

--- a/crates/sn2-types/src/circuit.rs
+++ b/crates/sn2-types/src/circuit.rs
@@ -69,4 +69,30 @@ impl Circuit {
 
         Ok(())
     }
+
+    pub fn validate_inputs_msgpack(&self, inputs: &[u8]) -> Result<(), String> {
+        let schema = match &self.metadata.input_schema {
+            Some(s) if !s.is_empty() => s,
+            _ => return Ok(()),
+        };
+
+        let value = rmpv::decode::read_value(&mut &inputs[..])
+            .map_err(|e| format!("decoding msgpack inputs: {e}"))?;
+
+        let entries = match &value {
+            rmpv::Value::Map(entries) => entries,
+            _ => return Err("inputs must be a msgpack map".to_string()),
+        };
+
+        for key in schema.keys() {
+            let present = entries
+                .iter()
+                .any(|(k, _)| k.as_str().map(|s| s == key).unwrap_or(false));
+            if !present {
+                return Err(format!("missing required input: {key}"));
+            }
+        }
+
+        Ok(())
+    }
 }

--- a/crates/sn2-types/src/lib.rs
+++ b/crates/sn2-types/src/lib.rs
@@ -17,6 +17,9 @@ pub use miner_response::*;
 pub use persistence::*;
 pub use protocol::*;
 pub use request::*;
+pub use tensor_codec::{
+    decode_msgpack_to_json, decode_msgpack_value, encode_msgpack_value, input_data_payload,
+};
 
 pub fn init_tracing(log_level: &str) {
     tracing_subscriber::fmt()

--- a/crates/sn2-types/src/miner_response.rs
+++ b/crates/sn2-types/src/miner_response.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use serde::{Deserialize, Serialize};
 
 use crate::{Circuit, ProofSystem, RequestType};
@@ -10,7 +12,7 @@ pub struct MinerResponse {
     pub response_time: f64,
     pub proof_size: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub circuit: Option<Circuit>,
+    pub circuit: Option<Arc<Circuit>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub proof_system: Option<ProofSystem>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/sn2-types/src/request.rs
+++ b/crates/sn2-types/src/request.rs
@@ -1,24 +1,18 @@
-use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use bytes::Bytes;
 
 use crate::{Circuit, ProofSystem, RequestType, RunSource};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Request {
-    pub circuit: Circuit,
-    pub inputs: serde_json::Value,
-    pub request_type: RequestType,
-    pub retry_count: u32,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct DSliceRequest {
-    pub circuit: Circuit,
-    pub inputs: serde_json::Value,
+    pub circuit: Arc<Circuit>,
+    pub inputs: Bytes,
     pub request_type: RequestType,
     pub proof_system: ProofSystem,
     pub slice_num: String,
     pub run_uid: String,
-    pub outputs: Option<serde_json::Value>,
+    pub outputs: Option<Bytes>,
     pub is_tile: bool,
     pub tile_idx: Option<u32>,
     pub task_id: Option<String>,

--- a/crates/sn2-types/src/tensor_codec.rs
+++ b/crates/sn2-types/src/tensor_codec.rs
@@ -288,3 +288,48 @@ fn build_nested(data: &[f64], shape: &[usize], dim: usize) -> serde_json::Value 
             .collect(),
     )
 }
+
+pub fn arrayd_to_msgpack_value(arr: &ArrayD<f64>) -> rmpv::Value {
+    if arr.ndim() == 0 {
+        return rmpv::Value::F64(arr.first().copied().unwrap_or(0.0));
+    }
+    let data: Vec<f64> = match arr.as_slice() {
+        Some(s) => s.to_vec(),
+        None => arr.iter().copied().collect(),
+    };
+    build_nested_rmpv(&data, arr.shape(), 0)
+}
+
+fn build_nested_rmpv(data: &[f64], shape: &[usize], dim: usize) -> rmpv::Value {
+    if dim == shape.len() - 1 {
+        return rmpv::Value::Array(data.iter().map(|&v| rmpv::Value::F64(v)).collect());
+    }
+    let stride: usize = shape[dim + 1..].iter().product();
+    rmpv::Value::Array(
+        (0..shape[dim])
+            .map(|i| build_nested_rmpv(&data[i * stride..(i + 1) * stride], shape, dim + 1))
+            .collect(),
+    )
+}
+
+pub fn encode_msgpack_value(value: &rmpv::Value) -> bytes::Bytes {
+    let mut buf = Vec::new();
+    rmpv::encode::write_value(&mut buf, value).expect("writing to Vec<u8> is infallible");
+    bytes::Bytes::from(buf)
+}
+
+pub fn input_data_payload(arr: &ArrayD<f64>) -> bytes::Bytes {
+    let map = rmpv::Value::Map(vec![(
+        rmpv::Value::String("input_data".into()),
+        arrayd_to_msgpack_value(arr),
+    )]);
+    encode_msgpack_value(&map)
+}
+
+pub fn decode_msgpack_value(bytes: &[u8]) -> anyhow::Result<rmpv::Value> {
+    rmpv::decode::read_value(&mut &bytes[..]).context("decoding msgpack value")
+}
+
+pub fn decode_msgpack_to_json(bytes: &[u8]) -> anyhow::Result<serde_json::Value> {
+    rmp_serde::from_slice::<serde_json::Value>(bytes).context("decoding msgpack to json")
+}

--- a/crates/sn2-validator/Cargo.toml
+++ b/crates/sn2-validator/Cargo.toml
@@ -36,6 +36,7 @@ futures-util = { workspace = true }
 dsperse = { workspace = true }
 ndarray = { workspace = true }
 flate2 = { workspace = true }
+bytes = { workspace = true }
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/crates/sn2-validator/src/validator_loop/dispatch.rs
+++ b/crates/sn2-validator/src/validator_loop/dispatch.rs
@@ -204,7 +204,7 @@ impl ValidatorLoop {
                 is_tile: false,
                 task_id: None,
                 tile_idx: None,
-                task_circuit: Some(circuit.clone()),
+                task_circuit: Some(Arc::new(circuit.clone())),
                 task_inputs: Some(rwr.inputs.clone()),
                 task_proof_system: Some(circuit.proof_system),
                 retry_payload: RetryPayload::Rwr(rwr),
@@ -223,7 +223,20 @@ impl ValidatorLoop {
                     .map(|d| (d, RunSource::Benchmark))
             })
         {
-            let inputs_json = sn2_types::decode_msgpack_to_json(&dslice.inputs).unwrap_or_default();
+            let inputs_json = match sn2_types::decode_msgpack_to_json(&dslice.inputs) {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(
+                        uid,
+                        run_uid = %dslice.run_uid,
+                        slice_num = %dslice.slice_num,
+                        tile_idx = ?dslice.tile_idx,
+                        error = %e,
+                        "dropping dslice: failed to decode queued msgpack inputs"
+                    );
+                    return None;
+                }
+            };
             let dslice_model = self.pipeline.prepare_dslice_request(
                 uid,
                 &dslice.circuit,
@@ -262,7 +275,7 @@ impl ValidatorLoop {
                 is_tile: dslice.is_tile,
                 task_id: dslice.task_id.clone(),
                 tile_idx: dslice.tile_idx,
-                task_circuit: Some((*dslice.circuit).clone()),
+                task_circuit: Some(Arc::clone(&dslice.circuit)),
                 task_inputs: Some(inputs_json),
                 task_proof_system: Some(dslice.proof_system),
                 retry_payload: RetryPayload::DSlice(Box::new(dslice)),

--- a/crates/sn2-validator/src/validator_loop/dispatch.rs
+++ b/crates/sn2-validator/src/validator_loop/dispatch.rs
@@ -1,23 +1,46 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
+use rand::seq::SliceRandom;
 use sn2_types::*;
 
 use super::{is_valid_ip, DispatchedRequest, RetryPayload, TaskOutcome, TaskResult, ValidatorLoop};
 use crate::metrics_server as metrics;
 use crate::relay::FRAME_PROOF_RESULT;
 
+const DISPATCH_CACHE_TTL: Duration = Duration::from_millis(2000);
+
+pub(crate) struct DispatchCache {
+    pub capacities: HashMap<u16, usize>,
+    pub adaptive_timeout: f64,
+    pub api_eligible: HashSet<u16>,
+    pub refreshed_at: Option<Instant>,
+}
+
+impl DispatchCache {
+    pub fn new() -> Self {
+        Self {
+            capacities: HashMap::new(),
+            adaptive_timeout: CIRCUIT_TIMEOUT_SECONDS as f64,
+            api_eligible: HashSet::new(),
+            refreshed_at: None,
+        }
+    }
+}
+
 impl ValidatorLoop {
     pub(super) async fn dispatch_requests(&mut self) -> Result<()> {
-        let verification_backlog = self.verify_tasks.len() + self.pending_verifications.len();
-        if verification_backlog >= self.verification_concurrency {
+        let pending_cap = self.verification_concurrency.saturating_mul(4);
+        if self.pending_verifications.len() >= pending_cap {
             return Ok(());
         }
 
         let active_count = self.tasks.len();
-        let total_pipeline = active_count + verification_backlog;
-        let dispatch_ceiling = self.verification_concurrency.saturating_mul(2);
+        let total_pipeline =
+            active_count + self.verify_tasks.len() + self.pending_verifications.len();
+        let dispatch_ceiling = self.verification_concurrency.saturating_mul(8);
         if total_pipeline >= dispatch_ceiling {
             return Ok(());
         }
@@ -25,22 +48,40 @@ impl ValidatorLoop {
 
         metrics::set_active_tasks(active_count);
 
-        let capacities = self.performance_tracker.miner_capacities();
-        let adaptive_timeout = self.performance_tracker.adaptive_timeout();
+        let mut queryable_uids: Vec<u16> = self
+            .config
+            .metagraph
+            .neurons
+            .iter()
+            .filter(|n| {
+                if let Some(targets) = &self.config.target_uids {
+                    return targets.contains(&n.uid);
+                }
+                if n.validator_permit {
+                    return false;
+                }
+                if n.axon_ip.is_empty() || n.axon_port == 0 {
+                    return false;
+                }
+                is_valid_ip(&n.axon_ip)
+            })
+            .map(|n| n.uid)
+            .collect();
+        queryable_uids.shuffle(&mut rand::rng());
 
-        let queryable = self.get_queryable_neurons();
-        let mut neurons: Vec<sn2_chain::NeuronInfo> = queryable.into_iter().cloned().collect();
-        rand::seq::SliceRandom::shuffle(neurons.as_mut_slice(), &mut rand::rng());
+        self.refresh_dispatch_cache_if_stale(&queryable_uids);
+        let adaptive_timeout = self.dispatch_cache.adaptive_timeout;
 
-        let neuron_refs: Vec<&sn2_chain::NeuronInfo> = neurons.iter().collect();
-        let api_eligible = self.compute_api_eligible(&neuron_refs);
-
-        for neuron in &neurons {
+        for uid in queryable_uids {
             if dispatch_budget == 0 {
                 break;
             }
-            let uid = neuron.uid;
-            let cap = capacities.get(&uid).copied().unwrap_or(1);
+            let cap = self
+                .dispatch_cache
+                .capacities
+                .get(&uid)
+                .copied()
+                .unwrap_or(1);
             let active_now = self.miner_active_count.get(&uid).copied().unwrap_or(0);
             if active_now >= cap {
                 continue;
@@ -56,18 +97,62 @@ impl ValidatorLoop {
                     None => break,
                 };
 
-                let timeout = if api_eligible.contains(&uid) {
+                let timeout = if self.dispatch_cache.api_eligible.contains(&uid) {
                     API_TIMEOUT_SECONDS
                 } else {
                     adaptive_timeout
                 };
 
-                self.spawn_miner_task(uid, neuron, was_at_capacity, timeout, dispatched);
+                let (ip, port, hotkey) = match self.config.metagraph.get_neuron(uid) {
+                    Some(n) => (n.axon_ip.clone(), n.axon_port, n.hotkey.clone()),
+                    None => break,
+                };
+                self.spawn_miner_task(uid, ip, port, hotkey, was_at_capacity, timeout, dispatched);
                 dispatch_budget = dispatch_budget.saturating_sub(1);
             }
         }
 
         Ok(())
+    }
+
+    fn refresh_dispatch_cache_if_stale(&mut self, queryable_uids: &[u16]) {
+        let fresh = self
+            .dispatch_cache
+            .refreshed_at
+            .map(|t| t.elapsed() < DISPATCH_CACHE_TTL)
+            .unwrap_or(false);
+        if fresh {
+            return;
+        }
+        self.dispatch_cache.capacities = self.performance_tracker.miner_capacities();
+        self.dispatch_cache.adaptive_timeout = self.performance_tracker.adaptive_timeout();
+        self.dispatch_cache.api_eligible = self.compute_api_eligible_from_uids(queryable_uids);
+        self.dispatch_cache.refreshed_at = Some(Instant::now());
+    }
+
+    fn compute_api_eligible_from_uids(&self, queryable_uids: &[u16]) -> HashSet<u16> {
+        if queryable_uids.is_empty() || self.config.api_miners_pct == 0 {
+            return HashSet::new();
+        }
+        let snap = self.performance_tracker.snapshot();
+        let queryable: HashSet<u16> = queryable_uids.iter().copied().collect();
+
+        let mut ranked: Vec<(u16, f64)> = snap
+            .iter()
+            .filter(|(uid, (_, count))| {
+                *count >= PERFORMANCE_MIN_SAMPLES && queryable.contains(uid)
+            })
+            .map(|(&uid, &(rate, _))| (uid, rate))
+            .collect();
+
+        ranked.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+        let top_count = (ranked.len() as u32 * self.config.api_miners_pct / 100).max(1) as usize;
+        ranked
+            .into_iter()
+            .take(top_count)
+            .map(|(uid, _)| uid)
+            .collect()
     }
 
     async fn select_request(&mut self, uid: u16) -> Option<DispatchedRequest> {
@@ -138,10 +223,11 @@ impl ValidatorLoop {
                     .map(|d| (d, RunSource::Benchmark))
             })
         {
+            let inputs_json = sn2_types::decode_msgpack_to_json(&dslice.inputs).unwrap_or_default();
             let dslice_model = self.pipeline.prepare_dslice_request(
                 uid,
                 &dslice.circuit,
-                dslice.inputs.clone(),
+                inputs_json.clone(),
                 None,
                 &dslice.slice_num,
                 &dslice.run_uid,
@@ -176,8 +262,8 @@ impl ValidatorLoop {
                 is_tile: dslice.is_tile,
                 task_id: dslice.task_id.clone(),
                 tile_idx: dslice.tile_idx,
-                task_circuit: Some(dslice.circuit.clone()),
-                task_inputs: Some(dslice.inputs.clone()),
+                task_circuit: Some((*dslice.circuit).clone()),
+                task_inputs: Some(inputs_json),
                 task_proof_system: Some(dslice.proof_system),
                 retry_payload: RetryPayload::DSlice(Box::new(dslice)),
                 dsperse_circuit_path: circuit_path,
@@ -188,17 +274,17 @@ impl ValidatorLoop {
         None
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn spawn_miner_task(
         &mut self,
         uid: u16,
-        neuron: &sn2_chain::NeuronInfo,
+        ip: String,
+        port: u16,
+        hotkey: String,
         was_at_capacity: bool,
         timeout: f64,
         d: DispatchedRequest,
     ) {
-        let ip = neuron.axon_ip.clone();
-        let port = neuron.axon_port;
-        let hotkey = neuron.hotkey.clone();
         let client = Arc::clone(&self.miner_client);
 
         let request_type = d.request_type;
@@ -329,32 +415,6 @@ impl ValidatorLoop {
                 }
                 is_valid_ip(&n.axon_ip)
             })
-            .collect()
-    }
-
-    pub(super) fn compute_api_eligible(&self, neurons: &[&sn2_chain::NeuronInfo]) -> HashSet<u16> {
-        if neurons.is_empty() || self.config.api_miners_pct == 0 {
-            return HashSet::new();
-        }
-
-        let snap = self.performance_tracker.snapshot();
-        let queryable: HashSet<u16> = neurons.iter().map(|n| n.uid).collect();
-
-        let mut ranked: Vec<(u16, f64)> = snap
-            .iter()
-            .filter(|(uid, (_, count))| {
-                *count >= PERFORMANCE_MIN_SAMPLES && queryable.contains(uid)
-            })
-            .map(|(&uid, &(rate, _))| (uid, rate))
-            .collect();
-
-        ranked.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-
-        let top_count = (ranked.len() as u32 * self.config.api_miners_pct / 100).max(1) as usize;
-        ranked
-            .into_iter()
-            .take(top_count)
-            .map(|(uid, _)| uid)
             .collect()
     }
 }

--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
@@ -97,7 +98,7 @@ impl ValidatorLoop {
             .ensure_circuit(&submission.circuit_id)
             .await
         {
-            Ok(c) => c,
+            Ok(c) => std::sync::Arc::new(c),
             Err(e) => {
                 warn!(circuit = %submission.circuit_id, error = %e, "unknown circuit in dsperse submission");
                 self.send_submit_error(submission.request_id, &format!("unknown circuit: {e}"))
@@ -420,7 +421,7 @@ impl ValidatorLoop {
     pub(super) async fn enqueue_all_dslices(
         &mut self,
         run_uid: &str,
-        circuit: &Circuit,
+        circuit: &Arc<Circuit>,
         run_source: RunSource,
         prove_pct: f64,
     ) {
@@ -546,12 +547,10 @@ impl ValidatorLoop {
                     }
                 }
             } else {
-                let inputs_json = serde_json::json!({
-                    "input_data": crate::tensor::arrayd_to_json(&input_tensor)
-                });
+                let inputs_bytes = crate::tensor::input_data_payload(&input_tensor);
                 staged.stage_request(DSliceRequest {
-                    circuit: circuit.clone(),
-                    inputs: inputs_json,
+                    circuit: Arc::clone(circuit),
+                    inputs: inputs_bytes,
                     request_type: RequestType::DSlice,
                     proof_system: circuit.proof_system,
                     slice_num: work.slice_id.clone(),
@@ -588,7 +587,7 @@ impl ValidatorLoop {
         staged: &mut StagedWork,
         run_manager: &mut crate::incremental_runner::IncrementalRunManager,
         run_uid: &str,
-        circuit: &Circuit,
+        circuit: &Arc<Circuit>,
         slice_id: &str,
         circuit_path: Option<&str>,
         component_sha: Option<&str>,
@@ -645,18 +644,15 @@ impl ValidatorLoop {
             return None;
         }
 
-        let mut prepared: Vec<(usize, serde_json::Value)> =
-            Vec::with_capacity(sampled_indices.len());
+        let mut prepared: Vec<(usize, bytes::Bytes)> = Vec::with_capacity(sampled_indices.len());
         match tiles_payload {
             TiledPayload::SingleInput(tiles) => {
                 for (idx, tile) in tiles.into_iter().enumerate() {
                     if !sampled_indices.contains(&idx) {
                         continue;
                     }
-                    let tile_json = serde_json::json!({
-                        "input_data": crate::tensor::arrayd_to_json(&tile.into_dyn())
-                    });
-                    prepared.push((idx, tile_json));
+                    let tile_bytes = crate::tensor::input_data_payload(&tile.into_dyn());
+                    prepared.push((idx, tile_bytes));
                 }
             }
             TiledPayload::MultiInput(per_tile) => {
@@ -679,10 +675,8 @@ impl ValidatorLoop {
                                 continue;
                             }
                         };
-                    let tile_json = serde_json::json!({
-                        "input_data": crate::tensor::arrayd_to_json(&tile_arr)
-                    });
-                    prepared.push((idx, tile_json));
+                    let tile_bytes = crate::tensor::input_data_payload(&tile_arr);
+                    prepared.push((idx, tile_bytes));
                 }
             }
         }
@@ -704,12 +698,12 @@ impl ValidatorLoop {
         }
 
         let staged_count = prepared.len();
-        for (idx, tile_json) in prepared {
+        for (idx, tile_bytes) in prepared {
             staged.stage_request(Self::build_tile_request(
                 circuit,
                 slice_id,
                 run_uid,
-                tile_json,
+                tile_bytes,
                 idx as u32,
                 run_source,
                 circuit_path,
@@ -722,18 +716,18 @@ impl ValidatorLoop {
 
     #[allow(clippy::too_many_arguments)]
     fn build_tile_request(
-        circuit: &Circuit,
+        circuit: &Arc<Circuit>,
         slice_id: &str,
         run_uid: &str,
-        tile_json: serde_json::Value,
+        tile_bytes: bytes::Bytes,
         tile_idx: u32,
         run_source: RunSource,
         circuit_path: Option<&str>,
         component_sha: Option<&str>,
     ) -> DSliceRequest {
         DSliceRequest {
-            circuit: circuit.clone(),
-            inputs: tile_json,
+            circuit: Arc::clone(circuit),
+            inputs: tile_bytes,
             request_type: RequestType::DSlice,
             proof_system: circuit.proof_system,
             slice_num: slice_id.to_string(),
@@ -947,7 +941,7 @@ impl ValidatorLoop {
             });
         }
 
-        let circuit = circuit.clone();
+        let circuit = Arc::new(circuit.clone());
         self.enqueue_all_dslices(&run_uid, &circuit, RunSource::Benchmark, 1.0)
             .await;
     }

--- a/crates/sn2-validator/src/validator_loop/mod.rs
+++ b/crates/sn2-validator/src/validator_loop/mod.rs
@@ -164,6 +164,7 @@ pub struct ValidatorLoop {
     pub(super) current_block: u64,
     pub(super) blocks_per_tempo: u64,
     pub(super) consecutive_metagraph_failures: u32,
+    pub(super) dispatch_cache: dispatch::DispatchCache,
 }
 
 pub(super) const METAGRAPH_FAILURE_RECONNECT_THRESHOLD: u32 = 3;
@@ -367,6 +368,7 @@ impl ValidatorLoop {
             current_block: 0,
             blocks_per_tempo: 360,
             consecutive_metagraph_failures: 0,
+            dispatch_cache: dispatch::DispatchCache::new(),
         })
     }
 

--- a/crates/sn2-validator/src/validator_loop/mod.rs
+++ b/crates/sn2-validator/src/validator_loop/mod.rs
@@ -117,7 +117,7 @@ pub(super) struct DispatchedRequest {
     pub(super) is_tile: bool,
     pub(super) task_id: Option<String>,
     pub(super) tile_idx: Option<u32>,
-    pub(super) task_circuit: Option<Circuit>,
+    pub(super) task_circuit: Option<std::sync::Arc<Circuit>>,
     pub(super) task_inputs: Option<serde_json::Value>,
     pub(super) task_proof_system: Option<ProofSystem>,
     pub(super) retry_payload: RetryPayload,


### PR DESCRIPTION
## Context

Mainnet profiling captured a validator running 26h:

- one main-loop thread pinned at 100%, fifteen tokio workers idle (load avg ~1 on a 16-core box, 94% CPU idle overall)
- 26 GB RSS + 11 GB swap; `[heap]` region at 16 GB in `pmap`
- `stacked_dslice_queue` health log showed ~31k entries (each a `DSliceRequest` holding a cloned `Circuit` plus a `serde_json::Value` input tree)
- throughput ~17 proofs/sec against ~243 queryable miners; ~30% of miner queries failing with reconnect-in-flight transport errors

The ceiling was the validator itself: `dispatch_ceiling = verification_concurrency * 2 = 32` in-flight tasks across the entire metagraph, and `dispatch_requests()` was cloning the full `NeuronInfo` Vec plus running `flat_map+sort` over every miner's history on each call (triggered by every task/verify completion and every tick).

## What this changes

**Queue payload shape** — `DSliceRequest.circuit: Circuit` → `Arc<Circuit>`, and `inputs: serde_json::Value` / `outputs: Option<serde_json::Value>` → `bytes::Bytes` / `Option<Bytes>` containing msgpack-encoded values built once at queue-insert time via a new `input_data_payload` helper. The dispatch path decodes once per dispatched request (`decode_msgpack_to_json`) to keep the existing `DSliceProofGenerationDataModel` wire compat. A 30k-entry queue drops from hundreds of MB of fragmented enum trees to a few MB of contiguous blobs plus 16-byte Arc refs. Dead `Request` struct removed.

**Dispatch hot path** — new `DispatchCache` (capacities, adaptive_timeout, api_eligible) refreshed lazily with a 2 s TTL, so the per-call `flat_map+sort` over miner history and the snapshot HashMap clones run at most once every two seconds instead of hundreds of times per second. Per-dispatch full `NeuronInfo` clone replaced with a `Vec<u16>` of UIDs + index shuffle; `NeuronInfo` resolved just-in-time via the existing O(1) `uid_to_idx` index. `spawn_miner_task` now takes owned `(ip, port, hotkey)` instead of `&NeuronInfo`, removing the aliased self-borrow that forced the full clone.

**Throughput ceiling** — `dispatch_ceiling` bumped from `verification_concurrency * 2` to `* 8` (32 → 128 on a 16-core box). The verification backpressure check was conflating in-flight verification (CPU-bound, must stay near `verification_concurrency`) with pending-but-not-yet-verifying results (memory-bound, can buffer). They now have independent caps, so I/O fanout to miners is no longer throttled by CPU-bound proof verification draining.

## Deferred to follow-ups

- Eliminate the dispatch-time msgpack→JSON transcode (push `rmpv::Value` through `DSliceProofGenerationDataModel` and miner handlers). Requires coordinated miner release.
- Custom global allocator (`mimalloc` or `tikv-jemallocator`). Re-measure RSS 24h after this lands; if `[heap]` still climbs after the queue compaction, do it.
- Lift `verification_concurrency` itself once the CPU headroom freed by the dispatch-cache changes is confirmed in production.

## Verification

`cargo check --workspace`, `cargo clippy --workspace --tests -- -D warnings`, `cargo fmt --check`, `cargo test --workspace --lib`, `cargo build -p sn2-validator --release` all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MessagePack support for tensor inputs and validation against optional input schemas
  * Exposed utilities for encoding/decoding MessagePack payloads

* **Bug Fixes & Improvements**
  * Switched request payloads from JSON to compact binary format for lower overhead
  * Request dispatch caching and improved miner selection with adaptive timeout handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inference-labs-inc/subnet-2/pull/494)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->