### PR TITLE
Resolve circuit cache override coverage gap in miner DSperse path

### DIFF
--- a/crates/sn2-miner/src/dsperse.rs
+++ b/crates/sn2-miner/src/dsperse.rs
@@ -112,10 +112,17 @@ fn prove_and_build_response(
 }
 
 impl DSperseClient {
-    pub fn new() -> Self {
-        let cache_dir = PathBuf::from(shellexpand::tilde(sn2_types::CIRCUIT_CACHE_DIR).to_string());
+    pub fn new(cache_dir_override: Option<&str>) -> Self {
+        let cache_dir = PathBuf::from(
+            shellexpand::tilde(cache_dir_override.unwrap_or(sn2_types::CIRCUIT_CACHE_DIR))
+                .to_string(),
+        );
         info!(cache_dir = %cache_dir.display(), "initialized DSperseClient");
         Self { cache_dir }
+    }
+
+    pub fn cache_dir(&self) -> &Path {
+        &self.cache_dir
     }
 
     pub async fn resolve_component(

--- a/crates/sn2-miner/src/handlers.rs
+++ b/crates/sn2-miner/src/handlers.rs
@@ -112,11 +112,11 @@ impl MinerHandlers {
             Some(dir) => dir,
             None => {
                 let slice_id = normalize_slice_id(slice_num)?;
-                let slices_dir = std::path::PathBuf::from(
-                    shellexpand::tilde(sn2_types::CIRCUIT_CACHE_DIR).to_string(),
-                )
-                .join(format!("model_{circuit_id}"))
-                .join("slices");
+                let slices_dir = self
+                    .dsperse
+                    .cache_dir()
+                    .join(format!("model_{circuit_id}"))
+                    .join("slices");
                 slices_dir.join(slice_id)
             }
         };

--- a/crates/sn2-miner/src/main.rs
+++ b/crates/sn2-miner/src/main.rs
@@ -104,7 +104,7 @@ async fn main() -> Result<()> {
     let quic_port = cli.axon_port;
     anyhow::ensure!(quic_port != 0, "QUIC port must be non-zero");
 
-    let dsperse = dsperse::DSperseClient::new();
+    let dsperse = dsperse::DSperseClient::new(cli.circuit_cache_dir.as_deref());
 
     let circuit_store = init_circuit_store(
         false,
@@ -264,7 +264,7 @@ async fn run_loopback(cli: Cli) -> Result<()> {
     )
     .context("loading wallet")?;
 
-    let dsperse = dsperse::DSperseClient::new();
+    let dsperse = dsperse::DSperseClient::new(cli.circuit_cache_dir.as_deref());
 
     let circuit_store = init_circuit_store(
         true,


### PR DESCRIPTION
## Context

Follow-up to #533. Live verification on sn2-testnet-1 (release `testnet-70e0e883`) confirmed the validator/miner CLI flag and `SN2_CIRCUIT_CACHE_DIR` env var both correctly route `CircuitStore` to the configured directory (strace-verified: flag wins over env, env over default, tilde-expanded). That testing surfaced a coverage gap this PR closes.

## Problem

The override threaded through `CircuitStore` did **not** reach two other miner consumers that independently resolved the hardcoded `CIRCUIT_CACHE_DIR` constant:

- `DSperseClient::new` (`dsperse.rs`) — read/wrote model dirs at the default path
- the `QueryDSlice` handler (`handlers.rs`) — built its slices path from the constant

With the cache relocated, `CircuitStore` downloaded circuits into the override directory while `DSperseClient` and the handler still read the **default** path — a split-brain that breaks slice resolution and proof generation under a relocated cache. Observed directly on the box: `DSperseClient` logged `cache_dir=/root/.bittensor/subnet-2/circuit_cache` even when `--circuit-cache-dir` pointed elsewhere.

## Change

- `DSperseClient::new` accepts the optional override (same tilde-expansion as `CircuitStore`); both miner call sites pass `cli.circuit_cache_dir`.
- Added a `cache_dir()` accessor; the `QueryDSlice` handler now derives its slices directory from that single source instead of re-resolving the constant — removing the duplicate resolution (DRY).

## Scope check

Audited every `CIRCUIT_CACHE_DIR` consumer. Validator-side maintenance and the verify crate derive their paths from `CircuitStore::cache_dir()`, so they already honor the override; only the two miner sites above were unhooked.

## Verification

`cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` clean. End-to-end behavior on the box will be re-confirmed against the next testnet release that includes this commit.