### PR TITLE
Implement validator axon publish and accept chain IPs for source allowlist

### DIFF
--- a/crates/sn2-miner/src/allowlist.rs
+++ b/crates/sn2-miner/src/allowlist.rs
@@ -34,7 +34,7 @@ use btlightning::{
     HandshakeObserver, LightningError, Result as LightningResult, SourceAddressResolver,
     SourceAllowlist, ValidatorPermitResolver,
 };
-use sn2_chain::Metagraph;
+use sn2_chain::{Metagraph, NeuronInfo};
 use tokio::sync::RwLock;
 use tracing::{info, warn};
 
@@ -151,9 +151,17 @@ impl ValidatorAllowlist {
         let roster = self.roster.read().await;
         for n in permit_iter {
             total_permit_stake = total_permit_stake.saturating_add(n.stake as u128);
-            if let Some(ip) = roster.ip_for(&n.hotkey) {
+            let mut covered = false;
+            if let Some(chain_ip) = chain_axon_ip(n) {
+                allowed_ips.insert(chain_ip);
+                covered = true;
+            }
+            if let Some(roster_ip) = roster.ip_for(&n.hotkey) {
+                allowed_ips.insert(roster_ip);
+                covered = true;
+            }
+            if covered {
                 observed_permit_stake = observed_permit_stake.saturating_add(n.stake as u128);
-                allowed_ips.insert(ip);
             }
         }
         drop(roster);
@@ -233,21 +241,34 @@ impl SourceAddressResolver for ValidatorAllowlist {
             State::Enforcing => {
                 let roster = self.roster.blocking_read();
                 let meta = self.metagraph.blocking_read();
-                let permitted: HashSet<&str> = meta
-                    .neurons
-                    .iter()
-                    .filter(|n| n.validator_permit)
-                    .map(|n| n.hotkey.as_str())
-                    .collect();
-                let ips: HashSet<IpAddr> = roster
-                    .entries()
-                    .filter(|e| permitted.contains(e.hotkey.as_str()))
-                    .map(|e| e.ip.clone().into())
-                    .collect();
+                let mut ips: HashSet<IpAddr> = HashSet::new();
+                for n in meta.neurons.iter().filter(|n| n.validator_permit) {
+                    if let Some(chain_ip) = chain_axon_ip(n) {
+                        ips.insert(chain_ip);
+                    }
+                    if let Some(roster_ip) = roster.ip_for(&n.hotkey) {
+                        ips.insert(roster_ip);
+                    }
+                }
                 Ok(SourceAllowlist::Enforce(ips))
             }
         }
     }
+}
+
+/// Read `n.axon_ip` as an `IpAddr` if the chain entry is populated (non-empty
+/// string, parseable, and not the all-zero sentinel). Validators that have not
+/// run `serve_axon` keep the default `0.0.0.0` axon entry; treating that as
+/// "no chain IP" lets the TOFU roster supply their IP instead.
+fn chain_axon_ip(n: &NeuronInfo) -> Option<IpAddr> {
+    if n.axon_ip.is_empty() {
+        return None;
+    }
+    let ip: IpAddr = n.axon_ip.parse().ok()?;
+    if ip.is_unspecified() {
+        return None;
+    }
+    Some(ip)
 }
 
 #[async_trait::async_trait]
@@ -420,5 +441,83 @@ mod tests {
             !cov.enforcing,
             "coverage drops to 100/1000 = 10% < kappa; must fall back to Learning"
         );
+    }
+
+    fn neuron_with_axon(uid: u16, hotkey: &str, stake: u64, axon_ip: &str) -> NeuronInfo {
+        let mut n = neuron(uid, hotkey, stake, true);
+        n.axon_ip = axon_ip.to_string();
+        n
+    }
+
+    #[tokio::test]
+    async fn chain_axon_ip_covers_validator_without_handshake() {
+        // hk_chain publishes an axon IP on chain; hk_legacy does not.
+        // The chain entry alone should make hk_chain's stake count toward
+        // kappa coverage and place its IP in the enforced source set.
+        let meta = build_meta(
+            vec![
+                neuron_with_axon(0, "hk_chain", 900, "10.0.0.1"),
+                neuron(1, "hk_legacy", 100, true),
+            ],
+            500,
+            32767,
+            100,
+        );
+        let al = build_allowlist(meta).await;
+        let _ = al.evaluate().await;
+        // No handshake observed for hk_chain — coverage must come from the chain entry.
+        al.metagraph.write().await.block = 600;
+        let cov = al.evaluate().await;
+        assert!(
+            cov.enforcing,
+            "chain axon IP alone should satisfy kappa coverage"
+        );
+        assert!(cov.allowed_ips.contains(&"10.0.0.1".parse().unwrap()));
+    }
+
+    #[tokio::test]
+    async fn chain_unspecified_ip_does_not_count_as_coverage() {
+        // Validators that have not run serve_axon keep 0.0.0.0 on chain; this
+        // must be treated identically to an absent entry.
+        let meta = build_meta(
+            vec![
+                neuron_with_axon(0, "hk_unset", 900, "0.0.0.0"),
+                neuron(1, "hk_other", 100, true),
+            ],
+            500,
+            32767,
+            100,
+        );
+        let al = build_allowlist(meta).await;
+        let _ = al.evaluate().await;
+        al.metagraph.write().await.block = 600;
+        let cov = al.evaluate().await;
+        assert!(
+            !cov.enforcing,
+            "0.0.0.0 axon entry must not count toward coverage"
+        );
+    }
+
+    #[tokio::test]
+    async fn chain_and_roster_ips_are_unioned() {
+        // hk_chain publishes one IP on chain; the roster has observed it from
+        // a different address (e.g., the validator just rotated egress). Both
+        // IPs should appear in the enforced source set so the rotation does
+        // not interrupt traffic.
+        let meta = build_meta(
+            vec![neuron_with_axon(0, "hk_chain", 1000, "10.0.0.1")],
+            500,
+            32767,
+            100,
+        );
+        let al = build_allowlist(meta).await;
+        let _ = al.evaluate().await;
+        al.observe_successful_handshake("hk_chain", "10.0.0.2".parse().unwrap())
+            .await;
+        al.metagraph.write().await.block = 600;
+        let cov = al.evaluate().await;
+        assert!(cov.enforcing);
+        assert!(cov.allowed_ips.contains(&"10.0.0.1".parse().unwrap()));
+        assert!(cov.allowed_ips.contains(&"10.0.0.2".parse().unwrap()));
     }
 }

--- a/crates/sn2-miner/src/main.rs
+++ b/crates/sn2-miner/src/main.rs
@@ -91,7 +91,17 @@ async fn main() -> Result<()> {
 
     let metagraph = Arc::new(RwLock::new(metagraph));
 
-    let external_ip = resolve_external_ip(cli.external_ip.as_deref()).await?;
+    let external_ip = match resolve_external_ip(cli.external_ip.as_deref()).await {
+        Ok(ip) => Some(ip),
+        Err(e) if cli.external_ip.is_none() => {
+            warn!(
+                error = ?e,
+                "external IP autodetection failed; skipping serve_axon for this boot"
+            );
+            None
+        }
+        Err(e) => return Err(e),
+    };
 
     let quic_port = cli.axon_port;
     anyhow::ensure!(quic_port != 0, "QUIC port must be non-zero");
@@ -153,13 +163,15 @@ async fn main() -> Result<()> {
         })
     };
 
-    match registration
-        .serve_axon(&chain_client, &wallet, external_ip, quic_port, 4)
-        .await
-    {
-        Ok(()) => {}
-        Err(e) => {
-            warn!(error = %e, "serve_axon failed (rate-limited or transient); miner will continue");
+    if let Some(external_ip) = external_ip {
+        match registration
+            .serve_axon(&chain_client, &wallet, external_ip, quic_port, 4)
+            .await
+        {
+            Ok(()) => {}
+            Err(e) => {
+                warn!(error = %e, "serve_axon failed (rate-limited or transient); miner will continue");
+            }
         }
     }
 

--- a/crates/sn2-miner/src/main.rs
+++ b/crates/sn2-miner/src/main.rs
@@ -7,7 +7,9 @@ mod lightning_server;
 mod nftables;
 mod roster;
 
+use std::net::IpAddr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -89,20 +91,7 @@ async fn main() -> Result<()> {
 
     let metagraph = Arc::new(RwLock::new(metagraph));
 
-    let external_ip: std::net::IpAddr = match cli.external_ip.as_deref() {
-        Some(ip) => ip.parse().context("parsing external IP")?,
-        None => {
-            let resp = reqwest::get("https://api.ipify.org")
-                .await
-                .context("detecting external IP")?
-                .text()
-                .await
-                .context("reading external IP response")?;
-            resp.trim()
-                .parse()
-                .with_context(|| format!("parsing detected IP: {resp}"))?
-        }
-    };
+    let external_ip = resolve_external_ip(cli.external_ip.as_deref()).await?;
 
     let quic_port = cli.axon_port;
     anyhow::ensure!(quic_port != 0, "QUIC port must be non-zero");
@@ -309,6 +298,41 @@ async fn run_loopback(cli: Cli) -> Result<()> {
     }
 
     Ok(())
+}
+
+async fn resolve_external_ip(override_ip: Option<&str>) -> Result<IpAddr> {
+    if let Some(ip) = override_ip {
+        let parsed: IpAddr = ip.parse().context("parsing --external-ip")?;
+        return require_ipv4(parsed);
+    }
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .context("building HTTP client for external-IP detection")?;
+    let resp = client
+        .get("https://api4.ipify.org")
+        .send()
+        .await
+        .context("detecting external IP via api4.ipify.org")?
+        .text()
+        .await
+        .context("reading external IP response body")?;
+    let parsed: IpAddr = resp
+        .trim()
+        .parse()
+        .with_context(|| format!("parsing detected IP: {resp}"))?;
+    require_ipv4(parsed)
+}
+
+fn require_ipv4(ip: IpAddr) -> Result<IpAddr> {
+    match ip {
+        IpAddr::V4(_) => Ok(ip),
+        IpAddr::V6(_) => {
+            anyhow::bail!(
+                "external IP must be IPv4 (axon registration does not support IPv6): {ip}"
+            )
+        }
+    }
 }
 
 async fn init_circuit_store(

--- a/crates/sn2-miner/src/roster.rs
+++ b/crates/sn2-miner/src/roster.rs
@@ -74,10 +74,6 @@ impl Roster {
         self.entries.get(hotkey).map(|e| e.ip.clone().into())
     }
 
-    pub fn entries(&self) -> impl Iterator<Item = &RosterEntry> {
-        self.entries.values()
-    }
-
     /// Inserts or replaces a roster entry. Returns true when this is a new hotkey or
     /// the IP changed for an existing one (caller can use this to gate writeback).
     pub fn upsert(

--- a/crates/sn2-validator/src/cli.rs
+++ b/crates/sn2-validator/src/cli.rs
@@ -83,4 +83,33 @@ pub struct Cli {
 
     #[arg(long, value_delimiter = ',')]
     pub additional_circuits: Vec<String>,
+
+    #[arg(
+        long,
+        alias = "axon.external_ip",
+        help = "External IP to publish to the subtensor Axons map so miners can \
+                enforce a source-IP allowlist. Auto-detected via api.ipify.org \
+                when unset."
+    )]
+    pub external_ip: Option<String>,
+
+    #[arg(
+        long,
+        alias = "axon.port",
+        default_value_t = 8091,
+        help = "Port published alongside external_ip in the Axons map. The \
+                validator does not bind this port — it is a placeholder used \
+                only so miners running source-IP allowlists can identify the \
+                validator's hotkey by IP."
+    )]
+    pub axon_port: u16,
+
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Skip publishing the validator axon (IP + port) to the chain. \
+                Use only when the validator runs behind an unstable egress IP \
+                and cannot serve a stable source IP to miners."
+    )]
+    pub disable_axon_publish: bool,
 }

--- a/crates/sn2-validator/src/config.rs
+++ b/crates/sn2-validator/src/config.rs
@@ -30,6 +30,9 @@ pub struct ValidatorConfig {
     pub additional_circuits: Vec<String>,
     pub verification_concurrency: Option<usize>,
     pub dispatch_ceiling: Option<usize>,
+    pub external_ip: Option<String>,
+    pub axon_port: u16,
+    pub disable_axon_publish: bool,
 }
 
 impl ValidatorConfig {
@@ -99,6 +102,9 @@ impl ValidatorConfig {
             additional_circuits: cli.additional_circuits.clone(),
             verification_concurrency: cli.verification_concurrency,
             dispatch_ceiling: cli.dispatch_ceiling,
+            external_ip: cli.external_ip.clone(),
+            axon_port: cli.axon_port,
+            disable_axon_publish: cli.disable_axon_publish,
         })
     }
 
@@ -162,6 +168,9 @@ impl ValidatorConfig {
             additional_circuits: cli.additional_circuits.clone(),
             verification_concurrency: cli.verification_concurrency,
             dispatch_ceiling: cli.dispatch_ceiling,
+            external_ip: None,
+            axon_port: cli.axon_port,
+            disable_axon_publish: true,
         })
     }
 

--- a/crates/sn2-validator/src/validator_loop/maintenance.rs
+++ b/crates/sn2-validator/src/validator_loop/maintenance.rs
@@ -36,6 +36,7 @@ impl ValidatorLoop {
 
             if now.duration_since(self.timings.metagraph_sync) > Duration::from_secs(3600) {
                 self.sync_metagraph().await?;
+                self.publish_axon_if_configured().await;
                 self.timings.metagraph_sync = now;
             }
 

--- a/crates/sn2-validator/src/validator_loop/mod.rs
+++ b/crates/sn2-validator/src/validator_loop/mod.rs
@@ -6,12 +6,12 @@ mod results;
 mod verification;
 
 use std::collections::{HashMap, VecDeque};
-use std::net::Ipv4Addr;
+use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
-use sn2_chain::WeightsSetter;
+use sn2_chain::{Registration, WeightsSetter};
 use sn2_types::*;
 use tokio::signal::unix::{signal, SignalKind};
 use tokio::sync::{watch, Notify, RwLock};
@@ -400,6 +400,8 @@ impl ValidatorLoop {
             relay.start().await?;
         }
 
+        self.publish_axon_if_configured().await;
+
         {
             let initial_miners = if self.config.loopback {
                 self.config
@@ -529,6 +531,44 @@ impl ValidatorLoop {
         Ok(())
     }
 
+    /// Publish the validator's external IP + axon port to the on-chain Axons
+    /// map. Miners running source-IP allowlists rely on this entry to identify
+    /// the validator's hotkey by source address; without it they cannot
+    /// distinguish a permitted validator from an unknown peer and must fall
+    /// back to handshake-only TOFU. `Registration::serve_axon` is idempotent
+    /// (chain state is checked first and the extrinsic is skipped if the
+    /// existing entry already matches), so callers may invoke this on every
+    /// metagraph sync without producing spurious extrinsics.
+    async fn publish_axon_if_configured(&self) {
+        if self.config.disable_axon_publish || self.config.loopback {
+            return;
+        }
+        let chain_client = match &self.config.chain_client {
+            Some(c) => c,
+            None => return,
+        };
+        let wallet = match &self.config.wallet {
+            Some(w) => w,
+            None => return,
+        };
+        let external_ip = match resolve_external_ip(self.config.external_ip.as_deref()).await {
+            Ok(ip) => ip,
+            Err(e) => {
+                warn!(error = ?e, "could not resolve external IP for axon publish; \
+                    miners with source-IP allowlists may reject this validator");
+                return;
+            }
+        };
+        let registration = Registration::new(self.config.netuid);
+        if let Err(e) = registration
+            .serve_axon(chain_client, wallet, external_ip, self.config.axon_port, 4)
+            .await
+        {
+            warn!(error = ?e, ip = %external_ip, port = self.config.axon_port,
+                "axon publish to chain failed; will retry on next metagraph sync");
+        }
+    }
+
     async fn shutdown(&mut self) {
         while self.dsperse_emit_tasks.join_next().await.is_some() {}
         if let Some(ev) = &self.dsperse_events {
@@ -566,6 +606,21 @@ impl ValidatorLoop {
         self.performance_tracker.save();
         self.rsv.save();
     }
+}
+
+async fn resolve_external_ip(override_ip: Option<&str>) -> Result<IpAddr> {
+    if let Some(ip) = override_ip {
+        return ip.parse().context("parsing --external-ip");
+    }
+    let resp = reqwest::get("https://api.ipify.org")
+        .await
+        .context("detecting external IP via api.ipify.org")?
+        .text()
+        .await
+        .context("reading external IP response body")?;
+    resp.trim()
+        .parse()
+        .with_context(|| format!("parsing detected IP: {resp}"))
 }
 
 pub(super) fn is_valid_ip(ip_str: &str) -> bool {

--- a/crates/sn2-validator/src/validator_loop/mod.rs
+++ b/crates/sn2-validator/src/validator_loop/mod.rs
@@ -610,17 +610,37 @@ impl ValidatorLoop {
 
 async fn resolve_external_ip(override_ip: Option<&str>) -> Result<IpAddr> {
     if let Some(ip) = override_ip {
-        return ip.parse().context("parsing --external-ip");
+        let parsed: IpAddr = ip.parse().context("parsing --external-ip")?;
+        return require_ipv4(parsed);
     }
-    let resp = reqwest::get("https://api.ipify.org")
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .context("building HTTP client for external-IP detection")?;
+    let resp = client
+        .get("https://api4.ipify.org")
+        .send()
         .await
-        .context("detecting external IP via api.ipify.org")?
+        .context("detecting external IP via api4.ipify.org")?
         .text()
         .await
         .context("reading external IP response body")?;
-    resp.trim()
+    let parsed: IpAddr = resp
+        .trim()
         .parse()
-        .with_context(|| format!("parsing detected IP: {resp}"))
+        .with_context(|| format!("parsing detected IP: {resp}"))?;
+    require_ipv4(parsed)
+}
+
+fn require_ipv4(ip: IpAddr) -> Result<IpAddr> {
+    match ip {
+        IpAddr::V4(_) => Ok(ip),
+        IpAddr::V6(_) => {
+            anyhow::bail!(
+                "external IP must be IPv4 (axon registration does not support IPv6): {ip}"
+            )
+        }
+    }
 }
 
 pub(super) fn is_valid_ip(ip_str: &str) -> bool {

--- a/crates/sn2-validator/src/validator_loop/mod.rs
+++ b/crates/sn2-validator/src/validator_loop/mod.rs
@@ -634,12 +634,16 @@ async fn resolve_external_ip(override_ip: Option<&str>) -> Result<IpAddr> {
 
 fn require_ipv4(ip: IpAddr) -> Result<IpAddr> {
     match ip {
-        IpAddr::V4(_) => Ok(ip),
-        IpAddr::V6(_) => {
-            anyhow::bail!(
-                "external IP must be IPv4 (axon registration does not support IPv6): {ip}"
-            )
-        }
+        IpAddr::V4(v4) if is_valid_ip(&v4.to_string()) => Ok(IpAddr::V4(v4)),
+        IpAddr::V4(v4) => anyhow::bail!(
+            "external IP must be a publicly routable IPv4 (loopback, RFC1918, \
+             CGNAT, link-local, multicast, and unspecified addresses are \
+             rejected so a misconfigured override does not count toward miner \
+             allowlist coverage without admitting the real public source): {v4}"
+        ),
+        IpAddr::V6(_) => anyhow::bail!(
+            "external IP must be IPv4 (axon registration does not support IPv6): {ip}"
+        ),
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `--external-ip`, `--axon-port`, and `--disable-axon-publish` flags to the validator. On startup and on every metagraph sync, call `Registration::serve_axon` so the validator's source IP appears in the on-chain Axons map. `serve_axon` is already idempotent (matching entries short-circuit), so periodic re-submission costs at most one storage read per hour.
- Extend the miner-side `ValidatorAllowlist` so a permit holder's on-chain `axon_ip` counts toward kappa coverage and is unioned with any TOFU roster entry into the enforced source-address set. The `0.0.0.0` sentinel (validators that have not yet run `serve_axon`) is treated as absent, so the existing TOFU path keeps covering legacy validators during a rolling release.

## Motivation

`ValidatorAllowlist` from #510 learns `(hotkey -> source IP)` via successful handshakes only. If the miner drops the very first handshake (source-address allowlist tripping while the roster is empty, transient transport error mid-handshake, etc.), the validator can never be added via TOFU; every subsequent dispatch is rejected at `verify_synapse_auth` with `handler error: authentication failed`. On the validator, that reply path passes through `record_reschedule` (`PERFORMANCE_RESCHEDULE_PENALTY = -0.5`), which drives the miner's effective rate to 0 in `uid_rate`, which causes the weight commit to collapse to owner-burn-only.

Once validators publish their source IPs to chain, the chain entry is sufficient to admit the source address from the first packet, the TOFU bootstrap becomes unnecessary for upgraded validators, and the cascade above cannot start.

## Rollout

- Phase 1 (this PR): validator-side publish + miner-side hybrid allowlist that prefers chain IP and falls back to TOFU. Safe to deploy on either side independently.
- Phase 2 (separate PR, once validators on the network have published): delete \`roster.rs\`, the TOFU paths in \`allowlist.rs\`, and the \`HandshakeObserver\` plumbing. Replace \`ValidatorAllowlist\` with a thin wrapper over \`MetagraphSourceResolver\`.

## Test plan

- [x] \`cargo check --bin sn2-validator --bin sn2-miner\`
- [x] \`cargo clippy --bin sn2-validator --bin sn2-miner --tests -- -D warnings\`
- [x] \`cargo fmt --check\`
- [x] \`cargo test --bin sn2-miner allowlist::\` (7 tests: 4 pre-existing + 3 new -- chain IP alone covers kappa, \`0.0.0.0\` does not count, chain and roster IPs are unioned)
- [ ] Manual: deploy validator with \`--external-ip\` and confirm the chain Axons entry is populated.
- [ ] Manual: deploy upgraded miner alongside; confirm \`Coverage::observed_permit_stake\` increases with each new validator that publishes.

## Security note

Publishing axon IPs makes validator source addresses enumerable from the chain. The same is already true for miners and for validators on subnets that \`serve_axon\` by default, so the change is consistent with the broader ecosystem, but operators relying on opaque egress as a defense layer should review their topology before the upgrade.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validators can publish Axon metadata (external IP + port) on-chain; CLI/config options to set external IP, port, or disable publishing. Autodetect uses an IPv4 service; IPv6 is rejected.

* **Improvements**
  * Miners evaluate and enforce allowlists using both chain-published Axon IPs and roster-observed IPs; unspecified placeholder addresses are ignored.
  * Validator startup/maintenance will attempt publishing when configured and log warnings on resolution/publish failures without blocking startup.

* **Tests**
  * Added tests covering chain-published Axon IPs, unspecified addresses, and combined chain/roster coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inference-labs-inc/subnet-2/pull/516?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->