### PR TITLE
Configure mimalloc purge_delay in-binary via ctor pre-main hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,6 +1515,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "ctr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6389,6 +6399,7 @@ dependencies = [
  "btlightning",
  "bytes",
  "clap",
+ "ctor",
  "dirs-next",
  "dsperse",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ rmp-serde = "1"
 rmpv = "1"
 bytes = "1"
 mimalloc = { version = "0.1", default-features = false }
+ctor = "0.2"
 hex = "0.4"
 sp-core = "34"
 bittensor_wallet = { version = "4.0.1", package = "btwallet", default-features = false }

--- a/crates/sn2-validator/Cargo.toml
+++ b/crates/sn2-validator/Cargo.toml
@@ -42,3 +42,4 @@ rustls = { version = "0.23", default-features = false, features = ["ring"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"
 mimalloc = { workspace = true }
+ctor = { workspace = true }

--- a/crates/sn2-validator/src/main.rs
+++ b/crates/sn2-validator/src/main.rs
@@ -4,6 +4,26 @@
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+// Mimalloc reads option env vars on first option access (lazy). The default
+// `purge_delay` of ~1s churns the page tables on our high-frequency
+// dispatch workload — observed 38k mmap/munmap syscalls per 3s on mainnet,
+// re-introducing a single-thread bottleneck at the allocator layer. Setting
+// the env var from a constructor that runs before main() (and crucially
+// before the tokio runtime build) captures the desired cadence before any
+// sustained allocation. Operators can still override by setting the env
+// var explicitly in their process environment.
+#[cfg(target_os = "linux")]
+#[ctor::ctor]
+fn configure_mimalloc_purge_delay() {
+    // SAFETY: ctor runs single-threaded before main; no other thread can
+    // race on environment state at this point.
+    unsafe {
+        if std::env::var_os("MIMALLOC_PURGE_DELAY").is_none() {
+            std::env::set_var("MIMALLOC_PURGE_DELAY", "60000");
+        }
+    }
+}
+
 mod cli;
 mod config;
 mod dsperse_events;


### PR DESCRIPTION
## Why

After PR #501 installed mimalloc on the validator, mainnet profiling revealed a second-order bottleneck: at mimalloc's default ~1s \`purge_delay\`, idle pages get returned to the OS so aggressively that the page-table churn itself becomes the new single-thread cap. Observed on mainnet:

\`\`\`
strace 3s sample on the main thread:
  55.26%  munmap   19,169 calls
  44.73%  mmap     19,192 calls
  100.00%  ~38k total / 3s = ~12.8k syscalls/sec
\`\`\`

mmap is process-global (serialised across threads), so this re-introduces exactly the single-thread bottleneck we eliminated at the dispatch layer in PR #494/#498.

Setting \`MIMALLOC_PURGE_DELAY=60000\` (60s) via pm2 env on the host eliminated the syscall storm immediately and lifted sustained throughput to **227 verified/sec** — the highest measured point.

## What this changes

Bake the configuration into the binary so it doesn't depend on operator-level env. Two-line ctor hook in \`crates/sn2-validator/src/main.rs\`:

\`\`\`rust
#[cfg(target_os = \"linux\")]
#[ctor::ctor]
fn configure_mimalloc_purge_delay() {
    unsafe {
        if std::env::var_os(\"MIMALLOC_PURGE_DELAY\").is_none() {
            std::env::set_var(\"MIMALLOC_PURGE_DELAY\", \"60000\");
        }
    }
}
\`\`\`

\`ctor::ctor\` runs the function before \`main()\` and crucially before the tokio runtime build that allocates worker stacks (triggering the first mimalloc option read). Mimalloc reads option env vars lazily on first access; the ctor timing ensures the value is captured before any sustained allocation begins.

## Why ctor crate

The \`mimalloc\` 0.1 crate's surface only exposes \`MiMalloc: GlobalAlloc\` — no programmatic option API. \`libmimalloc-sys\` exposes \`mi_option_set\`, but the rust binding curates option constants and doesn't expose \`mi_option_purge_delay\` (it's in the gap between 21 and \`_mi_option_last = 46\`). Using the env var path with a pre-main hook is the cleanest path that doesn't require hardcoded option IDs or a new transitive dep.

Adds \`ctor = \"0.2\"\` to the workspace; ~150 LOC crate, no transitive bloat.

## Operator override preserved

The ctor only sets the env if it's unset, so anyone who wants to tune further (e.g. shorter delay on memory-constrained hosts, or \`MIMALLOC_PURGE_DELAY=0\` to disable purging entirely) can still do so via pm2 / systemd / Dockerfile without rebuilding.

## Verification

\`cargo check --workspace\`, \`cargo clippy --workspace --tests -- -D warnings\`, \`cargo fmt --check\`, \`cargo test --workspace --lib\` all clean.

## Rollout

Bundles into the next mainnet tag with the in-flight 14.8.x stack. Operators upgrading without setting the env var will get the correct cadence automatically. Hosts that have the pm2 env set explicitly stay unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized memory allocation performance on Linux systems to reduce allocator overhead during high-frequency operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inference-labs-inc/subnet-2/pull/504)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->