### PR TITLE
Develop validator resilience to transient chain disruption and recover from network-wide slice failures

### DIFF
--- a/crates/sn2-validator/src/incremental_runner.rs
+++ b/crates/sn2-validator/src/incremental_runner.rs
@@ -498,6 +498,8 @@ impl IncrementalRunManager {
             .retain(|(run_uid, _), _| !stale_set.contains(run_uid.as_str()));
         self.verified_tile_counts
             .retain(|(run_uid, _), _| !stale_set.contains(run_uid.as_str()));
+        self.skipped_slices
+            .retain(|run_uid, _| !stale_set.contains(run_uid.as_str()));
         for uid in stale.iter() {
             self.runs.remove(uid);
             self.evicted.insert(uid.clone());

--- a/crates/sn2-validator/src/incremental_runner.rs
+++ b/crates/sn2-validator/src/incremental_runner.rs
@@ -93,6 +93,11 @@ pub struct IncrementalRunManager {
     evicted: BoundedFifoSet<String>,
     tile_counters: HashMap<(String, String), TileCounter>,
     verified_tile_counts: HashMap<(String, String), usize>,
+    // Slices marked failed without ever being dispatched (e.g. previously
+    // disabled, or rejected by preflight). Tracked per run so the run-wide
+    // failure guard in finalize_combined_run can distinguish "no slice was
+    // attempted" from "every attempted slice failed".
+    skipped_slices: HashMap<String, HashSet<String>>,
 }
 
 impl Default for IncrementalRunManager {
@@ -102,6 +107,7 @@ impl Default for IncrementalRunManager {
             evicted: BoundedFifoSet::new(EVICTED_CAP),
             tile_counters: HashMap::new(),
             verified_tile_counts: HashMap::new(),
+            skipped_slices: HashMap::new(),
         }
     }
 }
@@ -390,6 +396,25 @@ impl IncrementalRunManager {
             .unwrap_or(0)
     }
 
+    /// Record that a slice was marked failed without ever being dispatched.
+    /// Used by the run-wide failure guard in finalize_combined_run to avoid
+    /// conflating deterministic skips (already-disabled slices, preflight
+    /// rejections) with the "every attempted slice failed" signal that
+    /// triggers the disable-list write-suppression.
+    pub fn note_slice_skipped(&mut self, run_uid: &str, slice_id: &str) {
+        self.skipped_slices
+            .entry(run_uid.to_string())
+            .or_default()
+            .insert(slice_id.to_string());
+    }
+
+    pub fn skipped_slice_count(&self, run_uid: &str) -> usize {
+        self.skipped_slices
+            .get(run_uid)
+            .map(HashSet::len)
+            .unwrap_or(0)
+    }
+
     pub fn is_run_complete(&self, run_uid: &str) -> bool {
         self.runs
             .get(run_uid)
@@ -414,6 +439,7 @@ impl IncrementalRunManager {
         self.tile_counters.retain(|(uid, _), _| uid != run_uid);
         self.verified_tile_counts
             .retain(|(uid, _), _| uid != run_uid);
+        self.skipped_slices.remove(run_uid);
         self.runs.remove(run_uid)
     }
 
@@ -447,6 +473,8 @@ impl IncrementalRunManager {
             .retain(|(run_uid, _), _| !evict_set.contains(run_uid.as_str()));
         self.verified_tile_counts
             .retain(|(run_uid, _), _| !evict_set.contains(run_uid.as_str()));
+        self.skipped_slices
+            .retain(|run_uid, _| !evict_set.contains(run_uid.as_str()));
         for uid in to_remove.iter() {
             self.runs.remove(uid);
             self.evicted.insert(uid.clone());

--- a/crates/sn2-validator/src/validator_loop/dispatch.rs
+++ b/crates/sn2-validator/src/validator_loop/dispatch.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use rand::seq::SliceRandom;
 use sn2_types::*;
 
+use super::verification::pre_decide_sample;
 use super::{is_valid_ip, DispatchedRequest, RetryPayload, TaskOutcome, TaskResult, ValidatorLoop};
 use crate::metrics_server as metrics;
 use crate::relay::FRAME_PROOF_RESULT;
@@ -98,7 +99,7 @@ impl ValidatorLoop {
                 let active = self.miner_active_count.get(&uid).copied().unwrap_or(0);
                 let was_at_capacity = active + 1 >= cap;
 
-                let dispatched = match self.select_request(uid).await {
+                let mut dispatched = match self.select_request(uid).await {
                     Some(d) => d,
                     None => break,
                 };
@@ -113,6 +114,24 @@ impl ValidatorLoop {
                     Some(n) => (n.axon_ip.clone(), n.axon_port, n.hotkey.clone()),
                     None => break,
                 };
+
+                // Pre-decide the RSV sample before the miner task is spawned.
+                // Force-verify paths (PoW, customer RWR, external-hash, API
+                // dslice) bypass the roll; benchmark dslices take the random
+                // 4% sample. For non-sampled benchmark dispatches we drop
+                // task_inputs immediately so the validator's local input copy
+                // is not retained for the full request lifetime.
+                dispatched.pre_sampled = pre_decide_sample(
+                    &dispatched,
+                    &hotkey,
+                    self.current_block,
+                    self.blocks_per_tempo,
+                    &mut self.rsv,
+                );
+                if !dispatched.pre_sampled {
+                    dispatched.task_inputs = None;
+                }
+
                 self.spawn_miner_task(uid, ip, port, hotkey, was_at_capacity, timeout, dispatched);
                 dispatch_budget = dispatch_budget.saturating_sub(1);
             }
@@ -216,6 +235,7 @@ impl ValidatorLoop {
                 retry_payload: RetryPayload::Rwr(rwr),
                 dsperse_circuit_path: None,
                 component_sha: None,
+                pre_sampled: false,
             });
         }
 
@@ -287,6 +307,7 @@ impl ValidatorLoop {
                 retry_payload: RetryPayload::DSlice(Box::new(dslice)),
                 dsperse_circuit_path: circuit_path,
                 component_sha,
+                pre_sampled: false,
             });
         }
 
@@ -323,6 +344,7 @@ impl ValidatorLoop {
         let retry_payload = d.retry_payload;
         let dsperse_circuit_path = d.dsperse_circuit_path;
         let dsperse_component_sha = d.component_sha;
+        let pre_sampled = d.pre_sampled;
         let task_guard_hash = guard_hash.clone();
 
         let abort_handle = self.tasks.spawn(async move {
@@ -408,6 +430,7 @@ impl ValidatorLoop {
                 tile_idx,
                 outcome,
                 retry_payload,
+                pre_sampled,
             }
         });
         self.task_meta

--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -9,6 +9,13 @@ use tracing::{info, warn};
 
 use super::ValidatorLoop;
 use crate::relay::DsperseSubmission;
+
+/// Number of blocks before a slice in `disabled_slices` is reconsidered for
+/// dispatch. Roughly one tempo on subtensor (~12s blocks). Picked so that a
+/// transient network or chain event that synchronously fails every slice
+/// (e.g. a chain RPC reconnect storm) self-heals within the next epoch
+/// rather than persisting until the validator is restarted.
+const DISABLED_SLICE_REHAB_BLOCKS: u64 = 360;
 
 enum ExpectedInputs {
     NoMetadata,
@@ -440,7 +447,16 @@ impl ValidatorLoop {
         };
 
         let work_items: Vec<_> = {
-            let disabled = self.disabled_slices.get(&circuit.id).cloned();
+            let disabled: Option<HashSet<String>> =
+                self.disabled_slices.get(&circuit.id).map(|m| {
+                    m.iter()
+                        .filter(|(_, &disabled_at)| {
+                            self.current_block.saturating_sub(disabled_at)
+                                < DISABLED_SLICE_REHAB_BLOCKS
+                        })
+                        .map(|(slice_id, _)| slice_id.clone())
+                        .collect()
+                });
             match disabled {
                 Some(disabled) if !disabled.is_empty() => {
                     let (kept, skipped): (Vec<_>, Vec<_>) = work_items
@@ -790,6 +806,7 @@ impl ValidatorLoop {
             .map(str::to_string)
         {
             let (_, _, slice_tiles) = self.run_manager.slice_tile_counts(run_uid);
+            let total_slices = slice_tiles.len();
             let candidates: Vec<String> = slice_tiles
                 .into_keys()
                 .filter(|slice_id| {
@@ -797,11 +814,28 @@ impl ValidatorLoop {
                         && self.run_manager.verified_tile_count(run_uid, slice_id) == 0
                 })
                 .collect();
-            if !candidates.is_empty() {
+            // A run that lost every slice with zero verified tiles is much
+            // more likely to be a validator-side network or chain event
+            // (mass QUIC reconnect, RPC stall) than evidence that each slice
+            // is independently unprovable. Refuse to write the disable list
+            // in that case so the validator can self-heal on the next run
+            // instead of trapping itself into a no-dispatch loop. Per-slice
+            // disables still fire when at least one slice in the run made
+            // progress, which is the signal the mechanism was designed for.
+            let all_slices_failed = total_slices > 0 && candidates.len() == total_slices;
+            if all_slices_failed {
+                warn!(
+                    run_uid = %run_uid,
+                    circuit_id = %circuit_id,
+                    total_slices,
+                    "every slice failed with zero verified tiles, treating as run-wide failure and skipping disable-list write"
+                );
+            } else if !candidates.is_empty() {
+                let block = self.current_block;
                 let entry = self.disabled_slices.entry(circuit_id.clone()).or_default();
                 let mut inserted = 0usize;
                 for slice_id in &candidates {
-                    if entry.insert(slice_id.clone()) {
+                    if entry.insert(slice_id.clone(), block).is_none() {
                         inserted += 1;
                     }
                 }
@@ -810,6 +844,7 @@ impl ValidatorLoop {
                         circuit_id = %circuit_id,
                         newly_disabled = inserted,
                         total_disabled_for_circuit = entry.len(),
+                        rehab_blocks = DISABLED_SLICE_REHAB_BLOCKS,
                         "disabled slices with zero verified tiles"
                     );
                 }

--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -464,6 +464,7 @@ impl ValidatorLoop {
                         .partition(|w| !disabled.contains(&w.slice_id));
                     for work in &skipped {
                         self.run_manager.mark_slice_failed(run_uid, &work.slice_id);
+                        self.run_manager.note_slice_skipped(run_uid, &work.slice_id);
                     }
                     if !skipped.is_empty() {
                         info!(
@@ -503,6 +504,7 @@ impl ValidatorLoop {
         };
         for slice_id in &preflight_failed {
             self.run_manager.mark_slice_failed(run_uid, slice_id);
+            self.run_manager.note_slice_skipped(run_uid, slice_id);
         }
         if unsatisfiable > 0 {
             info!(
@@ -814,21 +816,29 @@ impl ValidatorLoop {
                         && self.run_manager.verified_tile_count(run_uid, slice_id) == 0
                 })
                 .collect();
-            // A run that lost every slice with zero verified tiles is much
-            // more likely to be a validator-side network or chain event
-            // (mass QUIC reconnect, RPC stall) than evidence that each slice
-            // is independently unprovable. Refuse to write the disable list
-            // in that case so the validator can self-heal on the next run
-            // instead of trapping itself into a no-dispatch loop. Per-slice
-            // disables still fire when at least one slice in the run made
-            // progress, which is the signal the mechanism was designed for.
-            let all_slices_failed = total_slices > 0 && candidates.len() == total_slices;
-            if all_slices_failed {
+            // The disable-list write is suppressed only when at least one
+            // slice was actually attempted and every attempted slice failed
+            // with zero verified tiles. That signal is characteristic of a
+            // validator-side network or chain event (mass QUIC reconnect,
+            // RPC stall) and would otherwise trap the validator into a
+            // permanent no-dispatch loop. Slices that never reached the
+            // miner — already-disabled entries or preflight rejections —
+            // are tracked via note_slice_skipped at the call sites so they
+            // are excluded from the "attempted" count here. Without that
+            // exclusion, a run where every slice was deterministically
+            // skipped would look identical to a network outage.
+            let skipped = self.run_manager.skipped_slice_count(run_uid);
+            let attempted = total_slices.saturating_sub(skipped);
+            let attempted_failed = candidates.len().saturating_sub(skipped);
+            let run_wide_failure = attempted > 0 && attempted_failed == attempted;
+            if run_wide_failure {
                 warn!(
                     run_uid = %run_uid,
                     circuit_id = %circuit_id,
                     total_slices,
-                    "every slice failed with zero verified tiles, treating as run-wide failure and skipping disable-list write"
+                    skipped,
+                    attempted,
+                    "every attempted slice failed with zero verified tiles, treating as run-wide failure and skipping disable-list write"
                 );
             } else if !candidates.is_empty() {
                 let block = self.current_block;

--- a/crates/sn2-validator/src/validator_loop/mod.rs
+++ b/crates/sn2-validator/src/validator_loop/mod.rs
@@ -65,6 +65,10 @@ pub(super) struct TaskResult {
     pub(super) tile_idx: Option<u32>,
     pub(super) outcome: TaskOutcome,
     pub(super) retry_payload: RetryPayload,
+    // Pre-decided RSV sample disposition. When false, validator never
+    // intended to deep-verify this request, so input/proof bytes may have
+    // been dropped before the response was received.
+    pub(super) pre_sampled: bool,
 }
 
 pub(super) enum TaskOutcome {
@@ -123,6 +127,10 @@ pub(super) struct DispatchedRequest {
     pub(super) retry_payload: RetryPayload,
     pub(super) dsperse_circuit_path: Option<String>,
     pub(super) component_sha: Option<String>,
+    // Pre-rolled RSV sample decision attached at dispatch time. When false,
+    // task_inputs is cleared before the miner task is spawned to avoid
+    // retaining the validator's local input copy across the in-flight window.
+    pub(super) pre_sampled: bool,
 }
 
 pub struct ValidatorLoop {

--- a/crates/sn2-validator/src/validator_loop/mod.rs
+++ b/crates/sn2-validator/src/validator_loop/mod.rs
@@ -5,7 +5,7 @@ mod relay;
 mod results;
 mod verification;
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, VecDeque};
 use std::net::Ipv4Addr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -159,7 +159,13 @@ pub struct ValidatorLoop {
     pub(super) pending_verifications: VecDeque<(TaskResult, bool)>,
     pub(super) verification_concurrency: usize,
     pub(super) dslice_input_scales: HashMap<(String, String), f64>,
-    pub(super) disabled_slices: HashMap<String, HashSet<String>>,
+    // Slices observed to fail across a full benchmark run with zero verified
+    // tiles. Inner map is slice_id -> block_height at disable time so entries
+    // can age out via prune_disabled_slices() once the validator recovers
+    // from a transient network or chain event. Without an age, a single
+    // network-wide reconnect storm leaves slices permanently skipped until
+    // restart.
+    pub(super) disabled_slices: HashMap<String, HashMap<String, u64>>,
     pub(super) rsv: RsvManager,
     pub(super) current_block: u64,
     pub(super) blocks_per_tempo: u64,

--- a/crates/sn2-validator/src/validator_loop/verification.rs
+++ b/crates/sn2-validator/src/validator_loop/verification.rs
@@ -18,8 +18,7 @@ impl ValidatorLoop {
         // until spawn_verification means pending_verifications buffers the
         // full proof payload across the verify-CPU bottleneck for ~95% of
         // responses that take the RSV fast path without needing them.
-        let hotkey = self.uid_hotkeys.get(&uid).cloned().unwrap_or_default();
-        let sample = decide_sample(&result, &hotkey);
+        let sample = decide_sample(&result);
         if !sample && !response_needs_proof_bytes_for_downstream(&result) {
             if let TaskOutcome::Success(ref mut response) = result.outcome {
                 response.proof_content = None;
@@ -247,20 +246,19 @@ impl ValidatorLoop {
     }
 }
 
-fn decide_sample(result: &TaskResult, hotkey: &str) -> bool {
+fn decide_sample(result: &TaskResult) -> bool {
     let has_proof = matches!(result.outcome, TaskOutcome::Success(ref r) if r.proof_size > 0);
     if !has_proof {
         return false;
     }
-    // Honor the pre-decided RSV disposition attached at dispatch. Empty
-    // hotkey is treated as force-sample to match historical post-response
-    // behavior when the metagraph was mid-sync at dispatch time. Force-verify
-    // paths (PoW, customer RWR, external-hash, API dslice) already set
-    // pre_sampled=true at dispatch, so a single boolean covers the decision
-    // once we know proof bytes exist.
-    if hotkey.is_empty() {
-        return true;
-    }
+    // The pre-decision attached at dispatch is authoritative. The historical
+    // empty-hotkey force-sample branch was a safety net for the RSV roll
+    // that used to run here, but it has migrated to pre_decide_sample at
+    // dispatch time. Re-checking hotkey state at verify time would let a
+    // post-dispatch metagraph reshuffle (uid deregistered between dispatch
+    // and response) revive sampling on a request whose task_inputs were
+    // already released, leading to a verification attempt against a missing
+    // input tensor. pre_sampled alone is the correct signal here.
     result.pre_sampled
 }
 

--- a/crates/sn2-validator/src/validator_loop/verification.rs
+++ b/crates/sn2-validator/src/validator_loop/verification.rs
@@ -19,13 +19,7 @@ impl ValidatorLoop {
         // full proof payload across the verify-CPU bottleneck for ~95% of
         // responses that take the RSV fast path without needing them.
         let hotkey = self.uid_hotkeys.get(&uid).cloned().unwrap_or_default();
-        let sample = decide_sample(
-            &result,
-            &hotkey,
-            self.current_block,
-            self.blocks_per_tempo,
-            &mut self.rsv,
-        );
+        let sample = decide_sample(&result, &hotkey);
         if !sample && !response_needs_proof_bytes_for_downstream(&result) {
             if let TaskOutcome::Success(ref mut response) = result.outcome {
                 response.proof_content = None;
@@ -33,6 +27,12 @@ impl ValidatorLoop {
                 response.witness = None;
                 response.raw = None;
                 response.public_json = None;
+                // Also release the validator's local input copy. Pre-sampling
+                // at dispatch already drops most of these before the task is
+                // spawned, but the audit-eligible path still allocates inputs
+                // and this branch lets force-verify-then-no-verify edge cases
+                // (e.g. empty proof on a force_verify request) reclaim them.
+                response.inputs = None;
             }
         }
 
@@ -247,22 +247,41 @@ impl ValidatorLoop {
     }
 }
 
-fn decide_sample(
-    result: &TaskResult,
+fn decide_sample(result: &TaskResult, hotkey: &str) -> bool {
+    let has_proof = matches!(result.outcome, TaskOutcome::Success(ref r) if r.proof_size > 0);
+    if !has_proof {
+        return false;
+    }
+    // Honor the pre-decided RSV disposition attached at dispatch. Empty
+    // hotkey is treated as force-sample to match historical post-response
+    // behavior when the metagraph was mid-sync at dispatch time. Force-verify
+    // paths (PoW, customer RWR, external-hash, API dslice) already set
+    // pre_sampled=true at dispatch, so a single boolean covers the decision
+    // once we know proof bytes exist.
+    if hotkey.is_empty() {
+        return true;
+    }
+    result.pre_sampled
+}
+
+/// Dispatch-time mirror of decide_sample. Runs before the miner task is
+/// spawned so the validator can drop its local copy of task_inputs (and any
+/// other per-request state that would only be needed for deep verification)
+/// for the ~96% of dispatches that take the RSV fast path. Empty hotkey is
+/// preserved as a force-verify case to keep parity with the response-side
+/// decision in case the metagraph is mid-sync at dispatch time.
+pub(super) fn pre_decide_sample(
+    dispatched: &super::DispatchedRequest,
     hotkey: &str,
     current_block: u64,
     blocks_per_tempo: u64,
     rsv: &mut crate::rsv::RsvManager,
 ) -> bool {
-    let has_proof = matches!(result.outcome, TaskOutcome::Success(ref r) if r.proof_size > 0);
-    if !has_proof {
-        return false;
-    }
-    let is_pow = result.request_type == RequestType::ProofOfWeights;
-    let is_customer_rwr = result.request_type == RequestType::Rwr;
-    let has_external_hash = result.external_request_hash.is_some();
+    let is_pow = dispatched.request_type == RequestType::ProofOfWeights;
+    let is_customer_rwr = dispatched.request_type == RequestType::Rwr;
+    let has_external_hash = dispatched.external_request_hash.is_some();
     let is_api_dslice = matches!(
-        &result.retry_payload,
+        &dispatched.retry_payload,
         RetryPayload::DSlice(d) if d.run_source == RunSource::Api
     );
     let force_verify = is_pow || is_customer_rwr || has_external_hash || is_api_dslice;


### PR DESCRIPTION
## Summary

Two independent improvements to validator state management under transient
disruption. Both target testnet so they can soak before promotion to main.

### Rehabilitate `disabled_slices` after run-wide failures

The validator currently writes every slice that ends a benchmark run with
zero verified tiles into a per-circuit disable list, and the only path that
ever clears that list is full circuit deactivation. When the chain RPC
forces a reconnect and the metagraph re-sync triggers a concurrent QUIC
handshake to every miner, those handshakes time out together. The next
benchmark run sees every dslice fail with zero verified tiles, the disable
list absorbs the entire slice set, and the validator transitions into a
state where each subsequent run logs `skipped=N / no circuit slices to
dispatch / combined run complete failed_count=N` and dispatches no work
until the process is restarted. vTrust degrades over the next epoch with
no observable cause in the local logs.

Two changes restore self-healing:

- `finalize_combined_run` no longer writes to `disabled_slices` when every
  slice in the run failed with zero verified tiles. That signal is more
  consistent with a validator-side network or chain disruption than with
  each slice being independently unprovable, and is now logged as a
  run-wide failure for operator visibility.
- `disabled_slices` carries the block height at which each slice was
  disabled, and the dispatch-side filter skips entries older than
  `DISABLED_SLICE_REHAB_BLOCKS` (one tempo). Repeated failures still
  refresh the entry, but transient ones age out cleanly.

### Pre-decide RSV sampling at dispatch time

Random-sample verification rolled at response receipt, which meant the
validator retained `task_inputs` (the local JSON copy of the input tensor)
across the entire in-flight window for every dispatched request even
though only ~4% of those requests would be deep-verified. At steady state
with thousands of concurrent dispatches, the retained inputs were a
dominant contributor to per-request memory footprint and amplified host
memory pressure events.

This change rolls the RSV decision in `dispatch_requests`, attaches the
result to both `DispatchedRequest` and `TaskResult` as `pre_sampled`, and
clears `task_inputs` immediately for the non-sampled path before the
miner task is spawned. Force-verify paths (PoW, customer RWR,
external-hash, API dslice) continue to retain their inputs because
`pre_decide_sample` marks them as pre-sampled regardless of the RSV roll.

`decide_sample` at response time now consults the pre-decision rather than
re-rolling. The defensive `no-proof / empty-response → no-sample`
short-circuit is preserved so an empty response on a force-verified
request still skips verification cleanly. Post-response byte-shedding for
`proof_content` / `witness` / `raw` / `public_json` is also extended to
release `MinerResponse.inputs` on the non-sample path for the residual
case where a force-verified request completes with an empty proof.

Sampling rate and skiplist behavior are unchanged: the RSV roll uses the
same `should_sample` over the same constants, just at an earlier point in
the request lifecycle.

## Test plan

- [x] `cargo check -p sn2-validator`
- [x] `cargo test -p sn2-validator --bin sn2-validator` (87 tests pass)
- [x] `cargo fmt --check`
- [x] `cargo clippy -p sn2-validator --tests -- -D warnings`
- [ ] Deploy to a testnet validator and observe RSS / `active_tasks` /
      `dispatch_budget` health-log metrics over a full epoch
- [ ] Force a chain RPC disconnect on a testnet validator and confirm the
      validator continues to dispatch after the reconnect storm rather
      than locking into the `skipped=N` no-dispatch loop
- [ ] Confirm RSV strike rate and skiplist behavior on testnet match
      historical baseline (the sampling rate and decision logic are
      unchanged, only the moment of the roll has moved)

## Follow-ups (separate PRs)

- Jitter / stagger in `btlightning::update_miner_registry` so a mass
  reconnect does not synchronize on a single timeout boundary in the
  first place. Tracking separately because it lands in `btlightning`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Disabled slices now automatically rehabilitate after a configurable block window.
  * Validator now tracks skipped slices per run to improve run-level failure handling.

* **Bug Fixes**
  * Avoids persisting a disable-list when all attempted slices produce no verified work, preventing permanent lockout.
  * Clears unnecessary task inputs before miner execution to reduce memory retention.

* **Refactor**
  * Sampling decision moved earlier in dispatch; pre-sampling is propagated so non‑sampled work can drop inputs/proofs before execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inference-labs-inc/subnet-2/pull/509?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->