### PR TITLE
Implement subtensor connection helper for ws and wss endpoints

### DIFF
--- a/crates/sn2-chain/src/lib.rs
+++ b/crates/sn2-chain/src/lib.rs
@@ -6,6 +6,9 @@ mod subxt_helpers;
 mod wallet;
 mod weights;
 
+use anyhow::{Context, Result};
+use subxt::{OnlineClient, PolkadotConfig};
+
 pub use metagraph::{Metagraph, NeuronInfo};
 pub use registration::Registration;
 pub use wallet::Wallet;
@@ -25,6 +28,19 @@ pub fn resolve_endpoint(network: &str, override_endpoint: Option<&str>) -> Strin
             other => other.to_string(),
         },
     }
+}
+
+/// Open a subxt `OnlineClient` against `endpoint`. `wss://` URLs use the
+/// TLS-validating `from_url`; `ws://` URLs use `from_insecure_url`, which
+/// subxt requires for non-TLS sockets even when reaching localhost or a
+/// private substrate node.
+pub async fn connect_chain(endpoint: &str) -> Result<OnlineClient<PolkadotConfig>> {
+    let result = if endpoint.starts_with("ws://") {
+        OnlineClient::<PolkadotConfig>::from_insecure_url(endpoint).await
+    } else {
+        OnlineClient::<PolkadotConfig>::from_url(endpoint).await
+    };
+    result.with_context(|| format!("connecting to subtensor at {endpoint}"))
 }
 
 pub fn is_rpc_disconnect(err: &anyhow::Error) -> bool {

--- a/crates/sn2-miner/src/firewall.rs
+++ b/crates/sn2-miner/src/firewall.rs
@@ -18,9 +18,7 @@ pub async fn emit_nftables(
 ) -> Result<()> {
     let endpoint = sn2_chain::resolve_endpoint(network, chain_endpoint);
     info!(netuid, %endpoint, "syncing metagraph for firewall ruleset");
-    let chain_client = subxt::OnlineClient::<subxt::PolkadotConfig>::from_url(&endpoint)
-        .await
-        .with_context(|| format!("connecting to subtensor at {endpoint}"))?;
+    let chain_client = sn2_chain::connect_chain(&endpoint).await?;
     let mut metagraph = Metagraph::new(netuid);
     metagraph
         .sync(&chain_client)

--- a/crates/sn2-miner/src/main.rs
+++ b/crates/sn2-miner/src/main.rs
@@ -66,9 +66,7 @@ async fn main() -> Result<()> {
     let endpoint =
         sn2_chain::resolve_endpoint(&cli.network, cli.subtensor_chain_endpoint.as_deref());
 
-    let chain_client = subxt::OnlineClient::<subxt::PolkadotConfig>::from_url(&endpoint)
-        .await
-        .with_context(|| format!("connecting to subtensor at {endpoint}"))?;
+    let chain_client = sn2_chain::connect_chain(&endpoint).await?;
 
     let registration = sn2_chain::Registration::new(cli.netuid);
 

--- a/crates/sn2-validator/src/config.rs
+++ b/crates/sn2-validator/src/config.rs
@@ -37,9 +37,7 @@ impl ValidatorConfig {
         let endpoint =
             sn2_chain::resolve_endpoint(&cli.network, cli.subtensor_chain_endpoint.as_deref());
 
-        let chain_client = OnlineClient::<PolkadotConfig>::from_url(&endpoint)
-            .await
-            .with_context(|| format!("connecting to subtensor at {endpoint}"))?;
+        let chain_client = sn2_chain::connect_chain(&endpoint).await?;
 
         let wallet = Arc::new(
             Wallet::from_paths(
@@ -167,9 +165,7 @@ impl ValidatorConfig {
 
     pub async fn reconnect_chain_client(&mut self) -> Result<()> {
         info!(endpoint = %self.chain_endpoint, "reconnecting to subtensor");
-        let client = OnlineClient::<PolkadotConfig>::from_url(&self.chain_endpoint)
-            .await
-            .with_context(|| format!("reconnecting to subtensor at {}", self.chain_endpoint))?;
+        let client = sn2_chain::connect_chain(&self.chain_endpoint).await?;
         self.chain_client = Some(client);
         info!("subtensor reconnection successful");
         Ok(())


### PR DESCRIPTION
## Summary

- Centralize subxt client construction behind a new \`sn2_chain::connect_chain\` helper that picks \`from_url\` (TLS-validating) for \`wss://\` and \`from_insecure_url\` for \`ws://\`. subxt rejects \`ws://\` on \`from_url\` for non-localhost hosts, so this is required to point any binary at a plain-WebSocket substrate node (private RPC, port-forwarded archive node, internal infra).
- Replace the four direct \`OnlineClient::from_url\` call sites (validator config init + reconnect, miner main, firewall command) with the helper so future call sites inherit the behavior automatically.

## Test plan

- [x] \`cargo check --workspace --bin sn2-validator --bin sn2-miner\` (clean)
- [x] \`cargo clippy --workspace --bin sn2-validator --bin sn2-miner -- -D warnings\` (clean)
- [x] \`cargo fmt --check\` (clean)
- [ ] Confirm the validator connects against a local \`ws://127.0.0.1:9944\` substrate node (the previous behavior, exercised by the local-endpoint path).
- [ ] Confirm the validator connects against \`wss://entrypoint-finney.opentensor.ai:443\` (existing happy path).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized blockchain endpoint connection handling across mining and validator components to use a unified connection method with consistent error context.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inference-labs-inc/subnet-2/pull/515?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->