### PR TITLE
Resolve semgrep JS WebSocket rule false-positive on subxt endpoint dispatch

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -63,6 +63,7 @@ jobs:
       - name: Run Semgrep
         run: |
           semgrep --config=auto \
+            --exclude-rule=javascript.lang.security.detect-insecure-websocket.detect-insecure-websocket \
             --json --output=semgrep-results.json \
             --error
 
@@ -70,6 +71,7 @@ jobs:
         if: always()
         run: |
           semgrep --config=auto \
+            --exclude-rule=javascript.lang.security.detect-insecure-websocket.detect-insecure-websocket \
             --sarif --output=semgrep-results.sarif \
             || true
 


### PR DESCRIPTION
## Summary

The release security gate has been failing on `testnet` since #515 with two blocking semgrep findings, both on the same rule:

- `crates/sn2-chain/src/lib.rs:34` — doc comment that documents the dispatch contract (mentions `\`ws://\`` and `\`wss://\``)
- `crates/sn2-chain/src/lib.rs:38` — runtime branch `endpoint.starts_with(\"ws://\")` selecting subxt's `from_insecure_url` for non-TLS substrate sockets

The rule is `javascript.lang.security.detect-insecure-websocket.detect-insecure-websocket`. It targets browser `new WebSocket(\"ws://...\")` patterns in JavaScript, but semgrep's `--config=auto` fires it against any source containing the `\"ws://\"` literal regardless of language scope. These match sites are in Rust and describe the intended, documented behavior introduced in #515 to allow operators to reach `ws://127.0.0.1:9944` or other internal substrate RPCs that subxt rejects under TLS-validating `from_url`.

Excluding the rule at the workflow level on both the gating scan and the SARIF generation pass. The repository contains no JavaScript source, so excluding a JS-scoped rule has no defensive cost.

## Validation

- [x] Local: `semgrep --config=auto --exclude-rule=javascript.lang.security.detect-insecure-websocket.detect-insecure-websocket .` → `Ran 333 rules on 129 files: 0 findings.` (down from `2 findings` blocking).
- [ ] CI security-gate semgrep step passes on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning configuration to exclude a specific insecure WebSocket detection rule from automated checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inference-labs-inc/subnet-2/pull/524?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->