### PR TITLE
Introduce dispatch cooldown for sustained-failure miners

### DIFF
--- a/crates/sn2-types/src/constants.rs
+++ b/crates/sn2-types/src/constants.rs
@@ -40,6 +40,13 @@ pub const CAPACITY_RAMP_MIN_AVAIL_MEM_RATIO: f64 = 0.20;
 pub const CAPACITY_PRESSURE_BACKOFF_FACTOR: f64 = 0.10;
 pub const IP_REGION_CAP_FRACTION: f64 = 0.25;
 
+/// Block-height cooldown applied to disabled slices and to miners whose
+/// adaptive capacity ratchets below 1. Approximately one mainnet epoch
+/// (~72 minutes at 12s blocks) — long enough for transient miner faults
+/// or chain-side reconnect storms to self-heal, short enough that a
+/// recovered miner re-enters dispatch within the same scoring window.
+pub const REHAB_BLOCKS: u64 = 360;
+
 pub const MAX_POW_QUEUE_SIZE: usize = 1024;
 pub const POW_OUTPUT_STRIDE: usize = MAX_POW_QUEUE_SIZE;
 pub const POW_SCORES_OFFSET: usize = 0;

--- a/crates/sn2-validator/src/performance.rs
+++ b/crates/sn2-validator/src/performance.rs
@@ -53,6 +53,14 @@ const MAX_BUFFERED_CAP_EVENTS: usize = 4096;
 pub enum CapDirection {
     Ramp,
     Backoff,
+    /// Cap ratcheted from 1 down to 0 — miner is excluded from dispatch
+    /// until a `REHAB_BLOCKS`-bounded cooldown elapses. Emitted only at the
+    /// 1->0 boundary, not on every sustained-failure window.
+    Evict,
+    /// Cap restored from 0 back to 1 after the cooldown elapsed. The miner
+    /// gets a single probe slot; the existing ramp-up logic decides whether
+    /// they climb back or land in another Evict.
+    Rehab,
 }
 
 #[derive(Clone, Debug)]
@@ -71,6 +79,10 @@ pub struct PerformanceTracker {
     adaptive_caps: HashMap<u16, usize>,
     at_cap_results: HashMap<u16, VecDeque<bool>>,
     cap_events: Vec<CapEvent>,
+    /// Uids whose cap just dropped to 0. Drained by the validator loop
+    /// to populate `dispatch_cooldowns` so the queryable filter excludes
+    /// them for `REHAB_BLOCKS`.
+    pending_evictions: Vec<(u16, String)>,
     persistence_path: Option<PathBuf>,
 }
 
@@ -96,6 +108,7 @@ impl PerformanceTracker {
             adaptive_caps: HashMap::new(),
             at_cap_results: HashMap::new(),
             cap_events: Vec::new(),
+            pending_evictions: Vec::new(),
             persistence_path: Some(path),
         };
         tracker.load();
@@ -480,9 +493,18 @@ impl PerformanceTracker {
             if let Some(r) = self.at_cap_results.get_mut(&uid) {
                 r.clear();
             }
-        } else if success_rate < CAPACITY_BACKOFF_THRESHOLD && *current > 1 {
+        } else if success_rate < CAPACITY_BACKOFF_THRESHOLD && *current > 0 {
             *current -= 1;
-            direction = Some(CapDirection::Backoff);
+            // 1 -> 0 is a terminal eviction; the caller will add the hotkey
+            // to dispatch_cooldowns so the queryable filter excludes it for
+            // REHAB_BLOCKS. Sustained-failure decrements above 1 still emit
+            // the normal Backoff direction.
+            direction = if *current == 0 {
+                self.pending_evictions.push((uid, hotkey.to_string()));
+                Some(CapDirection::Evict)
+            } else {
+                Some(CapDirection::Backoff)
+            };
             if let Some(r) = self.at_cap_results.get_mut(&uid) {
                 r.clear();
             }
@@ -513,6 +535,43 @@ impl PerformanceTracker {
     pub fn drain_cap_events(&mut self) -> Vec<CapEvent> {
         std::mem::take(&mut self.cap_events)
     }
+
+    /// Drain the set of (uid, hotkey) pairs whose adaptive cap just hit zero.
+    /// The validator loop consumes this on every dispatch tick and inserts
+    /// the hotkeys into `dispatch_cooldowns` with a `REHAB_BLOCKS` expiry.
+    pub fn drain_pending_evictions(&mut self) -> Vec<(u16, String)> {
+        std::mem::take(&mut self.pending_evictions)
+    }
+
+    /// Restore an evicted miner's cap from 0 back to 1, clearing the at-cap
+    /// result window so the next probe response starts a fresh ramp-up
+    /// evaluation. No-op for miners that are not currently at 0. Emits a
+    /// `CapDirection::Rehab` event for telemetry.
+    pub fn rehabilitate(&mut self, uid: u16, hotkey: &str) {
+        let current = match self.adaptive_caps.get_mut(&uid) {
+            Some(c) if *c == 0 => c,
+            _ => return,
+        };
+        let cap_from = *current;
+        *current = 1;
+        let cap_to = *current;
+        if let Some(r) = self.at_cap_results.get_mut(&uid) {
+            r.clear();
+        }
+        self.cap_events.push(CapEvent {
+            uid,
+            hotkey: hotkey.to_string(),
+            direction: CapDirection::Rehab,
+            cap_from,
+            cap_to,
+            success_rate: 0.0,
+            at: Instant::now(),
+        });
+        if self.cap_events.len() > MAX_BUFFERED_CAP_EVENTS {
+            let drop = self.cap_events.len() - MAX_BUFFERED_CAP_EVENTS;
+            self.cap_events.drain(0..drop);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -525,6 +584,7 @@ mod tests {
             adaptive_caps: HashMap::new(),
             at_cap_results: HashMap::new(),
             cap_events: Vec::new(),
+            pending_evictions: Vec::new(),
             persistence_path: None,
         }
     }
@@ -720,5 +780,85 @@ mod tests {
         let remaining = tracker.drain_cap_events();
         assert_eq!(remaining.len(), 1);
         assert_eq!(remaining[0].hotkey, "hk_new");
+    }
+
+    fn run_at_cap_failures(tracker: &mut PerformanceTracker, uid: u16, hotkey: &str, n: usize) {
+        for _ in 0..n {
+            tracker.record(uid, hotkey, false, 1.0, true);
+        }
+    }
+
+    #[test]
+    fn cap_ratchets_below_one_to_zero_on_sustained_failure() {
+        let mut tracker = test_tracker();
+        // Ramp to a higher cap first by running successful at-cap windows.
+        for _ in 0..(CAPACITY_MIN_AT_CAP * 3) {
+            tracker.record(1, "hk", true, 1.0, true);
+        }
+        assert!(tracker.adaptive_caps.get(&1).copied().unwrap_or(0) >= 2);
+        // Now ratchet down with failure windows until we hit 0.
+        for _ in 0..30 {
+            run_at_cap_failures(&mut tracker, 1, "hk", CAPACITY_MIN_AT_CAP);
+            if tracker.adaptive_caps.get(&1).copied() == Some(0) {
+                break;
+            }
+        }
+        assert_eq!(tracker.adaptive_caps.get(&1).copied(), Some(0));
+    }
+
+    #[test]
+    fn cap_drop_to_zero_emits_evict_event_and_pending_eviction() {
+        let mut tracker = test_tracker();
+        // Force the at-cap window full of failures; cap starts at default 1.
+        run_at_cap_failures(&mut tracker, 7, "hk_dead", CAPACITY_MIN_AT_CAP);
+        assert_eq!(tracker.adaptive_caps.get(&7).copied(), Some(0));
+        let events = tracker.drain_cap_events();
+        let evict = events
+            .iter()
+            .find(|e| matches!(e.direction, CapDirection::Evict))
+            .expect("expected Evict event");
+        assert_eq!(evict.uid, 7);
+        assert_eq!(evict.hotkey, "hk_dead");
+        assert_eq!(evict.cap_from, 1);
+        assert_eq!(evict.cap_to, 0);
+        let evicted = tracker.drain_pending_evictions();
+        assert_eq!(evicted, vec![(7, "hk_dead".to_string())]);
+    }
+
+    #[test]
+    fn drain_pending_evictions_clears() {
+        let mut tracker = test_tracker();
+        run_at_cap_failures(&mut tracker, 7, "hk_dead", CAPACITY_MIN_AT_CAP);
+        assert!(!tracker.drain_pending_evictions().is_empty());
+        assert!(tracker.drain_pending_evictions().is_empty());
+    }
+
+    #[test]
+    fn rehabilitate_restores_cap_from_zero_to_one() {
+        let mut tracker = test_tracker();
+        run_at_cap_failures(&mut tracker, 7, "hk_dead", CAPACITY_MIN_AT_CAP);
+        let _ = tracker.drain_cap_events();
+        tracker.rehabilitate(7, "hk_dead");
+        assert_eq!(tracker.adaptive_caps.get(&7).copied(), Some(1));
+        let events = tracker.drain_cap_events();
+        assert!(events
+            .iter()
+            .any(|e| matches!(e.direction, CapDirection::Rehab)));
+        // at-cap window cleared so the next probe doesn't carry old failures.
+        assert!(tracker
+            .at_cap_results
+            .get(&7)
+            .map(|r| r.is_empty())
+            .unwrap_or(true));
+    }
+
+    #[test]
+    fn rehabilitate_is_noop_when_cap_is_nonzero() {
+        let mut tracker = test_tracker();
+        tracker.adaptive_caps.insert(7, 3);
+        tracker.rehabilitate(7, "hk_alive");
+        assert_eq!(tracker.adaptive_caps.get(&7).copied(), Some(3));
+        let events = tracker.drain_cap_events();
+        assert!(events.is_empty());
     }
 }

--- a/crates/sn2-validator/src/stats_reporter.rs
+++ b/crates/sn2-validator/src/stats_reporter.rs
@@ -272,6 +272,8 @@ impl StatsReporter {
                 let direction = match e.direction {
                     CapDirection::Ramp => "ramp",
                     CapDirection::Backoff => "backoff",
+                    CapDirection::Evict => "evict",
+                    CapDirection::Rehab => "rehab",
                 };
                 let elapsed_ms = now.saturating_duration_since(e.at).as_millis() as u64;
                 serde_json::json!({

--- a/crates/sn2-validator/src/validator_loop/dispatch.rs
+++ b/crates/sn2-validator/src/validator_loop/dispatch.rs
@@ -56,7 +56,7 @@ impl ValidatorLoop {
             .neurons
             .iter()
             .filter(|n| {
-                if let Some(&until) = self.reconnect_blacklist.get(&n.hotkey) {
+                if let Some(&until) = self.dispatch_cooldowns.get(&n.hotkey) {
                     if current_block < until {
                         return false;
                     }
@@ -141,6 +141,28 @@ impl ValidatorLoop {
     }
 
     fn refresh_dispatch_cache_if_stale(&mut self, queryable_uids: &[u16]) {
+        // Always drain pending evictions even when the cache is fresh, so a
+        // 1->0 cap transition that happens between cache refreshes still
+        // lands in dispatch_cooldowns and excludes the miner on the next
+        // queryable filter pass.
+        let evicted = self.performance_tracker.drain_pending_evictions();
+        if !evicted.is_empty() {
+            let until = self.current_block.saturating_add(sn2_types::REHAB_BLOCKS);
+            for (uid, hotkey) in &evicted {
+                self.dispatch_cooldowns
+                    .insert(hotkey.clone(), until)
+                    .is_none()
+                    .then(|| {
+                        tracing::info!(
+                            uid = *uid,
+                            until_block = until,
+                            rehab_blocks = sn2_types::REHAB_BLOCKS,
+                            "miner evicted from dispatch — capacity ratcheted to 0, cooldown until block"
+                        );
+                    });
+            }
+        }
+
         let fresh = self
             .dispatch_cache
             .refreshed_at

--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -9,13 +9,7 @@ use tracing::{info, warn};
 
 use super::ValidatorLoop;
 use crate::relay::DsperseSubmission;
-
-/// Number of blocks before a slice in `disabled_slices` is reconsidered for
-/// dispatch. Roughly one tempo on subtensor (~12s blocks). Picked so that a
-/// transient network or chain event that synchronously fails every slice
-/// (e.g. a chain RPC reconnect storm) self-heals within the next epoch
-/// rather than persisting until the validator is restarted.
-const DISABLED_SLICE_REHAB_BLOCKS: u64 = 360;
+use sn2_types::REHAB_BLOCKS as DISABLED_SLICE_REHAB_BLOCKS;
 
 enum ExpectedInputs {
     NoMetadata,

--- a/crates/sn2-validator/src/validator_loop/maintenance.rs
+++ b/crates/sn2-validator/src/validator_loop/maintenance.rs
@@ -261,15 +261,29 @@ impl ValidatorLoop {
         self.score_manager.sync_uids(&uids);
         self.rsv
             .prune_expired(self.current_block, self.blocks_per_tempo);
-        let blacklist_before = self.reconnect_blacklist.len();
-        self.reconnect_blacklist
-            .retain(|_, until| self.current_block < *until);
-        let blacklist_after = self.reconnect_blacklist.len();
-        if blacklist_before != blacklist_after {
+        let cooldowns_before = self.dispatch_cooldowns.len();
+        let expired_hotkeys: Vec<String> = self
+            .dispatch_cooldowns
+            .iter()
+            .filter(|(_, &until)| self.current_block >= until)
+            .map(|(hk, _)| hk.clone())
+            .collect();
+        for hk in &expired_hotkeys {
+            self.dispatch_cooldowns.remove(hk);
+            // Re-arm the miner with one probe slot. If the probe fails,
+            // the at-cap window will refill with mostly-zero successes
+            // and the next `update_adaptive_cap` will Evict them again.
+            if let Some(uid) = self.config.metagraph.get_uid_by_hotkey(hk) {
+                self.performance_tracker.rehabilitate(uid, hk);
+            }
+        }
+        let cooldowns_after = self.dispatch_cooldowns.len();
+        if cooldowns_before != cooldowns_after {
             info!(
-                expired = blacklist_before - blacklist_after,
-                remaining = blacklist_after,
-                "reconnect_blacklist pruned"
+                expired = cooldowns_before - cooldowns_after,
+                remaining = cooldowns_after,
+                rehab_blocks = sn2_types::REHAB_BLOCKS,
+                "dispatch_cooldowns pruned"
             );
         }
 
@@ -456,7 +470,7 @@ impl ValidatorLoop {
                     if self.rsv.is_skiplisted(hk, current_block) {
                         return true;
                     }
-                    self.reconnect_blacklist
+                    self.dispatch_cooldowns
                         .get(hk)
                         .is_some_and(|&until| current_block < until)
                 })

--- a/crates/sn2-validator/src/validator_loop/mod.rs
+++ b/crates/sn2-validator/src/validator_loop/mod.rs
@@ -179,7 +179,7 @@ pub struct ValidatorLoop {
     pub(super) blocks_per_tempo: u64,
     pub(super) consecutive_metagraph_failures: u32,
     pub(super) dispatch_cache: dispatch::DispatchCache,
-    pub(super) reconnect_blacklist: HashMap<String, u64>,
+    pub(super) dispatch_cooldowns: HashMap<String, u64>,
 }
 
 pub(super) const METAGRAPH_FAILURE_RECONNECT_THRESHOLD: u32 = 3;
@@ -388,7 +388,7 @@ impl ValidatorLoop {
             blocks_per_tempo: 360,
             consecutive_metagraph_failures: 0,
             dispatch_cache: dispatch::DispatchCache::new(),
-            reconnect_blacklist: HashMap::new(),
+            dispatch_cooldowns: HashMap::new(),
         })
     }
 

--- a/crates/sn2-validator/src/validator_loop/results.rs
+++ b/crates/sn2-validator/src/validator_loop/results.rs
@@ -348,7 +348,7 @@ impl ValidatorLoop {
                 self.blocks_per_tempo
             };
             let until = self.current_block + bpt;
-            self.reconnect_blacklist.insert(hotkey.to_string(), until);
+            self.dispatch_cooldowns.insert(hotkey.to_string(), until);
         }
 
         let is_verification_failure = reason.starts_with("verification failed")


### PR DESCRIPTION
## Summary

Mainnet validators are seeing 80-90% slice failure rates per benchmark run because a small set of broken miners (6 UIDs accounting for ~99% of all retry-exhausting query failures in the validator log) keep absorbing the dispatch budget. The adaptive-cap mechanism in `performance.rs` already ratchets these miners down via `update_adaptive_cap`, but the ratchet **floors at 1** — they stay in the dispatch pool indefinitely, queueing up just enough work to fail fast and free their capacity for more work.

Scoring weight for those miners is already 0 (the throughput formula is `rate × cap`, and `rate ≈ 0`), so this is purely a dispatch-efficiency issue, not a payments one.

## Change

Reuse the existing `reconnect_blacklist` primitive — rename to `dispatch_cooldowns` to reflect its more general role: any hotkey in the map is excluded from `queryable_uids` until its block-height value expires, regardless of the reason it landed there.

- **Relax the cap floor**: `update_adaptive_cap` allows the cap to fall to 0 instead of clamping at 1. The 1→0 transition emits `CapDirection::Evict` and pushes `(uid, hotkey)` onto a new `pending_evictions` queue.
- **Drain + cooldown insert**: every dispatch refresh, the validator loop drains `pending_evictions` and inserts cooldown entries with `current_block + REHAB_BLOCKS` expiry.
- **Rehabilitation on expiry**: the maintenance loop's existing cooldown-prune path now calls `PerformanceTracker::rehabilitate(uid, hotkey)` for each expired entry — restores cap from 0 to 1 and clears the at-cap window so the next probe starts a fresh evaluation. The existing 8-sample ramp-up logic then decides whether the miner climbs back or lands in another Evict.
- **Shared constant**: hoists `REHAB_BLOCKS = 360` into `sn2-types/constants.rs`, replacing the per-module `DISABLED_SLICE_REHAB_BLOCKS` from #509. Operators tune one knob.

## Properties

- Symmetric with the disabled-slice rehab from #509 — same 360-block (~72min mainnet, ~20min testnet) self-healing window, same primitive.
- No new state machine. Reuses `dispatch_cooldowns` (renamed `reconnect_blacklist`), reuses ramp-up logic, reuses cap event telemetry.
- Single failed probe at cap=1 won't immediately re-evict because the at-cap window needs 8 samples before re-evaluating. A broken miner gets 8 wasted dispatches per epoch, down from thousands.
- Stats reporter learns two new cap-event directions: `"evict"`, `"rehab"`. Telemetry remains lossless.

## Test plan

- [x] `cargo test -p sn2-validator performance::` — 20 tests pass, 5 new:
  - `cap_ratchets_below_one_to_zero_on_sustained_failure`
  - `cap_drop_to_zero_emits_evict_event_and_pending_eviction`
  - `drain_pending_evictions_clears`
  - `rehabilitate_restores_cap_from_zero_to_one`
  - `rehabilitate_is_noop_when_cap_is_nonzero`
- [x] `cargo build -p sn2-validator` clean.
- [x] `cargo fmt --check` clean.
- [ ] CI for clippy + full workspace.
- [ ] Mainnet smoke after merge: confirm uid=37 and friends drop out of `queryable_uids` within their first at-cap evaluation window and re-appear ~360 blocks later for a single probe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added miner rehabilitation system: miners experiencing performance degradation or reaching zero capacity can now be temporarily disabled and automatically restored after a configurable block-height cooldown period.

* **Improvements**
  * Enhanced dispatch filtering and cooldown management for improved control over miner availability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inference-labs-inc/subnet-2/pull/513?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->