### PR TITLE
Eliminate GCS proof uploads for validator-generated benchmark runs

### DIFF
--- a/crates/sn2-validator/src/validator_loop/relay.rs
+++ b/crates/sn2-validator/src/validator_loop/relay.rs
@@ -87,6 +87,16 @@ impl ValidatorLoop {
         let Some(uploader) = &self.proof_uploader else {
             return;
         };
+        // Benchmark runs are validator-generated load for scoring; their proof
+        // bytes have no API consumer (customers only retrieve proofs by
+        // run_uids they themselves submitted, all of which are RunSource::Api).
+        // Skipping the upload here eliminates the GCS PUT firehose that drove
+        // the 429 SlowDown storm without changing any externally visible API
+        // surface — dsperse_events still carry run_source for stats.
+        let source = active_run.as_ref().map(|r| r.run_source);
+        if !matches!(source, Some(sn2_types::RunSource::Api)) {
+            return;
+        }
         if self.upload_tasks.len() >= sn2_types::MAX_CONCURRENT_UPLOADS {
             warn!(
                 run_uid = %run_uid,


### PR DESCRIPTION
## Why

The 429 SlowDown storm on \`sn2-dsperse-proofs-can\` traced back to \`spawn_artifact_upload\` firing for every completed dsperse run regardless of \`run_source\`. The offending run UIDs in the log (\`baca688d-…\`, \`16d4df69-…\`) all originated from \`replenish_dslice_queues\` -> \`RunSource::Benchmark\` — validator-internal load synthesised for miner scoring, not customer-submitted proof requests.

Cross-checked against \`sn2-api\`:

- \`POST /proofs/upload-urls\`, \`POST /proofs/confirm\`, \`GET /proofs/<run_uid>\`, \`GET /proofs/<run_uid>/artifacts\`, \`GET /proofs/<run_uid>/<slice_num>\` — all keyed solely on \`run_uid\`.
- The only run_uids any external consumer (customer or admin) ever sees are the API-submitted ones. Benchmark UUIDs are generated inside \`replenish_dslice_queues\` and never leave the validator process.
- \`dsperseProofsTable\` (BigQuery) has no \`run_source\` column — benchmark uploads land there indistinguishably from API uploads, with no downstream reader.
- Stats and admin endpoints read \`dsperseEventsTable\`, which DOES carry \`run_source\` and is populated independently via \`dsperse_events\` (unaffected by this change).

So benchmark proof bytes have been uploaded write-only-never-read. At ~5 dsperse circuits × ~460 slices per circuit, replenished every 5 seconds when queues empty, that's ~460 PUTs/sec sustained on a bucket whose per-object rate limit is ~1 mutation/sec and per-bucket sustained QPS is ~1000. The 429s were inevitable.

## What this changes

Single guard in \`spawn_artifact_upload\` (\`crates/sn2-validator/src/validator_loop/relay.rs\`):

\`\`\`rust
let source = active_run.as_ref().map(|r| r.run_source);
if !matches!(source, Some(sn2_types::RunSource::Api)) {
    return;
}
\`\`\`

That's it. No API change, no schema migration. API runs continue uploading normally. Benchmark runs no longer hit GCS for proof bytes.

## Cross-repo impact

None. \`sn2-api\` and \`sn2-frontend-mono\` are not affected — they only ever query proofs by API-submitted run_uids, which still get uploaded.

## Verification

\`cargo check --workspace\`, \`cargo clippy --workspace --tests -- -D warnings\`, \`cargo fmt --check\`, \`cargo test --workspace --lib\` all clean.

## Rollout

Bundles into 14.8.5 alongside #498 + #499 + #500 + #501. Expected effect on the mainnet validator: \`artifact upload failed\` log lines drop from ~hundreds/min to essentially zero (modulo any in-flight customer-submitted runs). \`upload_tasks\` JoinSet should rarely exceed 1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system performance by preventing artifact uploads for internal validator and benchmark runs, eliminating unnecessary processing overhead and backpressure on upload systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inference-labs-inc/subnet-2/pull/502)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->