### PR TITLE
Introduce SN2_CIRCUIT_CACHE_DIR override for circuit cache directory

### DIFF
--- a/crates/sn2-circuit-store/src/lib.rs
+++ b/crates/sn2-circuit-store/src/lib.rs
@@ -50,8 +50,10 @@ impl CircuitStore {
         api_url_override: Option<&str>,
         loopback: bool,
         additional_circuits: Vec<String>,
+        cache_dir_override: Option<&str>,
     ) -> Self {
-        let cache_dir = shellexpand::tilde(CIRCUIT_CACHE_DIR).to_string();
+        let cache_dir =
+            shellexpand::tilde(cache_dir_override.unwrap_or(CIRCUIT_CACHE_DIR)).to_string();
         let api_url_overridden = api_url_override.is_some();
         Self {
             circuits: HashMap::new(),

--- a/crates/sn2-miner/src/cli.rs
+++ b/crates/sn2-miner/src/cli.rs
@@ -85,6 +85,17 @@ pub struct Cli {
     #[arg(long, value_delimiter = ',')]
     pub additional_circuits: Vec<String>,
 
+    #[arg(
+        long,
+        env = "SN2_CIRCUIT_CACHE_DIR",
+        help = "Directory for the persisted circuit cache. Defaults to \
+                ~/.bittensor/subnet-2/circuit_cache when unset. May also be \
+                supplied via the SN2_CIRCUIT_CACHE_DIR environment variable; \
+                the CLI flag wins when both are present. A leading ~ is \
+                expanded to the home directory."
+    )]
+    pub circuit_cache_dir: Option<String>,
+
     #[arg(long, default_value_t = sn2_types::CIRCUIT_TIMEOUT_SECONDS, value_parser = clap::value_parser!(u64).range(1..))]
     pub handler_timeout: u64,
 }

--- a/crates/sn2-miner/src/main.rs
+++ b/crates/sn2-miner/src/main.rs
@@ -106,7 +106,12 @@ async fn main() -> Result<()> {
 
     let dsperse = dsperse::DSperseClient::new();
 
-    let circuit_store = init_circuit_store(false, &cli.additional_circuits).await;
+    let circuit_store = init_circuit_store(
+        false,
+        &cli.additional_circuits,
+        cli.circuit_cache_dir.as_deref(),
+    )
+    .await;
 
     let handlers = handlers::MinerHandlers::new(dsperse, circuit_store);
     let handlers = std::sync::Arc::new(handlers);
@@ -261,7 +266,12 @@ async fn run_loopback(cli: Cli) -> Result<()> {
 
     let dsperse = dsperse::DSperseClient::new();
 
-    let circuit_store = init_circuit_store(true, &cli.additional_circuits).await;
+    let circuit_store = init_circuit_store(
+        true,
+        &cli.additional_circuits,
+        cli.circuit_cache_dir.as_deref(),
+    )
+    .await;
 
     let handlers = handlers::MinerHandlers::new(dsperse, circuit_store);
     let handlers = std::sync::Arc::new(handlers);
@@ -348,9 +358,14 @@ fn require_ipv4(ip: IpAddr) -> Result<IpAddr> {
 async fn init_circuit_store(
     loopback: bool,
     additional_circuits: &[String],
+    cache_dir_override: Option<&str>,
 ) -> sn2_circuit_store::CircuitStore {
-    let mut store =
-        sn2_circuit_store::CircuitStore::new(None, loopback, additional_circuits.to_vec());
+    let mut store = sn2_circuit_store::CircuitStore::new(
+        None,
+        loopback,
+        additional_circuits.to_vec(),
+        cache_dir_override,
+    );
     if let Err(e) = store.load_circuits().await {
         warn!(error = %e, "failed to load circuits from cache");
     }

--- a/crates/sn2-validator/src/cli.rs
+++ b/crates/sn2-validator/src/cli.rs
@@ -51,6 +51,17 @@ pub struct Cli {
     #[arg(long)]
     pub circuit_api_url: Option<String>,
 
+    #[arg(
+        long,
+        env = "SN2_CIRCUIT_CACHE_DIR",
+        help = "Directory for the persisted circuit cache. Defaults to \
+                ~/.bittensor/subnet-2/circuit_cache when unset. May also be \
+                supplied via the SN2_CIRCUIT_CACHE_DIR environment variable; \
+                the CLI flag wins when both are present. A leading ~ is \
+                expanded to the home directory."
+    )]
+    pub circuit_cache_dir: Option<String>,
+
     #[arg(long)]
     pub verification_concurrency: Option<usize>,
 
@@ -166,5 +177,31 @@ mod tests {
         args.extend_from_slice(&["--external-ip", "10.0.0.99"]);
         let cli = Cli::try_parse_from(args).expect("parse with flag overriding env");
         assert_eq!(cli.external_ip.as_deref(), Some("10.0.0.99"));
+    }
+
+    #[test]
+    fn circuit_cache_dir_resolution_prefers_cli_then_env_then_unset() {
+        // Mirrors external_ip: a single field backs both the CLI flag and the
+        // SN2_CIRCUIT_CACHE_DIR env var, with CLI winning over env and env over
+        // unset. Guarded by EnvRestore so a panicking assertion cannot leak the
+        // mutated value into sibling tests in this binary.
+        let var = "SN2_CIRCUIT_CACHE_DIR";
+        let _guard = EnvRestore {
+            var,
+            prior: std::env::var(var).ok(),
+        };
+
+        std::env::remove_var(var);
+        let cli = Cli::try_parse_from(min_args()).expect("parse without env");
+        assert_eq!(cli.circuit_cache_dir, None);
+
+        std::env::set_var(var, "/var/cache/sn2");
+        let cli = Cli::try_parse_from(min_args()).expect("parse with env only");
+        assert_eq!(cli.circuit_cache_dir.as_deref(), Some("/var/cache/sn2"));
+
+        let mut args = min_args();
+        args.extend_from_slice(&["--circuit-cache-dir", "/srv/circuits"]);
+        let cli = Cli::try_parse_from(args).expect("parse with flag overriding env");
+        assert_eq!(cli.circuit_cache_dir.as_deref(), Some("/srv/circuits"));
     }
 }

--- a/crates/sn2-validator/src/config.rs
+++ b/crates/sn2-validator/src/config.rs
@@ -25,6 +25,7 @@ pub struct ValidatorConfig {
     pub proof_api_url: Option<String>,
     pub target_uids: Option<HashSet<u16>>,
     pub circuit_api_url: Option<String>,
+    pub circuit_cache_dir: Option<String>,
     pub disable_metric_logging: bool,
     pub loopback: bool,
     pub additional_circuits: Vec<String>,
@@ -95,6 +96,7 @@ impl ValidatorConfig {
                 Some(cli.target_uid.iter().copied().collect())
             },
             circuit_api_url: cli.circuit_api_url.clone(),
+            circuit_cache_dir: cli.circuit_cache_dir.clone(),
             disable_metric_logging: cli.disable_metric_logging,
             loopback: false,
             additional_circuits: cli.additional_circuits.clone(),
@@ -161,6 +163,7 @@ impl ValidatorConfig {
             proof_api_url: None,
             target_uids: Some([0].into_iter().collect()),
             circuit_api_url: cli.circuit_api_url.clone(),
+            circuit_cache_dir: cli.circuit_cache_dir.clone(),
             disable_metric_logging: true,
             loopback: true,
             additional_circuits: cli.additional_circuits.clone(),

--- a/crates/sn2-validator/src/validator_loop/mod.rs
+++ b/crates/sn2-validator/src/validator_loop/mod.rs
@@ -345,6 +345,7 @@ impl ValidatorLoop {
             config.circuit_api_url.as_deref(),
             circuit_store_loopback,
             config.additional_circuits.clone(),
+            config.circuit_cache_dir.as_deref(),
         );
         let run_manager = IncrementalRunManager::new();
 


### PR DESCRIPTION
## Summary

The circuit cache directory was hardcoded to `~/.bittensor/subnet-2/circuit_cache` (the `CIRCUIT_CACHE_DIR` constant) with no way to relocate it short of changing `HOME`. This adds a first-class override on both the validator and miner.

## Changes

- `CircuitStore::new` takes an optional `cache_dir_override`; when set it is used in place of the default constant. Both paths are `~`-expanded via `shellexpand::tilde`, so `~/foo` works either way.
- Both binaries expose `--circuit-cache-dir`, backed by the `SN2_CIRCUIT_CACHE_DIR` environment variable through clap's `env =`. The CLI flag wins when both are present — mirroring the existing `BT_AXON_EXTERNAL_IP` resolution pattern.
- Threaded through `ValidatorConfig` (both `from_cli` and `from_cli_loopback`) and the miner's `init_circuit_store` (both standard and loopback boot paths).
- Added a precedence test on the validator CLI verifying CLI-over-env-over-unset.

## Precedence

`--circuit-cache-dir` > `SN2_CIRCUIT_CACHE_DIR` > default `~/.bittensor/subnet-2/circuit_cache`.

## Verification

`cargo build`, `cargo clippy --all-targets -- -D warnings`, and `cargo fmt --check` all clean across the three affected crates; CLI precedence tests pass.