### PR TITLE
Resolve disabled-slice rehab clock reset on re-skipped slices

### DIFF
--- a/crates/sn2-validator/src/incremental_runner.rs
+++ b/crates/sn2-validator/src/incremental_runner.rs
@@ -415,6 +415,17 @@ impl IncrementalRunManager {
             .unwrap_or(0)
     }
 
+    /// Returns true when the slice was marked failed without ever being
+    /// dispatched in this run (already-disabled, preflight rejection, etc.).
+    /// finalize_combined_run uses this to keep skipped slices out of the
+    /// disable-list write — they were never attempted, so resetting their
+    /// disabled_at block would defeat the rehab cooldown.
+    pub fn is_slice_skipped(&self, run_uid: &str, slice_id: &str) -> bool {
+        self.skipped_slices
+            .get(run_uid)
+            .is_some_and(|s| s.contains(slice_id))
+    }
+
     pub fn is_run_complete(&self, run_uid: &str) -> bool {
         self.runs
             .get(run_uid)
@@ -601,6 +612,45 @@ mod tests {
             matches!(result, OutputConsistency::Consistent { .. }),
             "near-zero values should not trigger false positives, got {result:?}"
         );
+    }
+
+    #[test]
+    fn is_slice_skipped_false_before_noting() {
+        let mgr = make_manager_with_run("run-1");
+        assert!(!mgr.is_slice_skipped("run-1", "slice_a"));
+    }
+
+    #[test]
+    fn is_slice_skipped_true_after_noting() {
+        let mut mgr = make_manager_with_run("run-1");
+        mgr.note_slice_skipped("run-1", "slice_a");
+        assert!(mgr.is_slice_skipped("run-1", "slice_a"));
+        assert!(!mgr.is_slice_skipped("run-1", "slice_b"));
+    }
+
+    #[test]
+    fn is_slice_skipped_scoped_to_run_uid() {
+        let mut mgr = make_manager_with_run("run-1");
+        mgr.start_run(
+            "run-2".to_string(),
+            "test-circuit".to_string(),
+            "test".to_string(),
+            RunSource::Benchmark,
+            None,
+            None,
+        );
+        mgr.note_slice_skipped("run-1", "slice_a");
+        assert!(mgr.is_slice_skipped("run-1", "slice_a"));
+        assert!(!mgr.is_slice_skipped("run-2", "slice_a"));
+    }
+
+    #[test]
+    fn skipped_slices_cleared_on_run_removal() {
+        let mut mgr = make_manager_with_run("run-1");
+        mgr.note_slice_skipped("run-1", "slice_a");
+        mgr.remove_run("run-1");
+        assert!(!mgr.is_slice_skipped("run-1", "slice_a"));
+        assert_eq!(mgr.skipped_slice_count("run-1"), 0);
     }
 
     #[test]

--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -809,10 +809,21 @@ impl ValidatorLoop {
         {
             let (_, _, slice_tiles) = self.run_manager.slice_tile_counts(run_uid);
             let total_slices = slice_tiles.len();
+            // Candidates for the disable-list write are slices that were
+            // actually attempted in this run, returned without producing a
+            // verified tile, and ended up marked failed. Slices that were
+            // marked failed via the skip path (already-disabled, preflight
+            // rejected) are excluded here so that the disabled_at clock for
+            // already-disabled slices is not re-stamped to current_block on
+            // every subsequent run. Re-stamping would defeat the
+            // DISABLED_SLICE_REHAB_BLOCKS cooldown — a slice that ever
+            // landed in disabled_slices would never age out because each
+            // run would push its disabled_at forward.
             let candidates: Vec<String> = slice_tiles
                 .into_keys()
                 .filter(|slice_id| {
-                    self.run_manager.is_slice_failed(run_uid, slice_id)
+                    !self.run_manager.is_slice_skipped(run_uid, slice_id)
+                        && self.run_manager.is_slice_failed(run_uid, slice_id)
                         && self.run_manager.verified_tile_count(run_uid, slice_id) == 0
                 })
                 .collect();
@@ -823,14 +834,12 @@ impl ValidatorLoop {
             // RPC stall) and would otherwise trap the validator into a
             // permanent no-dispatch loop. Slices that never reached the
             // miner — already-disabled entries or preflight rejections —
-            // are tracked via note_slice_skipped at the call sites so they
-            // are excluded from the "attempted" count here. Without that
-            // exclusion, a run where every slice was deterministically
-            // skipped would look identical to a network outage.
+            // are tracked via note_slice_skipped at the call sites and
+            // already excluded from the candidates filter above, so
+            // candidates.len() is exactly the attempted-and-failed count.
             let skipped = self.run_manager.skipped_slice_count(run_uid);
             let attempted = total_slices.saturating_sub(skipped);
-            let attempted_failed = candidates.len().saturating_sub(skipped);
-            let run_wide_failure = attempted > 0 && attempted_failed == attempted;
+            let run_wide_failure = attempted > 0 && candidates.len() == attempted;
             if run_wide_failure {
                 warn!(
                     run_uid = %run_uid,


### PR DESCRIPTION
## Summary

The `DISABLED_SLICE_REHAB_BLOCKS` cooldown introduced alongside the disabled-slice rehab logic does not actually age slices out. Once a slice lands in `disabled_slices`, its `disabled_at` block is re-stamped to `current_block` on every subsequent run, holding it disabled until validator restart.

## Root cause

In `finalize_combined_run` (`crates/sn2-validator/src/validator_loop/dslice.rs`):

```rust
let candidates: Vec<String> = slice_tiles
    .into_keys()
    .filter(|slice_id| {
        self.run_manager.is_slice_failed(run_uid, slice_id)
            && self.run_manager.verified_tile_count(run_uid, slice_id) == 0
    })
    .collect();
…
} else if !candidates.is_empty() {
    let block = self.current_block;
    let entry = self.disabled_slices.entry(circuit_id.clone()).or_default();
    let mut inserted = 0usize;
    for slice_id in &candidates {
        if entry.insert(slice_id.clone(), block).is_none() {
            inserted += 1;
        }
    }
```

Two interacting facts make this re-stamp every disabled slice:

1. The dispatch-time filter in `dispatch_work_items_for_circuit` puts currently-disabled (within rehab) slices into `skipped`, then calls `self.run_manager.mark_slice_failed(run_uid, &work.slice_id)` on each. `mark_slice_failed` moves the slice from `pending_slices` into `failed_slices` on the fresh `CombinedRun` for this run, so `is_slice_failed(run_uid, sid)` returns true for them.
2. `HashMap::insert(k, v)` unconditionally replaces the value when the key exists, returning the old value via `Some(old)`. The `.is_none()` check only gates the `inserted` counter — the side effect (`entry["S"] = current_block`) always happens.

So every run that skips slice `S` for being disabled overwrites `S`'s `disabled_at` block. The dispatch-time filter `current_block - disabled_at < 360` therefore stays true forever.

## Fix

- Add `IncrementalRunManager::is_slice_skipped(run_uid, slice_id)` alongside the existing `note_slice_skipped` / `skipped_slice_count` surface.
- Exclude skipped slices from `candidates` in `finalize_combined_run` so the disable-list write only touches slices that were actually attempted in this run.
- Simplify the run-wide failure detection now that `candidates.len()` is exactly the attempted-and-failed count: `candidates.len() == attempted` replaces the saturating-sub bookkeeping.

Newly attempted-and-failed slices still get a fresh `disabled_at` stamp via the same `entry.insert` call. Once their block is older than `DISABLED_SLICE_REHAB_BLOCKS`, the dispatch-time filter excludes them from the active disabled set on the next run and they get a retry opportunity.

## Test plan

- [x] New unit tests for `is_slice_skipped`: false-before-noting, true-after-noting, per-`run_uid` scoping, cleared on `remove_run`.
- [x] `cargo test -p sn2-validator incremental_runner::` — 17 pass (13 existing + 4 new).
- [x] `cargo build -p sn2-validator` clean.
- [x] `cargo fmt -p sn2-validator --check` clean.
- [ ] CI to confirm clippy `-D warnings` and full workspace tests.
- [ ] Operator smoke on testnet: confirm a slice that lands in `disabled_slices` ages out after 360 blocks (~72 min) and re-enters dispatch.

## Targets

Branched off `origin/testnet` because the affected code (#509) is on the testnet branch and has not landed on `main` yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Validation runs now track which slices were skipped during execution.

* **Bug Fixes**
  * Improved detection of true run-wide failures by correctly distinguishing skipped slices from failed execution attempts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inference-labs-inc/subnet-2/pull/512?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->