### PR TITLE
Halt adaptive cap ramp under validator memory pressure

### DIFF
--- a/crates/sn2-types/src/constants.rs
+++ b/crates/sn2-types/src/constants.rs
@@ -36,6 +36,7 @@ pub const CAPACITY_WINDOW_SIZE: usize = 50;
 pub const CAPACITY_RAMP_THRESHOLD: f64 = 0.97;
 pub const CAPACITY_BACKOFF_THRESHOLD: f64 = 0.80;
 pub const CAPACITY_MIN_AT_CAP: usize = 8;
+pub const CAPACITY_RAMP_MIN_AVAIL_MEM_RATIO: f64 = 0.20;
 pub const IP_REGION_CAP_FRACTION: f64 = 0.25;
 
 pub const MAX_POW_QUEUE_SIZE: usize = 1024;

--- a/crates/sn2-validator/src/performance.rs
+++ b/crates/sn2-validator/src/performance.rs
@@ -4,11 +4,45 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use sn2_types::{
     ADAPTIVE_TIMEOUT_MIN_SAMPLES, ADAPTIVE_TIMEOUT_MULTIPLIER, ADAPTIVE_TIMEOUT_PERCENTILE,
-    BLOCK_TIME_SECS, CAPACITY_BACKOFF_THRESHOLD, CAPACITY_MIN_AT_CAP, CAPACITY_RAMP_THRESHOLD,
-    CAPACITY_WINDOW_SIZE, CIRCUIT_TIMEOUT_SECONDS, PERFORMANCE_MIN_SAMPLES,
-    PERFORMANCE_RESCHEDULE_PENALTY, PERFORMANCE_SCORING_PERCENTILE, VERIFICATION_WINDOW_BLOCKS,
+    BLOCK_TIME_SECS, CAPACITY_BACKOFF_THRESHOLD, CAPACITY_MIN_AT_CAP,
+    CAPACITY_RAMP_MIN_AVAIL_MEM_RATIO, CAPACITY_RAMP_THRESHOLD, CAPACITY_WINDOW_SIZE,
+    CIRCUIT_TIMEOUT_SECONDS, PERFORMANCE_MIN_SAMPLES, PERFORMANCE_RESCHEDULE_PENALTY,
+    PERFORMANCE_SCORING_PERCENTILE, VERIFICATION_WINDOW_BLOCKS,
 };
-use tracing::warn;
+use tracing::{debug, warn};
+
+#[cfg(target_os = "linux")]
+fn host_memory_available_ratio() -> Option<f64> {
+    let raw = std::fs::read_to_string("/proc/meminfo").ok()?;
+    parse_meminfo_avail_ratio(&raw)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn host_memory_available_ratio() -> Option<f64> {
+    None
+}
+
+fn parse_meminfo_avail_ratio(raw: &str) -> Option<f64> {
+    let mut total_kib: Option<u64> = None;
+    let mut avail_kib: Option<u64> = None;
+    for line in raw.lines() {
+        if let Some(rest) = line.strip_prefix("MemTotal:") {
+            total_kib = rest.split_whitespace().next().and_then(|n| n.parse().ok());
+        } else if let Some(rest) = line.strip_prefix("MemAvailable:") {
+            avail_kib = rest.split_whitespace().next().and_then(|n| n.parse().ok());
+        }
+    }
+    match (total_kib, avail_kib) {
+        (Some(t), Some(a)) if t > 0 => Some(a as f64 / t as f64),
+        _ => None,
+    }
+}
+
+fn cap_ramp_blocked_by_memory_pressure() -> bool {
+    host_memory_available_ratio()
+        .map(|r| r < CAPACITY_RAMP_MIN_AVAIL_MEM_RATIO)
+        .unwrap_or(false)
+}
 
 type WindowEntry = (Instant, bool, f64);
 
@@ -383,6 +417,18 @@ impl PerformanceTracker {
         let mut direction: Option<CapDirection> = None;
 
         if success_rate >= CAPACITY_RAMP_THRESHOLD {
+            if cap_ramp_blocked_by_memory_pressure() {
+                debug!(
+                    uid,
+                    cap = *current,
+                    success_rate,
+                    "cap ramp held back by validator memory pressure"
+                );
+                if let Some(r) = self.at_cap_results.get_mut(&uid) {
+                    r.clear();
+                }
+                return;
+            }
             *current += 1;
             direction = Some(CapDirection::Ramp);
             if let Some(r) = self.at_cap_results.get_mut(&uid) {
@@ -441,6 +487,26 @@ mod tests {
     fn adaptive_timeout_returns_default_with_few_samples() {
         let tracker = test_tracker();
         assert_eq!(tracker.adaptive_timeout(), CIRCUIT_TIMEOUT_SECONDS as f64);
+    }
+
+    #[test]
+    fn parse_meminfo_extracts_avail_ratio() {
+        let sample = "MemTotal:       32096780 kB\n\
+                      MemFree:         1234567 kB\n\
+                      MemAvailable:    8024195 kB\n\
+                      Buffers:           12345 kB\n";
+        let ratio = parse_meminfo_avail_ratio(sample).expect("ratio");
+        assert!(
+            (ratio - 0.25).abs() < 0.005,
+            "ratio {ratio} should be ~0.25"
+        );
+    }
+
+    #[test]
+    fn parse_meminfo_returns_none_on_missing_fields() {
+        assert!(parse_meminfo_avail_ratio("MemTotal: 1 kB\n").is_none());
+        assert!(parse_meminfo_avail_ratio("MemAvailable: 1 kB\n").is_none());
+        assert!(parse_meminfo_avail_ratio("").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Why

Overnight soak of \`testnet-bac1d9f9\` on the mainnet validator (uncapped dispatch + probabilistic RSV) showed adaptive caps running unchecked once the dispatch ceiling was removed:

```
top-miner cap:           57 -> 1110
aggregate cap (sum):  6,396 -> 38,577
active_tasks (p90):           25,385
host RSS:                      29.3 GB / 30 GB total
swap actively used:            11.8 GB
vmstat si:                     ~3.7k pages/sec
%Cpu wa:                       6.9%
throughput trend:    172/sec -> 114/sec -> 30/sec (collapsing)
```

The 97%-success-at-saturation ramp had no upper bound — caps kept climbing until the validator's 30 GB host RAM ceiling broke and the kernel started paging hot working set. Throughput then collapsed 5x within 15 minutes.

## What this changes

Gate the cap ramp branch in \`PerformanceTracker::update_adaptive_cap\` on \`/proc/meminfo MemAvailable >= CAPACITY_RAMP_MIN_AVAIL_MEM_RATIO\` (20% of MemTotal). When the gate trips:
- Refuse the cap increment.
- Reset the at-capacity window so we re-evaluate cleanly when pressure eases.
- Emit a debug log line.

Existing caps stay put — we're not yanking the rug from miners who already earned higher caps. We're just refusing to make anyone go faster while the validator is at the edge. Backoff (success rate < 80% -> cap--) still fires normally and will naturally trim caps as the pressure-induced timeouts kick in.

## Semantics

\"Don't make anyone go faster at this point\" — quoted directly from the operator framing. The ramp gate is the right shape because:
- adaptive cap ramp is the runaway feedback loop (1 cap = 1 in-flight task closure + ~1 MinerResponse worth of memory)
- per-miner cap unbounded means single hot miner can pin all our memory
- existing caps + ongoing backoff handle the rest organically

## Cross-platform

\`#[cfg(target_os = \"linux\")]\` reads \`/proc/meminfo\`. On non-Linux (dev workstations), the function returns \`None\` and the gate falls through to \"not pressured\" — preserving current behavior. The threshold lives as \`CAPACITY_RAMP_MIN_AVAIL_MEM_RATIO\` in sn2-types/constants.rs at 0.20 (20%), sized to engage before the kernel begins paging hot pages rather than reacting to thrash.

## Verification

\`cargo check --workspace\`, \`cargo clippy --workspace --tests -- -D warnings\`, \`cargo fmt --check\`, \`cargo test --workspace --lib\` all clean. Two new unit tests confirm the \`/proc/meminfo\` parser extracts the right ratio and rejects malformed input.

## Follow-up

Ship as 14.8.6 alongside the existing PR #498 changes. On mainnet, the validator should plateau at whatever cap distribution fits 80% of host memory rather than ramping past it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Capacity ramp-up now checks host memory availability on Linux to prevent increases during high memory pressure.

* **Tests**
  * Added validation tests for memory information parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inference-labs-inc/subnet-2/pull/499)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->