### PR TITLE
Introduce verification_concurrency override and conservative 2x default

### DIFF
--- a/crates/sn2-validator/src/cli.rs
+++ b/crates/sn2-validator/src/cli.rs
@@ -51,6 +51,9 @@ pub struct Cli {
     #[arg(long)]
     pub circuit_api_url: Option<String>,
 
+    #[arg(long)]
+    pub verification_concurrency: Option<usize>,
+
     #[arg(long, default_value_t = false)]
     pub disable_metric_logging: bool,
 

--- a/crates/sn2-validator/src/config.rs
+++ b/crates/sn2-validator/src/config.rs
@@ -28,6 +28,7 @@ pub struct ValidatorConfig {
     pub disable_metric_logging: bool,
     pub loopback: bool,
     pub additional_circuits: Vec<String>,
+    pub verification_concurrency: Option<usize>,
 }
 
 impl ValidatorConfig {
@@ -95,6 +96,7 @@ impl ValidatorConfig {
             disable_metric_logging: cli.disable_metric_logging,
             loopback: false,
             additional_circuits: cli.additional_circuits.clone(),
+            verification_concurrency: cli.verification_concurrency,
         })
     }
 
@@ -156,6 +158,7 @@ impl ValidatorConfig {
             disable_metric_logging: true,
             loopback: true,
             additional_circuits: cli.additional_circuits.clone(),
+            verification_concurrency: cli.verification_concurrency,
         })
     }
 

--- a/crates/sn2-validator/src/validator_loop/mod.rs
+++ b/crates/sn2-validator/src/validator_loop/mod.rs
@@ -306,15 +306,19 @@ impl ValidatorLoop {
             )
         };
 
-        let verification_concurrency = match std::thread::available_parallelism() {
-            Ok(n) => n.get(),
-            Err(e) => {
-                warn!(error = %e, fallback = 8, "CPU detection failed, using fallback verification concurrency");
-                8
-            }
-        };
+        let verification_concurrency = config.verification_concurrency.unwrap_or_else(|| {
+            let cores = match std::thread::available_parallelism() {
+                Ok(n) => n.get(),
+                Err(e) => {
+                    warn!(error = %e, fallback = 8, "CPU detection failed, using fallback core count");
+                    8
+                }
+            };
+            cores.saturating_mul(2)
+        });
         info!(
             verification_concurrency,
+            override_set = config.verification_concurrency.is_some(),
             "initialized verification concurrency"
         );
 


### PR DESCRIPTION
## Why

14.8.3 freed the validator main-loop bottleneck on mainnet — load avg dropped from 1.0 (one core pinned) to 0.37 (99% box idle) while sustaining 66 proofs/sec (vs. 17 pre-PR). The remaining ceiling is now \`verification_concurrency\`, which the previous code hard-pinned to \`available_parallelism()\` (= 16 on the mainnet host). That leaves substantial CPU headroom unused.

## What this changes

- New \`--verification-concurrency\` CLI flag (optional \`usize\`).
- Default when unset: \`available_parallelism() * 2\`. A conservative doubling — measurably safe on the mainnet box and small enough to avoid stressing operators on lower-spec validator hosts.
- Operators tuning their own validator can pass \`--verification-concurrency=N\` explicitly.

The field also drives two downstream caps proportionally:
- \`dispatch_ceiling = verification_concurrency * 8\` (in-flight miner queries)
- \`pending_verifications\` cap = \`verification_concurrency * 4\`

So a single override pulls all three knobs at once.

## Rollout plan

1. Ship as 14.8.4 with the 2x default — everyone gets a free ~2x throughput bump.
2. We bump our own mainnet validator via \`--verification-concurrency=N\` (planning to sweep 32 → 64 → 96 → 128 with health-log monitoring) to find the happy point on the 16-core, 30 GB mainnet host.
3. Adjust the default in a follow-up if the soak shows a higher value is universally safe.

## Verification

\`cargo check --workspace\`, \`cargo clippy --workspace --tests -- -D warnings\`, \`cargo fmt --check\`, \`cargo test --workspace --lib\` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--verification-concurrency` command-line option to control verification parallelism. When unspecified, the validator automatically defaults to CPU cores × 2.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inference-labs-inc/subnet-2/pull/497)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->