### PR TITLE
Skip queryable miners with active per-peer reconnect contention

### DIFF
--- a/crates/sn2-validator/src/validator_loop/dispatch.rs
+++ b/crates/sn2-validator/src/validator_loop/dispatch.rs
@@ -48,12 +48,18 @@ impl ValidatorLoop {
 
         metrics::set_active_tasks(active_count);
 
+        let current_block = self.current_block;
         let mut queryable_uids: Vec<u16> = self
             .config
             .metagraph
             .neurons
             .iter()
             .filter(|n| {
+                if let Some(&until) = self.reconnect_blacklist.get(&n.hotkey) {
+                    if current_block < until {
+                        return false;
+                    }
+                }
                 if let Some(targets) = &self.config.target_uids {
                     return targets.contains(&n.uid);
                 }

--- a/crates/sn2-validator/src/validator_loop/maintenance.rs
+++ b/crates/sn2-validator/src/validator_loop/maintenance.rs
@@ -261,6 +261,17 @@ impl ValidatorLoop {
         self.score_manager.sync_uids(&uids);
         self.rsv
             .prune_expired(self.current_block, self.blocks_per_tempo);
+        let blacklist_before = self.reconnect_blacklist.len();
+        self.reconnect_blacklist
+            .retain(|_, until| self.current_block < *until);
+        let blacklist_after = self.reconnect_blacklist.len();
+        if blacklist_before != blacklist_after {
+            info!(
+                expired = blacklist_before - blacklist_after,
+                remaining = blacklist_after,
+                "reconnect_blacklist pruned"
+            );
+        }
 
         let mut axon_count = 0usize;
         for n in &self.config.metagraph.neurons {

--- a/crates/sn2-validator/src/validator_loop/maintenance.rs
+++ b/crates/sn2-validator/src/validator_loop/maintenance.rs
@@ -449,9 +449,17 @@ impl ValidatorLoop {
             .iter()
             .copied()
             .filter(|uid| {
-                self.uid_hotkeys
-                    .get(uid)
-                    .is_some_and(|hk| !hk.is_empty() && self.rsv.is_skiplisted(hk, current_block))
+                self.uid_hotkeys.get(uid).is_some_and(|hk| {
+                    if hk.is_empty() {
+                        return false;
+                    }
+                    if self.rsv.is_skiplisted(hk, current_block) {
+                        return true;
+                    }
+                    self.reconnect_blacklist
+                        .get(hk)
+                        .is_some_and(|&until| current_block < until)
+                })
             })
             .collect();
         let coldstart: HashSet<u16> = uids

--- a/crates/sn2-validator/src/validator_loop/mod.rs
+++ b/crates/sn2-validator/src/validator_loop/mod.rs
@@ -165,6 +165,7 @@ pub struct ValidatorLoop {
     pub(super) blocks_per_tempo: u64,
     pub(super) consecutive_metagraph_failures: u32,
     pub(super) dispatch_cache: dispatch::DispatchCache,
+    pub(super) reconnect_blacklist: HashMap<String, u64>,
 }
 
 pub(super) const METAGRAPH_FAILURE_RECONNECT_THRESHOLD: u32 = 3;
@@ -373,6 +374,7 @@ impl ValidatorLoop {
             blocks_per_tempo: 360,
             consecutive_metagraph_failures: 0,
             dispatch_cache: dispatch::DispatchCache::new(),
+            reconnect_blacklist: HashMap::new(),
         })
     }
 

--- a/crates/sn2-validator/src/validator_loop/results.rs
+++ b/crates/sn2-validator/src/validator_loop/results.rs
@@ -339,6 +339,18 @@ impl ValidatorLoop {
     ) {
         warn!(uid = uid, rtype = %request_type, retry = retry_count, error = reason, "miner query failed");
 
+        if !hotkey.is_empty()
+            && (reason.contains("already in progress") || reason.contains("in backoff"))
+        {
+            let bpt = if self.blocks_per_tempo == 0 {
+                360
+            } else {
+                self.blocks_per_tempo
+            };
+            let until = self.current_block + bpt;
+            self.reconnect_blacklist.insert(hotkey.to_string(), until);
+        }
+
         let is_verification_failure = reason.starts_with("verification failed")
             && matches!(
                 request_type,


### PR DESCRIPTION
## Why

Mainnet validator soak under the new cap-1 floor exposed btlightning's per-PeerAddr reconnect-race as the dominant failure mode:

\`\`\`
60s failure breakdown:
  4,331  Reconnection to 137.184.234.151:8091 already in progress
  1,818  Reconnection to 72.46.85.157:31603 already in progress
\`\`\`

Two single peer addresses, 6k failures in a minute. Amplified by \`MAX_SLICE_RETRIES=5\` per dslice. Each retry burns a dispatch slot for a peer whose connection state can't accept the request. The natural backoff path through \`adaptive_caps\` and \`compute_throughput_weights\` is too slow to react because cap-1 victims can never reach the 97% success threshold needed to ramp.

## What this changes

Track a hotkey-keyed \`reconnect_blacklist: HashMap<String, u64>\` on \`ValidatorLoop\`:

- \`handle_failure\` inspects the error \`reason\` string. On match for \`"already in progress"\` or \`"in backoff"\`, inserts \`hotkey -> current_block + blocks_per_tempo\`.
- \`dispatch_requests\` queryable filter excludes any hotkey currently blocked. The deadline is \`current_block < until\`.
- \`sync_metagraph\` prunes expired entries with an info log on count change.

## Hotkey-keyed, not uid-keyed

Mirrors the RSV design. A miner who deregs and re-regs under a fresh hotkey gets a clean slate; a hotkey moving between uids carries the blacklist with it. Prevents the gameable "drop a uid, grab a new one" laundering path that uid-keyed would allow.

## Throughput and score effect (automatic)

While a hotkey is filtered out:
- No new \`performance_tracker\` window entries
- Existing entries age out via TTL
- Window length falls below \`PERFORMANCE_MIN_SAMPLES\`
- \`miner_capacities\` falls back to cap=1, count below threshold -> rate=0
- \`compute_throughput_weights\` outputs 0 for that hotkey

Result: blacklisted miner contributes 0 weight for one tempo, then gets a fresh dispatch attempt the tempo after. Matches the operator framing — drop their score to zero, recover natural at next tempo.

## Limitation worth flagging

Detection is string-substring match on the error \`reason\` field. \`btlightning::LightningError\` is exposed as \`anyhow::Error\` and our error chain flattens to a Display string. A typed \`MinerQueryError::PeerReconnecting\` variant in \`miner_client\` would be cleaner; deferred to a future PR that restructures the miner-query error surface.

## Verification

\`cargo check --workspace\`, \`cargo clippy --workspace --tests -- -D warnings\`, \`cargo fmt --check\`, \`cargo test --workspace --lib\` all clean.

## Rollout

Standalone change targeted at testnet, then bundled into the next mainnet tag with the rest of the in-flight 14.8.x stack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validators now avoid retrying miners that are temporarily in backoff, reducing redundant connection attempts and improving stability.
  * Backoff entries are pruned during maintenance and an informational log reports pruning activity.

* **Improvements**
  * Failures that indicate ongoing or backoff conditions now trigger temporary blacklisting to allow recovery without immediate reconnect attempts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inference-labs-inc/subnet-2/pull/503)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->