### PR TITLE
Develop dispatch main-loop throughput optimizations

### DIFF
--- a/crates/sn2-types/src/constants.rs
+++ b/crates/sn2-types/src/constants.rs
@@ -40,6 +40,13 @@ pub const CAPACITY_RAMP_MIN_AVAIL_MEM_RATIO: f64 = 0.20;
 pub const CAPACITY_PRESSURE_BACKOFF_FACTOR: f64 = 0.10;
 pub const IP_REGION_CAP_FRACTION: f64 = 0.25;
 
+/// Block-height cooldown applied to disabled slices and to miners whose
+/// adaptive capacity ratchets below 1. Approximately one mainnet epoch
+/// (~72 minutes at 12s blocks) — long enough for transient miner faults
+/// or chain-side reconnect storms to self-heal, short enough that a
+/// recovered miner re-enters dispatch within the same scoring window.
+pub const REHAB_BLOCKS: u64 = 360;
+
 pub const MAX_POW_QUEUE_SIZE: usize = 1024;
 pub const POW_OUTPUT_STRIDE: usize = MAX_POW_QUEUE_SIZE;
 pub const POW_SCORES_OFFSET: usize = 0;

--- a/crates/sn2-validator/src/performance.rs
+++ b/crates/sn2-validator/src/performance.rs
@@ -386,6 +386,7 @@ impl PerformanceTracker {
                     .map(|v| v.iter().filter_map(|b| b.as_bool()).collect())
                     .unwrap_or_default();
                 self.adaptive_caps.insert(uid, cap);
+                self.at_cap_last_touched.insert(uid, Instant::now());
                 if !results.is_empty() {
                     self.at_cap_results.insert(uid, results);
                 }
@@ -557,6 +558,9 @@ impl PerformanceTracker {
             *current -= 1;
             let cap_to = *current;
             decayed += 1;
+            if let Some(r) = self.at_cap_results.get_mut(&uid) {
+                r.clear();
+            }
             let hotkey = uid_hotkeys.get(&uid).cloned().unwrap_or_default();
             let direction = if cap_to == 0 {
                 self.pending_evictions.push((uid, hotkey.clone()));

--- a/crates/sn2-validator/src/performance.rs
+++ b/crates/sn2-validator/src/performance.rs
@@ -53,13 +53,7 @@ const MAX_BUFFERED_CAP_EVENTS: usize = 4096;
 pub enum CapDirection {
     Ramp,
     Backoff,
-    /// Cap ratcheted from 1 down to 0 — miner is excluded from dispatch
-    /// until a `REHAB_BLOCKS`-bounded cooldown elapses. Emitted only at the
-    /// 1->0 boundary, not on every sustained-failure window.
     Evict,
-    /// Cap restored from 0 back to 1 after the cooldown elapsed. The miner
-    /// gets a single probe slot; the existing ramp-up logic decides whether
-    /// they climb back or land in another Evict.
     Rehab,
 }
 
@@ -79,12 +73,12 @@ pub struct PerformanceTracker {
     adaptive_caps: HashMap<u16, usize>,
     at_cap_results: HashMap<u16, VecDeque<bool>>,
     cap_events: Vec<CapEvent>,
-    /// Uids whose cap just dropped to 0. Drained by the validator loop
-    /// to populate `dispatch_cooldowns` so the queryable filter excludes
-    /// them for `REHAB_BLOCKS`.
     pending_evictions: Vec<(u16, String)>,
+    at_cap_last_touched: HashMap<u16, Instant>,
     persistence_path: Option<PathBuf>,
 }
+
+const CAP_DECAY_IDLE_SECS: u64 = 600;
 
 fn window_ttl() -> Duration {
     Duration::from_secs(VERIFICATION_WINDOW_BLOCKS * BLOCK_TIME_SECS)
@@ -109,6 +103,7 @@ impl PerformanceTracker {
             at_cap_results: HashMap::new(),
             cap_events: Vec::new(),
             pending_evictions: Vec::new(),
+            at_cap_last_touched: HashMap::new(),
             persistence_path: Some(path),
         };
         tracker.load();
@@ -152,6 +147,7 @@ impl PerformanceTracker {
             if results.len() > CAPACITY_WINDOW_SIZE {
                 results.pop_front();
             }
+            self.at_cap_last_touched.insert(uid, now);
             self.update_adaptive_cap(uid, hotkey);
         }
     }
@@ -495,10 +491,6 @@ impl PerformanceTracker {
             }
         } else if success_rate < CAPACITY_BACKOFF_THRESHOLD && *current > 0 {
             *current -= 1;
-            // 1 -> 0 is a terminal eviction; the caller will add the hotkey
-            // to dispatch_cooldowns so the queryable filter excludes it for
-            // REHAB_BLOCKS. Sustained-failure decrements above 1 still emit
-            // the normal Backoff direction.
             direction = if *current == 0 {
                 self.pending_evictions.push((uid, hotkey.to_string()));
                 Some(CapDirection::Evict)
@@ -536,17 +528,53 @@ impl PerformanceTracker {
         std::mem::take(&mut self.cap_events)
     }
 
-    /// Drain the set of (uid, hotkey) pairs whose adaptive cap just hit zero.
-    /// The validator loop consumes this on every dispatch tick and inserts
-    /// the hotkeys into `dispatch_cooldowns` with a `REHAB_BLOCKS` expiry.
     pub fn drain_pending_evictions(&mut self) -> Vec<(u16, String)> {
         std::mem::take(&mut self.pending_evictions)
     }
 
-    /// Restore an evicted miner's cap from 0 back to 1, clearing the at-cap
-    /// result window so the next probe response starts a fresh ramp-up
-    /// evaluation. No-op for miners that are not currently at 0. Emits a
-    /// `CapDirection::Rehab` event for telemetry.
+    pub fn decay_idle_caps(&mut self, uid_hotkeys: &HashMap<u16, String>) -> usize {
+        let now = Instant::now();
+        let idle = Duration::from_secs(CAP_DECAY_IDLE_SECS);
+        let mut decayed = 0usize;
+        let uids: Vec<u16> = self
+            .adaptive_caps
+            .iter()
+            .filter(|(_, &cap)| cap > 1)
+            .filter(|(uid, _)| {
+                self.at_cap_last_touched
+                    .get(uid)
+                    .map(|t| now.duration_since(*t) > idle)
+                    .unwrap_or(true)
+            })
+            .map(|(uid, _)| *uid)
+            .collect();
+        for uid in uids {
+            let current = self.adaptive_caps.entry(uid).or_insert(1);
+            if *current <= 1 {
+                continue;
+            }
+            let cap_from = *current;
+            *current -= 1;
+            let cap_to = *current;
+            decayed += 1;
+            let hotkey = uid_hotkeys.get(&uid).cloned().unwrap_or_default();
+            self.cap_events.push(CapEvent {
+                uid,
+                hotkey,
+                direction: CapDirection::Backoff,
+                cap_from,
+                cap_to,
+                success_rate: 0.0,
+                at: now,
+            });
+            if self.cap_events.len() > MAX_BUFFERED_CAP_EVENTS {
+                let drop = self.cap_events.len() - MAX_BUFFERED_CAP_EVENTS;
+                self.cap_events.drain(0..drop);
+            }
+        }
+        decayed
+    }
+
     pub fn rehabilitate(&mut self, uid: u16, hotkey: &str) {
         let current = match self.adaptive_caps.get_mut(&uid) {
             Some(c) if *c == 0 => c,
@@ -558,6 +586,7 @@ impl PerformanceTracker {
         if let Some(r) = self.at_cap_results.get_mut(&uid) {
             r.clear();
         }
+        self.at_cap_last_touched.insert(uid, Instant::now());
         self.cap_events.push(CapEvent {
             uid,
             hotkey: hotkey.to_string(),
@@ -585,6 +614,7 @@ mod tests {
             at_cap_results: HashMap::new(),
             cap_events: Vec::new(),
             pending_evictions: Vec::new(),
+            at_cap_last_touched: HashMap::new(),
             persistence_path: None,
         }
     }

--- a/crates/sn2-validator/src/performance.rs
+++ b/crates/sn2-validator/src/performance.rs
@@ -539,7 +539,7 @@ impl PerformanceTracker {
         let uids: Vec<u16> = self
             .adaptive_caps
             .iter()
-            .filter(|(_, &cap)| cap > 1)
+            .filter(|(_, &cap)| cap > 0)
             .filter(|(uid, _)| {
                 self.at_cap_last_touched
                     .get(uid)
@@ -550,7 +550,7 @@ impl PerformanceTracker {
             .collect();
         for uid in uids {
             let current = self.adaptive_caps.entry(uid).or_insert(1);
-            if *current <= 1 {
+            if *current == 0 {
                 continue;
             }
             let cap_from = *current;
@@ -558,10 +558,16 @@ impl PerformanceTracker {
             let cap_to = *current;
             decayed += 1;
             let hotkey = uid_hotkeys.get(&uid).cloned().unwrap_or_default();
+            let direction = if cap_to == 0 {
+                self.pending_evictions.push((uid, hotkey.clone()));
+                CapDirection::Evict
+            } else {
+                CapDirection::Backoff
+            };
             self.cap_events.push(CapEvent {
                 uid,
                 hotkey,
-                direction: CapDirection::Backoff,
+                direction,
                 cap_from,
                 cap_to,
                 success_rate: 0.0,

--- a/crates/sn2-validator/src/performance.rs
+++ b/crates/sn2-validator/src/performance.rs
@@ -53,6 +53,14 @@ const MAX_BUFFERED_CAP_EVENTS: usize = 4096;
 pub enum CapDirection {
     Ramp,
     Backoff,
+    /// Cap ratcheted from 1 down to 0 — miner is excluded from dispatch
+    /// until a `REHAB_BLOCKS`-bounded cooldown elapses. Emitted only at the
+    /// 1->0 boundary, not on every sustained-failure window.
+    Evict,
+    /// Cap restored from 0 back to 1 after the cooldown elapsed. The miner
+    /// gets a single probe slot; the existing ramp-up logic decides whether
+    /// they climb back or land in another Evict.
+    Rehab,
 }
 
 #[derive(Clone, Debug)]
@@ -71,6 +79,10 @@ pub struct PerformanceTracker {
     adaptive_caps: HashMap<u16, usize>,
     at_cap_results: HashMap<u16, VecDeque<bool>>,
     cap_events: Vec<CapEvent>,
+    /// Uids whose cap just dropped to 0. Drained by the validator loop
+    /// to populate `dispatch_cooldowns` so the queryable filter excludes
+    /// them for `REHAB_BLOCKS`.
+    pending_evictions: Vec<(u16, String)>,
     persistence_path: Option<PathBuf>,
 }
 
@@ -96,6 +108,7 @@ impl PerformanceTracker {
             adaptive_caps: HashMap::new(),
             at_cap_results: HashMap::new(),
             cap_events: Vec::new(),
+            pending_evictions: Vec::new(),
             persistence_path: Some(path),
         };
         tracker.load();
@@ -480,9 +493,18 @@ impl PerformanceTracker {
             if let Some(r) = self.at_cap_results.get_mut(&uid) {
                 r.clear();
             }
-        } else if success_rate < CAPACITY_BACKOFF_THRESHOLD && *current > 1 {
+        } else if success_rate < CAPACITY_BACKOFF_THRESHOLD && *current > 0 {
             *current -= 1;
-            direction = Some(CapDirection::Backoff);
+            // 1 -> 0 is a terminal eviction; the caller will add the hotkey
+            // to dispatch_cooldowns so the queryable filter excludes it for
+            // REHAB_BLOCKS. Sustained-failure decrements above 1 still emit
+            // the normal Backoff direction.
+            direction = if *current == 0 {
+                self.pending_evictions.push((uid, hotkey.to_string()));
+                Some(CapDirection::Evict)
+            } else {
+                Some(CapDirection::Backoff)
+            };
             if let Some(r) = self.at_cap_results.get_mut(&uid) {
                 r.clear();
             }
@@ -513,6 +535,43 @@ impl PerformanceTracker {
     pub fn drain_cap_events(&mut self) -> Vec<CapEvent> {
         std::mem::take(&mut self.cap_events)
     }
+
+    /// Drain the set of (uid, hotkey) pairs whose adaptive cap just hit zero.
+    /// The validator loop consumes this on every dispatch tick and inserts
+    /// the hotkeys into `dispatch_cooldowns` with a `REHAB_BLOCKS` expiry.
+    pub fn drain_pending_evictions(&mut self) -> Vec<(u16, String)> {
+        std::mem::take(&mut self.pending_evictions)
+    }
+
+    /// Restore an evicted miner's cap from 0 back to 1, clearing the at-cap
+    /// result window so the next probe response starts a fresh ramp-up
+    /// evaluation. No-op for miners that are not currently at 0. Emits a
+    /// `CapDirection::Rehab` event for telemetry.
+    pub fn rehabilitate(&mut self, uid: u16, hotkey: &str) {
+        let current = match self.adaptive_caps.get_mut(&uid) {
+            Some(c) if *c == 0 => c,
+            _ => return,
+        };
+        let cap_from = *current;
+        *current = 1;
+        let cap_to = *current;
+        if let Some(r) = self.at_cap_results.get_mut(&uid) {
+            r.clear();
+        }
+        self.cap_events.push(CapEvent {
+            uid,
+            hotkey: hotkey.to_string(),
+            direction: CapDirection::Rehab,
+            cap_from,
+            cap_to,
+            success_rate: 0.0,
+            at: Instant::now(),
+        });
+        if self.cap_events.len() > MAX_BUFFERED_CAP_EVENTS {
+            let drop = self.cap_events.len() - MAX_BUFFERED_CAP_EVENTS;
+            self.cap_events.drain(0..drop);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -525,6 +584,7 @@ mod tests {
             adaptive_caps: HashMap::new(),
             at_cap_results: HashMap::new(),
             cap_events: Vec::new(),
+            pending_evictions: Vec::new(),
             persistence_path: None,
         }
     }
@@ -720,5 +780,85 @@ mod tests {
         let remaining = tracker.drain_cap_events();
         assert_eq!(remaining.len(), 1);
         assert_eq!(remaining[0].hotkey, "hk_new");
+    }
+
+    fn run_at_cap_failures(tracker: &mut PerformanceTracker, uid: u16, hotkey: &str, n: usize) {
+        for _ in 0..n {
+            tracker.record(uid, hotkey, false, 1.0, true);
+        }
+    }
+
+    #[test]
+    fn cap_ratchets_below_one_to_zero_on_sustained_failure() {
+        let mut tracker = test_tracker();
+        // Ramp to a higher cap first by running successful at-cap windows.
+        for _ in 0..(CAPACITY_MIN_AT_CAP * 3) {
+            tracker.record(1, "hk", true, 1.0, true);
+        }
+        assert!(tracker.adaptive_caps.get(&1).copied().unwrap_or(0) >= 2);
+        // Now ratchet down with failure windows until we hit 0.
+        for _ in 0..30 {
+            run_at_cap_failures(&mut tracker, 1, "hk", CAPACITY_MIN_AT_CAP);
+            if tracker.adaptive_caps.get(&1).copied() == Some(0) {
+                break;
+            }
+        }
+        assert_eq!(tracker.adaptive_caps.get(&1).copied(), Some(0));
+    }
+
+    #[test]
+    fn cap_drop_to_zero_emits_evict_event_and_pending_eviction() {
+        let mut tracker = test_tracker();
+        // Force the at-cap window full of failures; cap starts at default 1.
+        run_at_cap_failures(&mut tracker, 7, "hk_dead", CAPACITY_MIN_AT_CAP);
+        assert_eq!(tracker.adaptive_caps.get(&7).copied(), Some(0));
+        let events = tracker.drain_cap_events();
+        let evict = events
+            .iter()
+            .find(|e| matches!(e.direction, CapDirection::Evict))
+            .expect("expected Evict event");
+        assert_eq!(evict.uid, 7);
+        assert_eq!(evict.hotkey, "hk_dead");
+        assert_eq!(evict.cap_from, 1);
+        assert_eq!(evict.cap_to, 0);
+        let evicted = tracker.drain_pending_evictions();
+        assert_eq!(evicted, vec![(7, "hk_dead".to_string())]);
+    }
+
+    #[test]
+    fn drain_pending_evictions_clears() {
+        let mut tracker = test_tracker();
+        run_at_cap_failures(&mut tracker, 7, "hk_dead", CAPACITY_MIN_AT_CAP);
+        assert!(!tracker.drain_pending_evictions().is_empty());
+        assert!(tracker.drain_pending_evictions().is_empty());
+    }
+
+    #[test]
+    fn rehabilitate_restores_cap_from_zero_to_one() {
+        let mut tracker = test_tracker();
+        run_at_cap_failures(&mut tracker, 7, "hk_dead", CAPACITY_MIN_AT_CAP);
+        let _ = tracker.drain_cap_events();
+        tracker.rehabilitate(7, "hk_dead");
+        assert_eq!(tracker.adaptive_caps.get(&7).copied(), Some(1));
+        let events = tracker.drain_cap_events();
+        assert!(events
+            .iter()
+            .any(|e| matches!(e.direction, CapDirection::Rehab)));
+        // at-cap window cleared so the next probe doesn't carry old failures.
+        assert!(tracker
+            .at_cap_results
+            .get(&7)
+            .map(|r| r.is_empty())
+            .unwrap_or(true));
+    }
+
+    #[test]
+    fn rehabilitate_is_noop_when_cap_is_nonzero() {
+        let mut tracker = test_tracker();
+        tracker.adaptive_caps.insert(7, 3);
+        tracker.rehabilitate(7, "hk_alive");
+        assert_eq!(tracker.adaptive_caps.get(&7).copied(), Some(3));
+        let events = tracker.drain_cap_events();
+        assert!(events.is_empty());
     }
 }

--- a/crates/sn2-validator/src/performance.rs
+++ b/crates/sn2-validator/src/performance.rs
@@ -457,6 +457,8 @@ impl PerformanceTracker {
         self.windows.remove(&uid);
         self.adaptive_caps.remove(&uid);
         self.at_cap_results.remove(&uid);
+        self.at_cap_last_touched.remove(&uid);
+        self.pending_evictions.retain(|(u, _)| *u != uid);
         self.cap_events.retain(|e| e.hotkey != hotkey);
     }
 

--- a/crates/sn2-validator/src/stats_reporter.rs
+++ b/crates/sn2-validator/src/stats_reporter.rs
@@ -272,6 +272,8 @@ impl StatsReporter {
                 let direction = match e.direction {
                     CapDirection::Ramp => "ramp",
                     CapDirection::Backoff => "backoff",
+                    CapDirection::Evict => "evict",
+                    CapDirection::Rehab => "rehab",
                 };
                 let elapsed_ms = now.saturating_duration_since(e.at).as_millis() as u64;
                 serde_json::json!({

--- a/crates/sn2-validator/src/validator_loop/dispatch.rs
+++ b/crates/sn2-validator/src/validator_loop/dispatch.rs
@@ -145,19 +145,19 @@ impl ValidatorLoop {
         if !evicted.is_empty() {
             let until = self.current_block.saturating_add(sn2_types::REHAB_BLOCKS);
             for (uid, hotkey) in &evicted {
-                if self
-                    .dispatch_cooldowns
-                    .insert(hotkey.clone(), until)
-                    .is_none()
-                {
+                let prev = self.dispatch_cooldowns.get(hotkey).copied().unwrap_or(0);
+                let new_until = std::cmp::max(prev, until);
+                self.dispatch_cooldowns.insert(hotkey.clone(), new_until);
+                if prev == 0 {
                     tracing::info!(
                         uid = *uid,
-                        until_block = until,
+                        until_block = new_until,
                         rehab_blocks = sn2_types::REHAB_BLOCKS,
                         "miner evicted from dispatch"
                     );
                 }
             }
+            self.dispatch_cache.refreshed_at = None;
         }
 
         let fresh = self

--- a/crates/sn2-validator/src/validator_loop/dispatch.rs
+++ b/crates/sn2-validator/src/validator_loop/dispatch.rs
@@ -56,7 +56,7 @@ impl ValidatorLoop {
             .neurons
             .iter()
             .filter(|n| {
-                if let Some(&until) = self.reconnect_blacklist.get(&n.hotkey) {
+                if let Some(&until) = self.dispatch_cooldowns.get(&n.hotkey) {
                     if current_block < until {
                         return false;
                     }
@@ -141,6 +141,28 @@ impl ValidatorLoop {
     }
 
     fn refresh_dispatch_cache_if_stale(&mut self, queryable_uids: &[u16]) {
+        // Always drain pending evictions even when the cache is fresh, so a
+        // 1->0 cap transition that happens between cache refreshes still
+        // lands in dispatch_cooldowns and excludes the miner on the next
+        // queryable filter pass.
+        let evicted = self.performance_tracker.drain_pending_evictions();
+        if !evicted.is_empty() {
+            let until = self.current_block.saturating_add(sn2_types::REHAB_BLOCKS);
+            for (uid, hotkey) in &evicted {
+                self.dispatch_cooldowns
+                    .insert(hotkey.clone(), until)
+                    .is_none()
+                    .then(|| {
+                        tracing::info!(
+                            uid = *uid,
+                            until_block = until,
+                            rehab_blocks = sn2_types::REHAB_BLOCKS,
+                            "miner evicted from dispatch — capacity ratcheted to 0, cooldown until block"
+                        );
+                    });
+            }
+        }
+
         let fresh = self
             .dispatch_cache
             .refreshed_at

--- a/crates/sn2-validator/src/validator_loop/dispatch.rs
+++ b/crates/sn2-validator/src/validator_loop/dispatch.rs
@@ -141,25 +141,22 @@ impl ValidatorLoop {
     }
 
     fn refresh_dispatch_cache_if_stale(&mut self, queryable_uids: &[u16]) {
-        // Always drain pending evictions even when the cache is fresh, so a
-        // 1->0 cap transition that happens between cache refreshes still
-        // lands in dispatch_cooldowns and excludes the miner on the next
-        // queryable filter pass.
         let evicted = self.performance_tracker.drain_pending_evictions();
         if !evicted.is_empty() {
             let until = self.current_block.saturating_add(sn2_types::REHAB_BLOCKS);
             for (uid, hotkey) in &evicted {
-                self.dispatch_cooldowns
+                if self
+                    .dispatch_cooldowns
                     .insert(hotkey.clone(), until)
                     .is_none()
-                    .then(|| {
-                        tracing::info!(
-                            uid = *uid,
-                            until_block = until,
-                            rehab_blocks = sn2_types::REHAB_BLOCKS,
-                            "miner evicted from dispatch — capacity ratcheted to 0, cooldown until block"
-                        );
-                    });
+                {
+                    tracing::info!(
+                        uid = *uid,
+                        until_block = until,
+                        rehab_blocks = sn2_types::REHAB_BLOCKS,
+                        "miner evicted from dispatch"
+                    );
+                }
             }
         }
 

--- a/crates/sn2-validator/src/validator_loop/dispatch.rs
+++ b/crates/sn2-validator/src/validator_loop/dispatch.rs
@@ -142,6 +142,7 @@ impl ValidatorLoop {
 
     fn refresh_dispatch_cache_if_stale(&mut self, queryable_uids: &[u16]) {
         let evicted = self.performance_tracker.drain_pending_evictions();
+        let evicted_uids: HashSet<u16> = evicted.iter().map(|(uid, _)| *uid).collect();
         if !evicted.is_empty() {
             let until = self.current_block.saturating_add(sn2_types::REHAB_BLOCKS);
             for (uid, hotkey) in &evicted {
@@ -168,9 +169,14 @@ impl ValidatorLoop {
         if fresh {
             return;
         }
+        let filtered_queryable: Vec<u16> = queryable_uids
+            .iter()
+            .copied()
+            .filter(|uid| !evicted_uids.contains(uid))
+            .collect();
         self.dispatch_cache.capacities = self.performance_tracker.miner_capacities();
         self.dispatch_cache.adaptive_timeout = self.performance_tracker.adaptive_timeout();
-        self.dispatch_cache.api_eligible = self.compute_api_eligible_from_uids(queryable_uids);
+        self.dispatch_cache.api_eligible = self.compute_api_eligible_from_uids(&filtered_queryable);
         self.dispatch_cache.refreshed_at = Some(Instant::now());
     }
 

--- a/crates/sn2-validator/src/validator_loop/dispatch.rs
+++ b/crates/sn2-validator/src/validator_loop/dispatch.rs
@@ -49,6 +49,8 @@ impl ValidatorLoop {
 
         metrics::set_active_tasks(active_count);
 
+        self.absorb_pending_evictions();
+
         let current_block = self.current_block;
         let mut queryable_uids: Vec<u16> = self
             .config
@@ -140,27 +142,29 @@ impl ValidatorLoop {
         Ok(())
     }
 
-    fn refresh_dispatch_cache_if_stale(&mut self, queryable_uids: &[u16]) {
+    fn absorb_pending_evictions(&mut self) {
         let evicted = self.performance_tracker.drain_pending_evictions();
-        let evicted_uids: HashSet<u16> = evicted.iter().map(|(uid, _)| *uid).collect();
-        if !evicted.is_empty() {
-            let until = self.current_block.saturating_add(sn2_types::REHAB_BLOCKS);
-            for (uid, hotkey) in &evicted {
-                let prev = self.dispatch_cooldowns.get(hotkey).copied().unwrap_or(0);
-                let new_until = std::cmp::max(prev, until);
-                self.dispatch_cooldowns.insert(hotkey.clone(), new_until);
-                if prev == 0 {
-                    tracing::info!(
-                        uid = *uid,
-                        until_block = new_until,
-                        rehab_blocks = sn2_types::REHAB_BLOCKS,
-                        "miner evicted from dispatch"
-                    );
-                }
-            }
-            self.dispatch_cache.refreshed_at = None;
+        if evicted.is_empty() {
+            return;
         }
+        let until = self.current_block.saturating_add(sn2_types::REHAB_BLOCKS);
+        for (uid, hotkey) in &evicted {
+            let prev = self.dispatch_cooldowns.get(hotkey).copied().unwrap_or(0);
+            let new_until = std::cmp::max(prev, until);
+            self.dispatch_cooldowns.insert(hotkey.clone(), new_until);
+            if prev == 0 {
+                tracing::info!(
+                    uid = *uid,
+                    until_block = new_until,
+                    rehab_blocks = sn2_types::REHAB_BLOCKS,
+                    "miner evicted from dispatch"
+                );
+            }
+        }
+        self.dispatch_cache.refreshed_at = None;
+    }
 
+    fn refresh_dispatch_cache_if_stale(&mut self, queryable_uids: &[u16]) {
         let fresh = self
             .dispatch_cache
             .refreshed_at
@@ -169,14 +173,9 @@ impl ValidatorLoop {
         if fresh {
             return;
         }
-        let filtered_queryable: Vec<u16> = queryable_uids
-            .iter()
-            .copied()
-            .filter(|uid| !evicted_uids.contains(uid))
-            .collect();
         self.dispatch_cache.capacities = self.performance_tracker.miner_capacities();
         self.dispatch_cache.adaptive_timeout = self.performance_tracker.adaptive_timeout();
-        self.dispatch_cache.api_eligible = self.compute_api_eligible_from_uids(&filtered_queryable);
+        self.dispatch_cache.api_eligible = self.compute_api_eligible_from_uids(queryable_uids);
         self.dispatch_cache.refreshed_at = Some(Instant::now());
     }
 

--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -9,13 +9,7 @@ use tracing::{info, warn};
 
 use super::ValidatorLoop;
 use crate::relay::DsperseSubmission;
-
-/// Number of blocks before a slice in `disabled_slices` is reconsidered for
-/// dispatch. Roughly one tempo on subtensor (~12s blocks). Picked so that a
-/// transient network or chain event that synchronously fails every slice
-/// (e.g. a chain RPC reconnect storm) self-heals within the next epoch
-/// rather than persisting until the validator is restarted.
-const DISABLED_SLICE_REHAB_BLOCKS: u64 = 360;
+use sn2_types::REHAB_BLOCKS as DISABLED_SLICE_REHAB_BLOCKS;
 
 enum ExpectedInputs {
     NoMetadata,

--- a/crates/sn2-validator/src/validator_loop/maintenance.rs
+++ b/crates/sn2-validator/src/validator_loop/maintenance.rs
@@ -124,9 +124,7 @@ impl ValidatorLoop {
                     "host memory pressure: trimming adaptive caps across all miners"
                 );
             }
-            let idle_decayed = self
-                .performance_tracker
-                .decay_idle_caps(&self.uid_hotkeys);
+            let idle_decayed = self.performance_tracker.decay_idle_caps(&self.uid_hotkeys);
             if idle_decayed > 0 {
                 info!(decremented = idle_decayed, "decayed idle adaptive caps");
             }

--- a/crates/sn2-validator/src/validator_loop/maintenance.rs
+++ b/crates/sn2-validator/src/validator_loop/maintenance.rs
@@ -39,6 +39,11 @@ impl ValidatorLoop {
                 self.timings.metagraph_sync = now;
             }
 
+            if now.duration_since(self.timings.cooldown_prune) > Duration::from_secs(60) {
+                self.prune_expired_cooldowns();
+                self.timings.cooldown_prune = now;
+            }
+
             if now.duration_since(self.timings.weight_update)
                 > Duration::from_secs(WEIGHT_UPDATE_POLL_SECS)
             {
@@ -225,6 +230,31 @@ impl ValidatorLoop {
         }
     }
 
+    pub(super) fn prune_expired_cooldowns(&mut self) {
+        let cooldowns_before = self.dispatch_cooldowns.len();
+        let expired_hotkeys: Vec<String> = self
+            .dispatch_cooldowns
+            .iter()
+            .filter(|(_, &until)| self.current_block >= until)
+            .map(|(hk, _)| hk.clone())
+            .collect();
+        for hk in &expired_hotkeys {
+            self.dispatch_cooldowns.remove(hk);
+            if let Some(uid) = self.config.metagraph.get_uid_by_hotkey(hk) {
+                self.performance_tracker.rehabilitate(uid, hk);
+            }
+        }
+        let cooldowns_after = self.dispatch_cooldowns.len();
+        if cooldowns_before != cooldowns_after {
+            info!(
+                expired = cooldowns_before - cooldowns_after,
+                remaining = cooldowns_after,
+                rehab_blocks = sn2_types::REHAB_BLOCKS,
+                "dispatch_cooldowns pruned"
+            );
+        }
+    }
+
     pub(super) async fn sync_metagraph(&mut self) -> Result<()> {
         let chain_client = self
             .config
@@ -265,31 +295,7 @@ impl ValidatorLoop {
         self.score_manager.sync_uids(&uids);
         self.rsv
             .prune_expired(self.current_block, self.blocks_per_tempo);
-        let cooldowns_before = self.dispatch_cooldowns.len();
-        let expired_hotkeys: Vec<String> = self
-            .dispatch_cooldowns
-            .iter()
-            .filter(|(_, &until)| self.current_block >= until)
-            .map(|(hk, _)| hk.clone())
-            .collect();
-        for hk in &expired_hotkeys {
-            self.dispatch_cooldowns.remove(hk);
-            // Re-arm the miner with one probe slot. If the probe fails,
-            // the at-cap window will refill with mostly-zero successes
-            // and the next `update_adaptive_cap` will Evict them again.
-            if let Some(uid) = self.config.metagraph.get_uid_by_hotkey(hk) {
-                self.performance_tracker.rehabilitate(uid, hk);
-            }
-        }
-        let cooldowns_after = self.dispatch_cooldowns.len();
-        if cooldowns_before != cooldowns_after {
-            info!(
-                expired = cooldowns_before - cooldowns_after,
-                remaining = cooldowns_after,
-                rehab_blocks = sn2_types::REHAB_BLOCKS,
-                "dispatch_cooldowns pruned"
-            );
-        }
+        self.prune_expired_cooldowns();
 
         let mut axon_count = 0usize;
         for n in &self.config.metagraph.neurons {

--- a/crates/sn2-validator/src/validator_loop/maintenance.rs
+++ b/crates/sn2-validator/src/validator_loop/maintenance.rs
@@ -124,6 +124,12 @@ impl ValidatorLoop {
                     "host memory pressure: trimming adaptive caps across all miners"
                 );
             }
+            let idle_decayed = self
+                .performance_tracker
+                .decay_idle_caps(&self.uid_hotkeys);
+            if idle_decayed > 0 {
+                info!(decremented = idle_decayed, "decayed idle adaptive caps");
+            }
             info!(
                 active_tasks = active_tasks,
                 rwr_queue = self.rwr_queue.len(),

--- a/crates/sn2-validator/src/validator_loop/maintenance.rs
+++ b/crates/sn2-validator/src/validator_loop/maintenance.rs
@@ -261,15 +261,29 @@ impl ValidatorLoop {
         self.score_manager.sync_uids(&uids);
         self.rsv
             .prune_expired(self.current_block, self.blocks_per_tempo);
-        let blacklist_before = self.reconnect_blacklist.len();
-        self.reconnect_blacklist
-            .retain(|_, until| self.current_block < *until);
-        let blacklist_after = self.reconnect_blacklist.len();
-        if blacklist_before != blacklist_after {
+        let cooldowns_before = self.dispatch_cooldowns.len();
+        let expired_hotkeys: Vec<String> = self
+            .dispatch_cooldowns
+            .iter()
+            .filter(|(_, &until)| self.current_block >= until)
+            .map(|(hk, _)| hk.clone())
+            .collect();
+        for hk in &expired_hotkeys {
+            self.dispatch_cooldowns.remove(hk);
+            // Re-arm the miner with one probe slot. If the probe fails,
+            // the at-cap window will refill with mostly-zero successes
+            // and the next `update_adaptive_cap` will Evict them again.
+            if let Some(uid) = self.config.metagraph.get_uid_by_hotkey(hk) {
+                self.performance_tracker.rehabilitate(uid, hk);
+            }
+        }
+        let cooldowns_after = self.dispatch_cooldowns.len();
+        if cooldowns_before != cooldowns_after {
             info!(
-                expired = blacklist_before - blacklist_after,
-                remaining = blacklist_after,
-                "reconnect_blacklist pruned"
+                expired = cooldowns_before - cooldowns_after,
+                remaining = cooldowns_after,
+                rehab_blocks = sn2_types::REHAB_BLOCKS,
+                "dispatch_cooldowns pruned"
             );
         }
 
@@ -456,7 +470,7 @@ impl ValidatorLoop {
                     if self.rsv.is_skiplisted(hk, current_block) {
                         return true;
                     }
-                    self.reconnect_blacklist
+                    self.dispatch_cooldowns
                         .get(hk)
                         .is_some_and(|&until| current_block < until)
                 })

--- a/crates/sn2-validator/src/validator_loop/maintenance.rs
+++ b/crates/sn2-validator/src/validator_loop/maintenance.rs
@@ -238,11 +238,16 @@ impl ValidatorLoop {
             .filter(|(_, &until)| self.current_block >= until)
             .map(|(hk, _)| hk.clone())
             .collect();
+        let mut rehabilitated = false;
         for hk in &expired_hotkeys {
             self.dispatch_cooldowns.remove(hk);
             if let Some(uid) = self.config.metagraph.get_uid_by_hotkey(hk) {
                 self.performance_tracker.rehabilitate(uid, hk);
+                rehabilitated = true;
             }
+        }
+        if rehabilitated {
+            self.dispatch_cache.refreshed_at = None;
         }
         let cooldowns_after = self.dispatch_cooldowns.len();
         if cooldowns_before != cooldowns_after {

--- a/crates/sn2-validator/src/validator_loop/mod.rs
+++ b/crates/sn2-validator/src/validator_loop/mod.rs
@@ -179,7 +179,7 @@ pub struct ValidatorLoop {
     pub(super) blocks_per_tempo: u64,
     pub(super) consecutive_metagraph_failures: u32,
     pub(super) dispatch_cache: dispatch::DispatchCache,
-    pub(super) reconnect_blacklist: HashMap<String, u64>,
+    pub(super) dispatch_cooldowns: HashMap<String, u64>,
 }
 
 pub(super) const METAGRAPH_FAILURE_RECONNECT_THRESHOLD: u32 = 3;
@@ -388,7 +388,7 @@ impl ValidatorLoop {
             blocks_per_tempo: 360,
             consecutive_metagraph_failures: 0,
             dispatch_cache: dispatch::DispatchCache::new(),
-            reconnect_blacklist: HashMap::new(),
+            dispatch_cooldowns: HashMap::new(),
         })
     }
 

--- a/crates/sn2-validator/src/validator_loop/mod.rs
+++ b/crates/sn2-validator/src/validator_loop/mod.rs
@@ -77,7 +77,7 @@ pub(super) enum TaskOutcome {
 }
 
 pub(super) struct VerifyResult {
-    pub(super) verify_task_id: tokio::task::Id,
+    pub(super) verify_task_id: Option<tokio::task::Id>,
     pub(super) task_result: TaskResult,
     pub(super) verified: bool,
     pub(super) hotkey: String,
@@ -471,8 +471,11 @@ impl ValidatorLoop {
                 Some(result) = self.verify_tasks.join_next() => {
                     match result {
                         Ok(verify_result) => {
-                            let guard_hash = self.verify_guard_hashes.remove(&verify_result.verify_task_id);
-                            self.finish_verification(verify_result, guard_hash.flatten()).await;
+                            let guard_hash = verify_result
+                                .verify_task_id
+                                .and_then(|id| self.verify_guard_hashes.remove(&id))
+                                .flatten();
+                            self.finish_verification(verify_result, guard_hash).await;
                         }
                         Err(e) => {
                             if let Some(Some(hash)) = self.verify_guard_hashes.remove(&e.id()) {

--- a/crates/sn2-validator/src/validator_loop/mod.rs
+++ b/crates/sn2-validator/src/validator_loop/mod.rs
@@ -92,6 +92,7 @@ pub(super) struct PeriodicTimings {
     pub(super) health_log: Instant,
     pub(super) replenish: Instant,
     pub(super) gc: Instant,
+    pub(super) cooldown_prune: Instant,
 }
 
 impl PeriodicTimings {
@@ -105,6 +106,7 @@ impl PeriodicTimings {
             health_log: now,
             replenish: now,
             gc: now,
+            cooldown_prune: now,
         }
     }
 }

--- a/crates/sn2-validator/src/validator_loop/mod.rs
+++ b/crates/sn2-validator/src/validator_loop/mod.rs
@@ -449,7 +449,7 @@ impl ValidatorLoop {
                     match result {
                         Ok(task_result) => {
                             self.task_meta.remove(&task_result.tokio_task_id);
-                            self.start_verification(task_result);
+                            self.start_verification(task_result).await;
                         }
                         Err(e) => {
                             if let Some((uid, guard_hash)) = self.task_meta.remove(&e.id()) {

--- a/crates/sn2-validator/src/validator_loop/results.rs
+++ b/crates/sn2-validator/src/validator_loop/results.rs
@@ -348,7 +348,7 @@ impl ValidatorLoop {
                 self.blocks_per_tempo
             };
             let until = self.current_block + bpt;
-            self.reconnect_blacklist.insert(hotkey.to_string(), until);
+            self.dispatch_cooldowns.insert(hotkey.to_string(), until);
         }
 
         let is_verification_failure = reason.starts_with("verification failed")

--- a/crates/sn2-validator/src/validator_loop/verification.rs
+++ b/crates/sn2-validator/src/validator_loop/verification.rs
@@ -30,7 +30,8 @@ impl ValidatorLoop {
         if !needs_real_verify {
             let guard_hash = result.guard_hash.clone();
             let hotkey = self.uid_hotkeys.get(&uid).cloned().unwrap_or_default();
-            let verified = matches!(result.outcome, TaskOutcome::Success(ref r) if r.proof_size > 0);
+            let verified =
+                matches!(result.outcome, TaskOutcome::Success(ref r) if r.proof_size > 0);
             if verified {
                 if let TaskOutcome::Success(ref mut response) = result.outcome {
                     response.verification_result = true;

--- a/crates/sn2-validator/src/validator_loop/verification.rs
+++ b/crates/sn2-validator/src/validator_loop/verification.rs
@@ -6,18 +6,13 @@ use crate::relay::FRAME_PROOF_RESULT;
 use crate::response_processor::ResponseProcessor;
 
 impl ValidatorLoop {
-    pub(super) fn start_verification(&mut self, mut result: TaskResult) {
+    pub(super) async fn start_verification(&mut self, mut result: TaskResult) {
         let uid = result.uid;
 
         if let Some(count) = self.miner_active_count.get_mut(&uid) {
             *count = count.saturating_sub(1);
         }
 
-        // Decide sampling now so we can free proof bytes from responses
-        // that will be no-op verified and never relayed. Holding the bytes
-        // until spawn_verification means pending_verifications buffers the
-        // full proof payload across the verify-CPU bottleneck for ~95% of
-        // responses that take the RSV fast path without needing them.
         let sample = decide_sample(&result);
         if !sample && !response_needs_proof_bytes_for_downstream(&result) {
             if let TaskOutcome::Success(ref mut response) = result.outcome {
@@ -26,20 +21,35 @@ impl ValidatorLoop {
                 response.witness = None;
                 response.raw = None;
                 response.public_json = None;
-                // Also release the validator's local input copy. Pre-sampling
-                // at dispatch already drops most of these before the task is
-                // spawned, but the audit-eligible path still allocates inputs
-                // and this branch lets force-verify-then-no-verify edge cases
-                // (e.g. empty proof on a force_verify request) reclaim them.
                 response.inputs = None;
             }
+        }
+
+        let needs_real_verify =
+            sample && matches!(result.outcome, TaskOutcome::Success(ref r) if r.proof_size > 0);
+        if !needs_real_verify {
+            let guard_hash = result.guard_hash.clone();
+            let hotkey = self.uid_hotkeys.get(&uid).cloned().unwrap_or_default();
+            let verified = matches!(result.outcome, TaskOutcome::Success(ref r) if r.proof_size > 0);
+            if verified {
+                if let TaskOutcome::Success(ref mut response) = result.outcome {
+                    response.verification_result = true;
+                }
+            }
+            let vr = VerifyResult {
+                verify_task_id: None,
+                task_result: result,
+                verified,
+                hotkey,
+            };
+            self.finish_verification(vr, guard_hash).await;
+            return;
         }
 
         if self.verify_tasks.len() >= self.verification_concurrency {
             self.pending_verifications.push_back((result, sample));
             return;
         }
-
         self.spawn_verification(result, sample);
     }
 
@@ -75,7 +85,7 @@ impl ValidatorLoop {
                     let captured_hotkey = hotkey.clone();
                     self.verify_tasks.spawn(async move {
                         VerifyResult {
-                            verify_task_id: tokio::task::id(),
+                            verify_task_id: Some(tokio::task::id()),
                             task_result: result,
                             verified: true,
                             hotkey: captured_hotkey,
@@ -85,7 +95,7 @@ impl ValidatorLoop {
                     let processor = ResponseProcessor::new();
                     let captured_hotkey = hotkey.clone();
                     self.verify_tasks.spawn(async move {
-                        let verify_task_id = tokio::task::id();
+                        let verify_task_id = Some(tokio::task::id());
                         let verified =
                             matches!(processor.verify_response(&mut response).await, Ok(true));
                         response.verification_result = verified;
@@ -103,7 +113,7 @@ impl ValidatorLoop {
                 let captured_hotkey = hotkey.clone();
                 self.verify_tasks.spawn(async move {
                     VerifyResult {
-                        verify_task_id: tokio::task::id(),
+                        verify_task_id: Some(tokio::task::id()),
                         task_result: result,
                         verified: false,
                         hotkey: captured_hotkey,


### PR DESCRIPTION
## Summary

Three coordinated changes to the validator dispatch loop that compose into a meaningful throughput improvement:

1. **Inline-finish fast path for no-op verification.** The sample-decided no-op verification path used to round-trip through `verify_tasks.spawn` -> `JoinSet::join_next()` -> `finish_verification`. That round-trip is pure scheduling overhead for verifications that immediately return a pre-decided result. The no-op path now calls `finish_verification` directly, leaving the `verify_tasks` JoinSet exclusively for real CPU-bound verifications. `pending_verifications` is no longer back-pressured by the no-op stream, and the dispatch loop's `pending_verifications >= pending_cap` halt path no longer fires under sustained load.

2. **Dispatch cooldown for sustained-failure miners.** Picked up from the disabled-slice rehab work — reuses `dispatch_cooldowns` (renamed from `reconnect_blacklist`) so any hotkey whose adaptive cap ratchets to zero is excluded from the queryable filter for `REHAB_BLOCKS`. Once the cooldown elapses, the maintenance loop calls `rehabilitate` and the existing ramp-up logic re-evaluates them with one probe slot.

3. **Idle-cap decay.** Adaptive caps are monotonic when not at-capacity — the existing ramp/backoff logic only fires when the cap is actually being challenged. A miner whose dispatch share drops off keeps a stale historical-peak cap forever. `decay_idle_caps` decrements the cap by one per maintenance tick after `CAP_DECAY_IDLE_SECS` without an at-capacity sample, so caps regress toward the live signal. When a cap decays through 1 -> 0, the existing dispatch_cooldown machinery picks it up the same way as any other eviction.

## Properties

- All three reuse existing primitives: cap-decay piggybacks on the eviction signal, the cooldown reuses the queryable-filter map, the inline-finish path reuses `finish_verification` unchanged.
- Verification security is preserved: the sample decision still happens at dispatch time via `pre_decide_sample`. The inline path produces an identical `VerifyResult` to the spawned path and runs the same `finish_verification` body. The per-call timing delta from skipping the JoinSet round-trip is below the network jitter floor that any external observer would see across batched dispatches.
- Real ZK verification (`sample=true && proof_size > 0`) is unchanged — still goes through `verify_tasks` so it can run concurrent on the runtime worker pool.

## Test plan

- [x] `cargo build -p sn2-validator` clean.
- [x] `cargo test -p sn2-validator performance::` — 20 tests pass (includes the cap=0 floor + Evict event + rehabilitate cases).
- [ ] CI for clippy + workspace tests.
- [ ] Operator smoke: verify aggregate finish_verification rate is sustained without the periodic burst-and-stall pattern that the `pending_verifications` back-pressure used to introduce.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Miner eviction and rehabilitation workflow to temporarily skip unhealthy miners and restore them after rehab.
  * Idle-capacity decay that lowers unused capacity and can drive backoff or eviction.

* **Behavior**
  * Dispatch cooldowns now govern retry/skip behavior and are periodically pruned.
  * Capacity logs now include explicit "evict" and "rehab" directions.

* **Chores**
  * Rehab/cooldown duration consolidated to 360 blocks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inference-labs-inc/subnet-2/pull/514?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->