### PR TITLE
Introduce BT_AXON_EXTERNAL_IP environment override on validator CLI

### DIFF
--- a/crates/sn2-validator/src/cli.rs
+++ b/crates/sn2-validator/src/cli.rs
@@ -87,9 +87,11 @@ pub struct Cli {
     #[arg(
         long,
         alias = "axon.external_ip",
+        env = "BT_AXON_EXTERNAL_IP",
         help = "External IP to publish to the subtensor Axons map so miners can \
                 enforce a source-IP allowlist. Auto-detected via api.ipify.org \
-                when unset."
+                when unset. May also be supplied via the BT_AXON_EXTERNAL_IP \
+                environment variable; the CLI flag wins when both are present."
     )]
     pub external_ip: Option<String>,
 
@@ -112,4 +114,44 @@ pub struct Cli {
                 and cannot serve a stable source IP to miners."
     )]
     pub disable_axon_publish: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Cli;
+    use clap::Parser;
+
+    fn min_args() -> Vec<&'static str> {
+        vec!["sn2-validator"]
+    }
+
+    #[test]
+    fn external_ip_resolution_prefers_cli_then_env_then_unset() {
+        // The env var and CLI flag share a single field; clap's resolution
+        // rule is "CLI wins over env, env wins over default/unset". The three
+        // assertions run inside one test so the env mutation isn't racing
+        // with sibling parser invocations on other rules.
+        let var = "BT_AXON_EXTERNAL_IP";
+
+        // Snapshot any operator-set value so the test doesn't clobber it.
+        let prior = std::env::var(var).ok();
+
+        std::env::remove_var(var);
+        let cli = Cli::try_parse_from(min_args()).expect("parse without env");
+        assert_eq!(cli.external_ip, None);
+
+        std::env::set_var(var, "10.0.0.42");
+        let cli = Cli::try_parse_from(min_args()).expect("parse with env only");
+        assert_eq!(cli.external_ip.as_deref(), Some("10.0.0.42"));
+
+        let mut args = min_args();
+        args.extend_from_slice(&["--external-ip", "10.0.0.99"]);
+        let cli = Cli::try_parse_from(args).expect("parse with flag overriding env");
+        assert_eq!(cli.external_ip.as_deref(), Some("10.0.0.99"));
+
+        match prior {
+            Some(v) => std::env::set_var(var, v),
+            None => std::env::remove_var(var),
+        }
+    }
 }

--- a/crates/sn2-validator/src/cli.rs
+++ b/crates/sn2-validator/src/cli.rs
@@ -125,16 +125,34 @@ mod tests {
         vec!["sn2-validator"]
     }
 
+    struct EnvRestore {
+        var: &'static str,
+        prior: Option<String>,
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            match self.prior.take() {
+                Some(v) => std::env::set_var(self.var, v),
+                None => std::env::remove_var(self.var),
+            }
+        }
+    }
+
     #[test]
     fn external_ip_resolution_prefers_cli_then_env_then_unset() {
         // The env var and CLI flag share a single field; clap's resolution
         // rule is "CLI wins over env, env wins over default/unset". The three
         // assertions run inside one test so the env mutation isn't racing
-        // with sibling parser invocations on other rules.
+        // with sibling parser invocations on other rules. EnvRestore is an
+        // RAII guard that restores the operator's original value even if any
+        // assertion below panics, so a failing assertion can't leak mutated
+        // state into the rest of the test binary.
         let var = "BT_AXON_EXTERNAL_IP";
-
-        // Snapshot any operator-set value so the test doesn't clobber it.
-        let prior = std::env::var(var).ok();
+        let _guard = EnvRestore {
+            var,
+            prior: std::env::var(var).ok(),
+        };
 
         std::env::remove_var(var);
         let cli = Cli::try_parse_from(min_args()).expect("parse without env");
@@ -148,10 +166,5 @@ mod tests {
         args.extend_from_slice(&["--external-ip", "10.0.0.99"]);
         let cli = Cli::try_parse_from(args).expect("parse with flag overriding env");
         assert_eq!(cli.external_ip.as_deref(), Some("10.0.0.99"));
-
-        match prior {
-            Some(v) => std::env::set_var(var, v),
-            None => std::env::remove_var(var),
-        }
     }
 }


### PR DESCRIPTION
## Summary

Extends the validator's existing `--external-ip` parser with a clap `env` binding to `BT_AXON_EXTERNAL_IP`, matching the ecosystem-wide `BT_AXON_*` convention used by btcli and other bittensor tooling. Operators can now layer the override into systemd unit files or container manifests without rewriting the command line.

Resolution rules (clap's default for `env`):

| State | Result |
|---|---|
| Neither set | `external_ip = None` (falls back to api.ipify.org auto-detect, as before #516) |
| Only `BT_AXON_EXTERNAL_IP=1.2.3.4` | `external_ip = Some("1.2.3.4")` |
| Only `--external-ip 1.2.3.4` | `external_ip = Some("1.2.3.4")` |
| Both set | CLI flag wins |

Backward compat: the prior `--external-ip` behavior is unchanged.

## Test plan

- [x] `cargo build -p sn2-validator --locked`
- [x] `cargo test -p sn2-validator cli:: --locked` (1 new test, 100 existing pass)
- [x] `cargo clippy -p sn2-validator --all-targets --locked -- -D warnings`
- [x] `cargo fmt --check`
- [ ] CI green
- [ ] Operator smoke: deploy a validator with `BT_AXON_EXTERNAL_IP` set in the systemd `Environment=` block, no `--external-ip` flag, confirm chain Axons entry matches the env-provided IP

The single regression test exercises all three resolution paths inside one test body to avoid env-var races against sibling parallel tests, snapshotting and restoring any operator-set value at start/end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The --external-ip option now also reads BT_AXON_EXTERNAL_IP from the environment; the CLI flag takes precedence when both are present. Help text updated to document this behavior.

* **Tests**
  * Added tests confirming env-var support, absence behavior, and that an explicit CLI flag overrides the environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inference-labs-inc/subnet-2/pull/525?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->