### PR TITLE
Migrate sn2-validator to mimalloc as global allocator on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -189,7 +189,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1200,7 +1200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1777,7 +1777,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2033,7 +2033,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3272,7 +3272,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3636,6 +3636,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3945,6 +3954,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mimalloc"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
+dependencies = [
+ "libmimalloc-sys",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4119,7 +4137,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5452,7 +5470,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5520,7 +5538,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5541,7 +5559,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6379,6 +6397,7 @@ dependencies = [
  "libc",
  "metrics",
  "metrics-exporter-prometheus",
+ "mimalloc",
  "ndarray 0.17.2",
  "rand 0.9.4",
  "reqwest 0.12.28",
@@ -6431,7 +6450,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6996,7 +7015,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8198,7 +8217,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ axum = "0.7"
 rmp-serde = "1"
 rmpv = "1"
 bytes = "1"
+mimalloc = { version = "0.1", default-features = false }
 hex = "0.4"
 sp-core = "34"
 bittensor_wallet = { version = "4.0.1", package = "btwallet", default-features = false }

--- a/crates/sn2-validator/Cargo.toml
+++ b/crates/sn2-validator/Cargo.toml
@@ -41,3 +41,4 @@ rustls = { version = "0.23", default-features = false, features = ["ring"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"
+mimalloc = { workspace = true }

--- a/crates/sn2-validator/src/main.rs
+++ b/crates/sn2-validator/src/main.rs
@@ -1,5 +1,9 @@
 #![feature(ip)]
 
+#[cfg(target_os = "linux")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 mod cli;
 mod config;
 mod dsperse_events;

--- a/crates/sn2-validator/src/performance.rs
+++ b/crates/sn2-validator/src/performance.rs
@@ -22,6 +22,7 @@ fn host_memory_available_ratio() -> Option<f64> {
     None
 }
 
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 fn parse_meminfo_avail_ratio(raw: &str) -> Option<f64> {
     let mut total_kib: Option<u64> = None;
     let mut avail_kib: Option<u64> = None;


### PR DESCRIPTION
## Why

Day-long mainnet validator soak under the new uncapped-dispatch profile produced the same memory pattern repeatedly: heap climbed past the host RAM ceiling and never released, even after caps collapsed back to floor and active task count dropped. \`pmap\` on the runaway process:

\`\`\`
[heap]            25.2 GB   (single brk-extended mapping)
anonymous regions  ~5.0 GB   (983 separate mappings)
VmData total       52 GB
\`\`\`

That distribution is the textbook signature of glibc \`ptmalloc2\` thread-arena retention:

- **Per-thread arenas don't shrink.** Each tokio worker gets its own malloc arena; once expanded under contention, the arena stays at high-water mark forever. 983 anonymous regions = ~128 max arenas × growth segments.
- **\`brk()\` main heap can only shrink from the top.** Any single long-lived allocation near the top pins the entire heap below it. Our workload constantly intermixes long-lived state (\`adaptive_caps\`, dispatch cache, \`CircuitStore\`, RSV) with high-frequency short-lived churn (msgpack en/decode, \`serde_json::Value\` trees, response buffers, proof payloads).
- **Size-class threshold.** Allocations <128 KB stay in arena (un-shrinkable); only >128 KB use \`mmap\` (individually \`munmap\`-able). Most of our churn falls below the threshold.

The cap-ramp gate (#499) and pressure backoff (#500) govern dispatch fan-out; neither can affect allocator retention behaviour. The validator's RSS goes 12 GB at restart -> 30 GB after 87 minutes of soak, and never returns regardless of subsequent load patterns.

## What this changes

Install \`mimalloc\` as the global allocator behind \`#[cfg(target_os = \"linux\")]\` in \`crates/sn2-validator/src/main.rs\`:

\`\`\`rust
#[cfg(target_os = \"linux\")]
#[global_allocator]
static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
\`\`\`

\`mimalloc = { workspace = true }\` added to the validator's Linux-only dependencies. Workspace pin: \`mimalloc = { version = \"0.1\", default-features = false }\` (no secure-mode overhead).

Dev workflows on macOS continue to use the system allocator — no platform-specific allocator behaviour to debug locally.

## Why mimalloc over jemalloc

Both fix the issue; picking mimalloc for:
- Smaller binary footprint
- Configurable purge interval (\`MIMALLOC_PURGE_DELAY\` env var) for ops tuning without rebuild
- Better cross-platform support if we later want to enable on macOS/aarch64

## Expected impact

Published comparisons for high-churn Rust async services (Discord, Cloudflare, etc.) show 50-70% steady-state RSS reduction. That matches our observed delta between fresh-restart (~12 GB) and post-soak (~30 GB), suggesting the entire 18 GB delta is allocator retention rather than working set growth.

## Verification

\`cargo check --workspace\`, \`cargo clippy --workspace --tests -- -D warnings\`, \`cargo fmt --check\`, \`cargo test --workspace --lib\` all clean. Also fixes an existing dead-code warning on non-Linux for \`parse_meminfo_avail_ratio\` from #499 by gating it with \`#[cfg_attr(not(target_os = \"linux\"), allow(dead_code))]\`.

## Rollout

Bundles with #498 + #499 + #500 into 14.8.5. After deploy, monitor RSS curve over a multi-hour soak; expect plateau at ~10-15 GB rather than the current 30 GB ceiling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized memory allocation performance on Linux systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inference-labs-inc/subnet-2/pull/501)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->