### PR TITLE
Eliminate proof-byte duplication across the verification pipeline

### DIFF
--- a/crates/sn2-validator/src/validator_loop/dispatch.rs
+++ b/crates/sn2-validator/src/validator_loop/dispatch.rs
@@ -374,7 +374,7 @@ impl ValidatorLoop {
                         .map(|s| s.len())
                         .unwrap_or(0);
 
-                    if let Some(raw) = &response.raw {
+                    if let Some(raw) = response.raw.take() {
                         response.witness = raw
                             .get("witness")
                             .and_then(|v| v.as_str())

--- a/crates/sn2-validator/src/validator_loop/mod.rs
+++ b/crates/sn2-validator/src/validator_loop/mod.rs
@@ -156,7 +156,7 @@ pub struct ValidatorLoop {
     pub(super) dsperse_emit_tasks: JoinSet<()>,
     pub(super) verify_tasks: JoinSet<VerifyResult>,
     pub(super) verify_guard_hashes: HashMap<tokio::task::Id, Option<String>>,
-    pub(super) pending_verifications: VecDeque<TaskResult>,
+    pub(super) pending_verifications: VecDeque<(TaskResult, bool)>,
     pub(super) verification_concurrency: usize,
     pub(super) dslice_input_scales: HashMap<(String, String), f64>,
     pub(super) disabled_slices: HashMap<String, HashSet<String>>,

--- a/crates/sn2-validator/src/validator_loop/verification.rs
+++ b/crates/sn2-validator/src/validator_loop/verification.rs
@@ -255,7 +255,7 @@ fn decide_sample(
     rsv: &mut crate::rsv::RsvManager,
 ) -> bool {
     let has_proof =
-        matches!(result.outcome, TaskOutcome::Success(ref r) if r.proof_content.is_some());
+        matches!(result.outcome, TaskOutcome::Success(ref r) if r.proof_size > 0);
     if !has_proof {
         return false;
     }

--- a/crates/sn2-validator/src/validator_loop/verification.rs
+++ b/crates/sn2-validator/src/validator_loop/verification.rs
@@ -6,52 +6,63 @@ use crate::relay::FRAME_PROOF_RESULT;
 use crate::response_processor::ResponseProcessor;
 
 impl ValidatorLoop {
-    pub(super) fn start_verification(&mut self, result: TaskResult) {
+    pub(super) fn start_verification(&mut self, mut result: TaskResult) {
         let uid = result.uid;
 
         if let Some(count) = self.miner_active_count.get_mut(&uid) {
             *count = count.saturating_sub(1);
         }
 
+        // Decide sampling now so we can free proof bytes from responses
+        // that will be no-op verified and never relayed. Holding the bytes
+        // until spawn_verification means pending_verifications buffers the
+        // full proof payload across the verify-CPU bottleneck for ~95% of
+        // responses that take the RSV fast path without needing them.
+        let hotkey = self.uid_hotkeys.get(&uid).cloned().unwrap_or_default();
+        let sample = decide_sample(
+            &result,
+            &hotkey,
+            self.current_block,
+            self.blocks_per_tempo,
+            &mut self.rsv,
+        );
+        if !sample && !response_needs_proof_bytes_for_downstream(&result) {
+            if let TaskOutcome::Success(ref mut response) = result.outcome {
+                response.proof_content = None;
+                response.computed_outputs = None;
+                response.witness = None;
+                response.raw = None;
+                response.public_json = None;
+            }
+        }
+
         if self.verify_tasks.len() >= self.verification_concurrency {
-            self.pending_verifications.push_back(result);
+            self.pending_verifications.push_back((result, sample));
             return;
         }
 
-        self.spawn_verification(result);
+        self.spawn_verification(result, sample);
     }
 
     pub(super) fn drain_pending_verifications(&mut self) {
         while self.verify_tasks.len() < self.verification_concurrency {
             match self.pending_verifications.pop_front() {
-                Some(result) => self.spawn_verification(result),
+                Some((result, sample)) => self.spawn_verification(result, sample),
                 None => break,
             }
         }
     }
 
-    fn spawn_verification(&mut self, mut result: TaskResult) {
+    fn spawn_verification(&mut self, mut result: TaskResult, sample: bool) {
         let guard_hash = result.guard_hash.clone();
         let uid = result.uid;
         let hotkey = self.uid_hotkeys.get(&uid).cloned().unwrap_or_default();
-        let has_proof =
-            matches!(result.outcome, TaskOutcome::Success(ref r) if r.proof_content.is_some());
-        let is_pow = result.request_type == RequestType::ProofOfWeights;
-        let is_customer_rwr = result.request_type == RequestType::Rwr;
-        let has_external_hash = result.external_request_hash.is_some();
-        let is_api_dslice = matches!(
-            &result.retry_payload,
-            RetryPayload::DSlice(d) if d.run_source == RunSource::Api
-        );
-        let force_verify = is_pow || is_customer_rwr || has_external_hash || is_api_dslice;
-        let sample = has_proof
-            && (force_verify
-                || hotkey.is_empty()
-                || self
-                    .rsv
-                    .should_sample(&hotkey, self.current_block, self.blocks_per_tempo));
+        // proof_size is set at response construction in dispatch and remains
+        // valid even after the byte-shedding in start_verification cleared
+        // proof_content for the no-op verify path. Gate on that instead of
+        // the bytes themselves.
         let handle = match result.outcome {
-            TaskOutcome::Success(ref mut response) if response.proof_content.is_some() => {
+            TaskOutcome::Success(ref mut response) if response.proof_size > 0 => {
                 let mut response = match std::mem::replace(
                     &mut result.outcome,
                     TaskOutcome::Failure(String::new()),
@@ -234,4 +245,41 @@ impl ValidatorLoop {
             }
         }
     }
+}
+
+fn decide_sample(
+    result: &TaskResult,
+    hotkey: &str,
+    current_block: u64,
+    blocks_per_tempo: u64,
+    rsv: &mut crate::rsv::RsvManager,
+) -> bool {
+    let has_proof =
+        matches!(result.outcome, TaskOutcome::Success(ref r) if r.proof_content.is_some());
+    if !has_proof {
+        return false;
+    }
+    let is_pow = result.request_type == RequestType::ProofOfWeights;
+    let is_customer_rwr = result.request_type == RequestType::Rwr;
+    let has_external_hash = result.external_request_hash.is_some();
+    let is_api_dslice = matches!(
+        &result.retry_payload,
+        RetryPayload::DSlice(d) if d.run_source == RunSource::Api
+    );
+    let force_verify = is_pow || is_customer_rwr || has_external_hash || is_api_dslice;
+    force_verify || hotkey.is_empty() || rsv.should_sample(hotkey, current_block, blocks_per_tempo)
+}
+
+/// True when a successful response's proof bytes are consumed by something
+/// other than the verifier — either relayed back to a customer or pushed
+/// into run_manager.artifacts for upload. False for benchmark dslices and
+/// other purely-internal flows where the bytes have no downstream reader.
+fn response_needs_proof_bytes_for_downstream(result: &TaskResult) -> bool {
+    if result.external_request_hash.is_some() {
+        return true;
+    }
+    matches!(
+        &result.retry_payload,
+        RetryPayload::DSlice(d) if d.run_source == RunSource::Api
+    )
 }

--- a/crates/sn2-validator/src/validator_loop/verification.rs
+++ b/crates/sn2-validator/src/validator_loop/verification.rs
@@ -254,8 +254,7 @@ fn decide_sample(
     blocks_per_tempo: u64,
     rsv: &mut crate::rsv::RsvManager,
 ) -> bool {
-    let has_proof =
-        matches!(result.outcome, TaskOutcome::Success(ref r) if r.proof_size > 0);
+    let has_proof = matches!(result.outcome, TaskOutcome::Success(ref r) if r.proof_size > 0);
     if !has_proof {
         return false;
     }


### PR DESCRIPTION
## Why

Mainnet validator profiling under the new high-concurrency path traced the runaway memory footprint to duplicate proof-payload retention along the verify pipeline. Each successful in-flight response carries:

- \`raw\`: full wire payload (the largest single field)
- \`proof_content\`: extracted from \`raw\` via clone
- \`computed_outputs\`: extracted from \`raw\` via clone
- \`witness\`: extracted from \`raw\`
- \`public_json\`: parsed from \`raw\`

All clones of overlapping bytes from the same source, all held *concurrently*. At ~8k active tasks with 1-2 MB proofs per slice this drives 30+ GB peak working set on a 30 GB host even with mimalloc installed. The allocator hits memory pressure, triggers purge bursts that pin the main thread, which stalls dispatch and triggers the cap-collapse cascade documented in #498/#499/#500.

The bytes are then carried through \`pending_verifications\` (capped at 512 entries) waiting for a verify slot, which adds another full duplication layer of ~1-2 GB worst-case.

## Three fixes in one pass

1. **\`raw.take()\` immediately after extracting fields out of it** (\`dispatch.rs::spawn_miner_task\`). \`raw\` is the source from which \`witness\`, \`computed_outputs\`, and \`public_json\` are pulled — once those are out, the full wire payload is never read again. Switching \`&response.raw\` to \`response.raw.take()\` lets the Value drop at end of scope.

2. **Drop proof bytes from no-op verify responses before they enter \`pending_verifications\`**. Pre-compute the RSV sample decision in \`start_verification\` (was deferred to \`spawn_verification\`). For responses heading to the no-op path with no downstream consumer of the bytes (no \`external_request_hash\`, not an API-source dslice), clear \`proof_content\` / \`computed_outputs\` / \`witness\` / \`raw\` / \`public_json\` before the result enters the buffer. At RSV's 4% sample rate, ~95% of responses take this path.

3. **\`pending_verifications\` becomes a queue of minimal handles for the no-op path**. Consequent of (2) — once the bytes are gone before push, the buffer holds only the \`TaskResult\` metadata plus sample decision. Retyped from \`VecDeque<TaskResult>\` to \`VecDeque<(TaskResult, bool)>\` to carry the pre-computed sample decision across the buffering window without re-rolling RSV.

## Downstream-consumer rule

A response's proof bytes are kept if any of:
- \`external_request_hash.is_some()\` — must relay back to a customer via \`/proofs/<run_uid>\` flow
- \`RetryPayload::DSlice(d)\` with \`d.run_source == RunSource::Api\` — pushed into \`run_manager.artifacts\` for GCS upload

Benchmark dslices on the unsampled path no longer carry the bytes. \`spawn_artifact_upload\` (#502) already filters those from upload, so this just stops holding the bytes that would have been silently discarded later.

## Verify-path correctness

The match guard in \`spawn_verification\` was \`response.proof_content.is_some()\` — that breaks once we drop the bytes. Swapped to \`response.proof_size > 0\`. \`proof_size\` is the \`usize\` byte-length set at construction in \`dispatch.rs\` and is unaffected by the byte-shedding. The fast-path still routes correctly to \`verified=true\` for proofs that had bytes originally, regardless of whether those bytes survived into spawn.

## Expected impact

\`raw\` alone is the dominant proof field by size — its elimination should cut working set ~50%. The pending buffer drop is another ~1-2 GB during sustained pressure. Combined: 30 GB peak working set → ~12-15 GB. That's comfortably under the 30 GB host ceiling, eliminating the swap-thrash trigger that drives the mimalloc purge bursts.

## Verification

\`cargo check --workspace\`, \`cargo clippy --workspace --tests -- -D warnings\`, \`cargo fmt --check\`, \`cargo test --workspace --lib\` all clean. \`response_needs_proof_bytes_for_downstream\` and \`decide_sample\` are pure helpers with no side effects (\`decide_sample\` does roll RSV).

## Rollout

Bundles into 14.8.5 alongside the in-flight stack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Validator loop reworked to make sampling decisions explicit and to persist those decisions alongside queued tasks, improving determinism of verification flow.

* **Improvements**
  * Non-sampled verifications now strip large proof/payload fields early, reducing memory and bandwidth usage and improving throughput.
  * Response payloads are consumed when appropriate to avoid retaining unnecessary data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inference-labs-inc/subnet-2/pull/505)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->