### PR TITLE
Resolve circuit artifact integrity and decode depth coverage gaps

### DIFF
--- a/crates/sn2-circuit-store/src/lib.rs
+++ b/crates/sn2-circuit-store/src/lib.rs
@@ -462,6 +462,10 @@ impl CircuitStore {
         circuit_id: &str,
         data: &serde_json::Value,
     ) -> Result<(Circuit, Vec<(String, String)>)> {
+        anyhow::ensure!(
+            is_sha256_hex(circuit_id),
+            "invalid circuit id {circuit_id:?}: expected 64-character sha256 hex"
+        );
         let cache_path = self.cache_dir.join(format!("model_{circuit_id}"));
         let is_fresh = !cache_path.exists();
         std::fs::create_dir_all(&cache_path)
@@ -648,7 +652,11 @@ impl CircuitStore {
                     .get("sha256")
                     .and_then(|v| v.as_str())
                     .context("component missing sha256")?
-                    .to_string();
+                    .to_lowercase();
+                anyhow::ensure!(
+                    is_sha256_hex(&sha),
+                    "component {name}: invalid sha256 {sha:?}"
+                );
                 let files: Vec<String> = comp
                     .get("files")
                     .and_then(|v| v.as_array())
@@ -658,28 +666,29 @@ impl CircuitStore {
                             .collect()
                     })
                     .unwrap_or_default();
-                let weights: Vec<WeightRef> = comp
-                    .get("weights")
-                    .and_then(|v| v.as_array())
-                    .map(|arr| {
-                        arr.iter()
-                            .enumerate()
-                            .filter_map(|(i, w)| {
-                                let wb_sha = w.get("sha256")?.as_str()?.to_string();
-                                let fallback = format!("{name}_weight_{i}.onnx");
-                                let filename = w
-                                    .get("filename")
-                                    .and_then(|v| v.as_str())
-                                    .unwrap_or(&fallback)
-                                    .to_string();
-                                Some(WeightRef {
-                                    sha: wb_sha,
-                                    filename,
-                                })
-                            })
-                            .collect()
-                    })
-                    .unwrap_or_default();
+                let mut weights: Vec<WeightRef> = Vec::new();
+                if let Some(arr) = comp.get("weights").and_then(|v| v.as_array()) {
+                    for (i, w) in arr.iter().enumerate() {
+                        let Some(wb_sha) = w.get("sha256").and_then(|v| v.as_str()) else {
+                            continue;
+                        };
+                        let wb_sha = wb_sha.to_lowercase();
+                        anyhow::ensure!(
+                            is_sha256_hex(&wb_sha),
+                            "component {name}: invalid weight blob sha256 {wb_sha:?}"
+                        );
+                        let fallback = format!("{name}_weight_{i}.onnx");
+                        let filename = w
+                            .get("filename")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or(&fallback)
+                            .to_string();
+                        weights.push(WeightRef {
+                            sha: wb_sha,
+                            filename,
+                        });
+                    }
+                }
                 let has_circuit = files.iter().any(|f| f == "circuit.bin");
                 Ok(ParsedComponent {
                     name,
@@ -808,7 +817,7 @@ impl CircuitStore {
                     "{}/components/{}/files/{}",
                     self.api_url, comp.sha, filename
                 );
-                self.download_file(&url, &dest)
+                self.download_file(&url, &dest, None)
                     .await
                     .with_context(|| format!("downloading {}/{}", comp.name, filename))?;
             }
@@ -830,7 +839,7 @@ impl CircuitStore {
                 continue;
             }
             let url = format!("{}/models/wb/{}", self.api_url, wb.sha);
-            self.download_file(&url, &dest)
+            self.download_file(&url, &dest, Some(&wb.sha))
                 .await
                 .with_context(|| format!("downloading weight blob for {}", comp.name))?;
             Self::write_weight_sha_stamp(&dest, &wb.sha);
@@ -1016,7 +1025,12 @@ impl CircuitStore {
                 .get("sha256")
                 .and_then(|v| v.as_str())
                 .filter(|s| !s.is_empty())
-                .context("model artifact missing sha256")?;
+                .context("model artifact missing sha256")?
+                .to_lowercase();
+            anyhow::ensure!(
+                is_sha256_hex(&sha),
+                "model artifact: invalid sha256 {sha:?}"
+            );
             let raw_filename = artifact
                 .get("filename")
                 .and_then(|v| v.as_str())
@@ -1027,7 +1041,7 @@ impl CircuitStore {
                 continue;
             }
             let url = format!("{}/models/wb/{}", self.api_url, sha);
-            self.download_file(&url, &dest)
+            self.download_file(&url, &dest, Some(&sha))
                 .await
                 .with_context(|| format!("downloading model artifact {filename}"))?;
             info!(filename, "downloaded model artifact");
@@ -1121,7 +1135,7 @@ impl CircuitStore {
     ) -> Option<(String, Circuit)> {
         let dir_name = entry.file_name().to_string_lossy().to_string();
         let circuit_id = match dir_name.strip_prefix("model_") {
-            Some(id) if id.len() == 64 => id.to_string(),
+            Some(id) if is_sha256_hex(id) => id.to_string(),
             _ => return None,
         };
 
@@ -1157,12 +1171,29 @@ impl CircuitStore {
         }
     }
 
-    async fn download_file(&self, url: &str, dest: &Path) -> Result<()> {
-        download_file_static(&self.http, url, dest).await
+    async fn download_file(
+        &self,
+        url: &str,
+        dest: &Path,
+        pinned_sha256: Option<&str>,
+    ) -> Result<()> {
+        download_file_static(&self.http, url, dest, pinned_sha256).await
     }
 }
 
-async fn download_file_static(http: &reqwest::Client, url: &str, dest: &Path) -> Result<()> {
+async fn download_file_static(
+    http: &reqwest::Client,
+    url: &str,
+    dest: &Path,
+    pinned_sha256: Option<&str>,
+) -> Result<()> {
+    if let Some(pinned) = pinned_sha256 {
+        anyhow::ensure!(
+            is_sha256_hex(pinned),
+            "pinned sha256 for {url} is not 64-character hex: {pinned:?}"
+        );
+    }
+
     let resp = http
         .get(url)
         .timeout(std::time::Duration::from_secs(300))
@@ -1174,11 +1205,14 @@ async fn download_file_static(http: &reqwest::Client, url: &str, dest: &Path) ->
         anyhow::bail!("download returned {}", resp.status());
     }
 
-    let expected_sha256 = resp
-        .headers()
-        .get("x-checksum-sha256")
-        .and_then(|v| v.to_str().ok())
+    let expected_sha256 = pinned_sha256
         .map(|s| s.trim().to_lowercase())
+        .or_else(|| {
+            resp.headers()
+                .get("x-checksum-sha256")
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.trim().to_lowercase())
+        })
         .or_else(|| {
             let segment = url.rsplit('/').next()?;
             let clean = segment.split('?').next()?;

--- a/crates/sn2-circuit-store/src/lib.rs
+++ b/crates/sn2-circuit-store/src/lib.rs
@@ -670,6 +670,11 @@ impl CircuitStore {
                 if let Some(arr) = comp.get("weights").and_then(|v| v.as_array()) {
                     for (i, w) in arr.iter().enumerate() {
                         let Some(wb_sha) = w.get("sha256").and_then(|v| v.as_str()) else {
+                            warn!(
+                                component = %name,
+                                index = i,
+                                "skipping weight entry with missing sha256"
+                            );
                             continue;
                         };
                         let wb_sha = wb_sha.to_lowercase();

--- a/crates/sn2-types/src/circuit.rs
+++ b/crates/sn2-types/src/circuit.rs
@@ -76,8 +76,11 @@ impl Circuit {
             _ => return Ok(()),
         };
 
-        let value = rmpv::decode::read_value(&mut &inputs[..])
-            .map_err(|e| format!("decoding msgpack inputs: {e}"))?;
+        let value = rmpv::decode::read_value_with_max_depth(
+            &mut &inputs[..],
+            crate::tensor_codec::MSGPACK_MAX_DEPTH,
+        )
+        .map_err(|e| format!("decoding msgpack inputs: {e}"))?;
 
         let entries = match &value {
             rmpv::Value::Map(entries) => entries,

--- a/crates/sn2-types/src/tensor_codec.rs
+++ b/crates/sn2-types/src/tensor_codec.rs
@@ -7,6 +7,7 @@ use std::io::Read;
 const MAX_TENSOR_ELEMENTS: usize = 16_777_216;
 const MAX_PROTOBUF_BYTES: usize = 128 * 1024 * 1024;
 const MAX_PROTO_SHAPE_DIMS: usize = 32;
+pub const MSGPACK_MAX_DEPTH: usize = 64;
 
 pub fn decode_gzipped_protobuf_tensor(gzipped: &[u8], shape: &[usize]) -> Result<ArrayD<f64>> {
     let expected = shape
@@ -327,9 +328,12 @@ pub fn input_data_payload(arr: &ArrayD<f64>) -> bytes::Bytes {
 }
 
 pub fn decode_msgpack_value(bytes: &[u8]) -> anyhow::Result<rmpv::Value> {
-    rmpv::decode::read_value(&mut &bytes[..]).context("decoding msgpack value")
+    rmpv::decode::read_value_with_max_depth(&mut &bytes[..], MSGPACK_MAX_DEPTH)
+        .context("decoding msgpack value")
 }
 
 pub fn decode_msgpack_to_json(bytes: &[u8]) -> anyhow::Result<serde_json::Value> {
-    rmp_serde::from_slice::<serde_json::Value>(bytes).context("decoding msgpack to json")
+    let mut deserializer = rmp_serde::Deserializer::from_read_ref(bytes);
+    deserializer.set_max_depth(MSGPACK_MAX_DEPTH);
+    serde::Deserialize::deserialize(&mut deserializer).context("decoding msgpack to json")
 }

--- a/crates/sn2-validator/src/miner_client.rs
+++ b/crates/sn2-validator/src/miner_client.rs
@@ -7,9 +7,8 @@ use btlightning::{LightningClient, QuicAxonInfo, QuicRequest, Signer};
 use rmpv::Value as RmpvValue;
 use serde_json::Value as JsonValue;
 use sn2_chain::Wallet;
+use sn2_types::tensor_codec::MSGPACK_MAX_DEPTH;
 use tracing::{debug, info};
-
-const MAX_RESPONSE_VALUE_DEPTH: usize = 64;
 
 /// Converts an `rmpv::Value` tree into a `serde_json::Value`, hex-encoding any
 /// MessagePack `bin` payloads so they appear as hex strings to the rest of the
@@ -22,8 +21,8 @@ fn rmpv_to_json_value(value: RmpvValue) -> Result<JsonValue> {
 
 fn rmpv_to_json_value_bounded(value: RmpvValue, depth: usize) -> Result<JsonValue> {
     anyhow::ensure!(
-        depth <= MAX_RESPONSE_VALUE_DEPTH,
-        "miner response nesting depth exceeds {MAX_RESPONSE_VALUE_DEPTH}"
+        depth <= MSGPACK_MAX_DEPTH,
+        "miner response nesting depth exceeds {MSGPACK_MAX_DEPTH}"
     );
     Ok(match value {
         RmpvValue::Nil => JsonValue::Null,
@@ -242,7 +241,7 @@ mod tests {
     #[test]
     fn nesting_beyond_depth_limit_is_rejected() {
         let mut value = RmpvValue::Nil;
-        for _ in 0..=MAX_RESPONSE_VALUE_DEPTH {
+        for _ in 0..=MSGPACK_MAX_DEPTH {
             value = RmpvValue::Array(vec![value]);
         }
         let err = rmpv_to_json_value(value).unwrap_err().to_string();
@@ -252,7 +251,7 @@ mod tests {
     #[test]
     fn nesting_at_depth_limit_is_accepted() {
         let mut value = RmpvValue::Boolean(true);
-        for _ in 0..MAX_RESPONSE_VALUE_DEPTH {
+        for _ in 0..MSGPACK_MAX_DEPTH {
             value = RmpvValue::Array(vec![value]);
         }
         assert!(rmpv_to_json_value(value).is_ok());

--- a/crates/sn2-validator/src/miner_client.rs
+++ b/crates/sn2-validator/src/miner_client.rs
@@ -9,13 +9,23 @@ use serde_json::Value as JsonValue;
 use sn2_chain::Wallet;
 use tracing::{debug, info};
 
+const MAX_RESPONSE_VALUE_DEPTH: usize = 64;
+
 /// Converts an `rmpv::Value` tree into a `serde_json::Value`, hex-encoding any
 /// MessagePack `bin` payloads so they appear as hex strings to the rest of the
 /// validator pipeline. This is the wire-boundary adapter that lets miners emit
 /// binary proof/witness/public_signals without forcing changes through
 /// `MinerResponse`, the verifier, the proof uploader, and the relay.
-fn rmpv_to_json_value(value: RmpvValue) -> JsonValue {
-    match value {
+fn rmpv_to_json_value(value: RmpvValue) -> Result<JsonValue> {
+    rmpv_to_json_value_bounded(value, 0)
+}
+
+fn rmpv_to_json_value_bounded(value: RmpvValue, depth: usize) -> Result<JsonValue> {
+    anyhow::ensure!(
+        depth <= MAX_RESPONSE_VALUE_DEPTH,
+        "miner response nesting depth exceeds {MAX_RESPONSE_VALUE_DEPTH}"
+    );
+    Ok(match value {
         RmpvValue::Nil => JsonValue::Null,
         RmpvValue::Boolean(b) => JsonValue::Bool(b),
         RmpvValue::Integer(i) => {
@@ -42,9 +52,12 @@ fn rmpv_to_json_value(value: RmpvValue) -> JsonValue {
             .map(JsonValue::String)
             .unwrap_or(JsonValue::Null),
         RmpvValue::Binary(bytes) => JsonValue::String(hex::encode(bytes)),
-        RmpvValue::Array(items) => {
-            JsonValue::Array(items.into_iter().map(rmpv_to_json_value).collect())
-        }
+        RmpvValue::Array(items) => JsonValue::Array(
+            items
+                .into_iter()
+                .map(|item| rmpv_to_json_value_bounded(item, depth + 1))
+                .collect::<Result<Vec<_>>>()?,
+        ),
         RmpvValue::Map(pairs) => {
             let mut obj = serde_json::Map::with_capacity(pairs.len());
             for (k, v) in pairs {
@@ -63,12 +76,12 @@ fn rmpv_to_json_value(value: RmpvValue) -> JsonValue {
                     RmpvValue::Integer(i) => i.to_string(),
                     other => format!("{other}"),
                 };
-                obj.insert(key, rmpv_to_json_value(v));
+                obj.insert(key, rmpv_to_json_value_bounded(v, depth + 1)?);
             }
             JsonValue::Object(obj)
         }
         RmpvValue::Ext(_, _) => JsonValue::Null,
-    }
+    })
 }
 
 struct WalletSigner(Arc<Wallet>);
@@ -162,7 +175,10 @@ impl MinerQueryClient {
 
         let mut obj = serde_json::Map::with_capacity(response.data.len());
         for (k, v) in response.data {
-            obj.insert(k, rmpv_to_json_value(v));
+            obj.insert(
+                k,
+                rmpv_to_json_value(v).context("decoding miner response value")?,
+            );
         }
         let resp_body = serde_json::Value::Object(obj);
         Ok((resp_body, elapsed))
@@ -180,7 +196,7 @@ mod tests {
             RmpvValue::String("proof".into()),
             RmpvValue::Binary(bytes.clone()),
         )]);
-        let json = rmpv_to_json_value(value);
+        let json = rmpv_to_json_value(value).unwrap();
         assert_eq!(json["proof"], JsonValue::String(hex::encode(&bytes)));
     }
 
@@ -190,7 +206,7 @@ mod tests {
             RmpvValue::String("proof".into()),
             RmpvValue::String("deadbeef".into()),
         )]);
-        let json = rmpv_to_json_value(value);
+        let json = rmpv_to_json_value(value).unwrap();
         assert_eq!(json["proof"], JsonValue::String("deadbeef".into()));
     }
 
@@ -204,7 +220,7 @@ mod tests {
             0x02,
         ];
         let value = rmpv::decode::read_value(&mut std::io::Cursor::new(bytes)).expect("decode");
-        let json = rmpv_to_json_value(value);
+        let json = rmpv_to_json_value(value).unwrap();
         let obj = json.as_object().expect("map");
         assert_eq!(obj.len(), 2, "non-utf8 keys must not collide");
         assert!(obj.keys().all(|k| k.starts_with("__msgpack_str_hex:")));
@@ -218,8 +234,27 @@ mod tests {
             RmpvValue::Binary(vec![0x01, 0x02]),
             RmpvValue::String("abc".into()),
         ]);
-        let json = rmpv_to_json_value(value);
+        let json = rmpv_to_json_value(value).unwrap();
         assert_eq!(json[0], JsonValue::String("0102".into()));
         assert_eq!(json[1], JsonValue::String("abc".into()));
+    }
+
+    #[test]
+    fn nesting_beyond_depth_limit_is_rejected() {
+        let mut value = RmpvValue::Nil;
+        for _ in 0..=MAX_RESPONSE_VALUE_DEPTH {
+            value = RmpvValue::Array(vec![value]);
+        }
+        let err = rmpv_to_json_value(value).unwrap_err().to_string();
+        assert!(err.contains("nesting depth"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn nesting_at_depth_limit_is_accepted() {
+        let mut value = RmpvValue::Boolean(true);
+        for _ in 0..MAX_RESPONSE_VALUE_DEPTH {
+            value = RmpvValue::Array(vec![value]);
+        }
+        assert!(rmpv_to_json_value(value).is_ok());
     }
 }

--- a/crates/sn2-verify/src/reconstruct.rs
+++ b/crates/sn2-verify/src/reconstruct.rs
@@ -1,3 +1,7 @@
+use anyhow::{bail, Result};
+
+const MAX_OUTPUT_ELEMENTS: usize = 1 << 26;
+
 pub fn grid_reconstruct(
     tiles: &[&[f64]],
     tiles_y: usize,
@@ -5,10 +9,42 @@ pub fn grid_reconstruct(
     channels: usize,
     tile_h: usize,
     tile_w: usize,
-) -> Vec<f64> {
-    let out_h = tiles_y * tile_h;
-    let out_w = tiles_x * tile_w;
-    let mut output = vec![0.0f64; channels * out_h * out_w];
+) -> Result<Vec<f64>> {
+    let expected_tiles = tiles_y
+        .checked_mul(tiles_x)
+        .ok_or_else(|| anyhow::anyhow!("tile grid {tiles_y}x{tiles_x} overflows"))?;
+    if tiles.len() != expected_tiles {
+        bail!("tile count {} != grid {tiles_y}x{tiles_x}", tiles.len());
+    }
+    let tile_elements = channels
+        .checked_mul(tile_h)
+        .and_then(|v| v.checked_mul(tile_w))
+        .ok_or_else(|| anyhow::anyhow!("tile shape {channels}x{tile_h}x{tile_w} overflows"))?;
+    let out_h = tiles_y
+        .checked_mul(tile_h)
+        .ok_or_else(|| anyhow::anyhow!("output height {tiles_y}*{tile_h} overflows"))?;
+    let out_w = tiles_x
+        .checked_mul(tile_w)
+        .ok_or_else(|| anyhow::anyhow!("output width {tiles_x}*{tile_w} overflows"))?;
+    let total_elements = channels
+        .checked_mul(out_h)
+        .and_then(|v| v.checked_mul(out_w))
+        .ok_or_else(|| anyhow::anyhow!("output shape {channels}x{out_h}x{out_w} overflows"))?;
+    if total_elements > MAX_OUTPUT_ELEMENTS {
+        bail!(
+            "output shape {channels}x{out_h}x{out_w} has {total_elements} elements, max is {MAX_OUTPUT_ELEMENTS}"
+        );
+    }
+    for (idx, tile) in tiles.iter().enumerate() {
+        if tile.len() != tile_elements {
+            bail!(
+                "tile {idx} length {} != expected {tile_elements}",
+                tile.len()
+            );
+        }
+    }
+
+    let mut output = vec![0.0f64; total_elements];
 
     for ty in 0..tiles_y {
         for tx in 0..tiles_x {
@@ -26,7 +62,7 @@ pub fn grid_reconstruct(
         }
     }
 
-    output
+    Ok(output)
 }
 
 #[cfg(test)]
@@ -41,7 +77,7 @@ mod tests {
         let t3: Vec<f64> = vec![13.0, 14.0, 15.0, 16.0];
         let tiles: Vec<&[f64]> = vec![&t0, &t1, &t2, &t3];
 
-        let result = grid_reconstruct(&tiles, 2, 2, 1, 2, 2);
+        let result = grid_reconstruct(&tiles, 2, 2, 1, 2, 2).unwrap();
 
         assert_eq!(result.len(), 4 * 4);
         #[rustfmt::skip]
@@ -75,7 +111,7 @@ mod tests {
         }
         let tiles: Vec<&[f64]> = tiles_data.iter().map(|v| v.as_slice()).collect();
 
-        let result = grid_reconstruct(&tiles, 2, 2, c, h, w);
+        let result = grid_reconstruct(&tiles, 2, 2, c, h, w).unwrap();
 
         assert_eq!(result.len(), c * 4 * 4);
 
@@ -106,7 +142,7 @@ mod tests {
     fn test_1x1_grid() {
         let tile: Vec<f64> = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let tiles: Vec<&[f64]> = vec![&tile];
-        let result = grid_reconstruct(&tiles, 1, 1, 2, 1, 3);
+        let result = grid_reconstruct(&tiles, 1, 1, 2, 1, 3).unwrap();
         assert_eq!(result, tile);
     }
 
@@ -120,7 +156,40 @@ mod tests {
             tiles_data.push((0..c * h * w).map(|i| (t * 100 + i) as f64).collect());
         }
         let tiles: Vec<&[f64]> = tiles_data.iter().map(|v| v.as_slice()).collect();
-        let result = grid_reconstruct(&tiles, 3, 2, c, h, w);
+        let result = grid_reconstruct(&tiles, 3, 2, c, h, w).unwrap();
         assert_eq!(result.len(), c * 6 * 6);
+    }
+
+    #[test]
+    fn test_rejects_output_above_element_cap() {
+        let tile: Vec<f64> = vec![0.0; 4];
+        let tiles: Vec<&[f64]> = vec![&tile];
+        let result = grid_reconstruct(&tiles, 1, 1, 2, 8192, 8192);
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("max is"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn test_rejects_overflowing_shape_product() {
+        let tile: Vec<f64> = vec![0.0; 4];
+        let tiles: Vec<&[f64]> = vec![&tile];
+        let result = grid_reconstruct(&tiles, 1, 1, usize::MAX, usize::MAX, usize::MAX);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_rejects_tile_count_mismatch() {
+        let tile: Vec<f64> = vec![0.0; 4];
+        let tiles: Vec<&[f64]> = vec![&tile];
+        let result = grid_reconstruct(&tiles, 2, 2, 1, 2, 2);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_rejects_tile_length_mismatch() {
+        let short: Vec<f64> = vec![0.0; 3];
+        let tiles: Vec<&[f64]> = vec![&short];
+        let result = grid_reconstruct(&tiles, 1, 1, 1, 2, 2);
+        assert!(result.is_err());
     }
 }

--- a/crates/sn2-verify/src/store.rs
+++ b/crates/sn2-verify/src/store.rs
@@ -163,9 +163,7 @@ impl TileStore {
             tile_refs.push(&entry.data);
         }
 
-        Ok(reconstruct::grid_reconstruct(
-            &tile_refs, tiles_y, tiles_x, channels, tile_h, tile_w,
-        ))
+        reconstruct::grid_reconstruct(&tile_refs, tiles_y, tiles_x, channels, tile_h, tile_w)
     }
 
     pub fn evict(&self, keys: &[String]) -> Result<usize> {


### PR DESCRIPTION
## Summary

Systematic review of untrusted input handling surfaced four coverage gaps; this change closes the client-side portion of each.

### Circuit store (`sn2-circuit-store`)
- `cache_and_load_circuit` now requires the circuit id to be 64-character sha256 hex before any cache path is constructed. Previously an id taken from the repository API response flowed directly into `create_dir_all`/`fs::write` path joins; the read and purge paths already enforced this format but the write path did not. `try_load_cache_entry` is tightened from a length check to the same hex check.
- Component, weight blob, and model artifact sha256 values from the manifest are format-validated before they are embedded in request URLs or written to stamp files.
- Weight blob and model artifact downloads now pass their manifest-declared sha256 into the download path as a pinned expectation, making content verification mandatory for those files instead of dependent on the `x-checksum-sha256` response header or the URL happening to end in a hash.

### Validator response decoding (`sn2-validator`, `sn2-types`)
- The msgpack-to-JSON conversion at the miner response boundary is now depth-bounded (64 levels) and returns an error on over-nested payloads instead of recursing without an explicit limit.
- `decode_msgpack_value` uses `read_value_with_max_depth` and `decode_msgpack_to_json` sets an explicit deserializer depth cap, replacing reliance on the libraries' transitive defaults (1024). `validate_inputs_msgpack` uses the same bound.

### Tile reconstruction (`sn2-verify`)
- `grid_reconstruct` previously computed `channels * out_h * out_w` with unchecked multiplication and allocated the result unconditionally; internally consistent per-tile shapes could still drive the product to a multi-terabyte allocation. It now uses checked products, validates tile count and per-tile lengths at entry, and caps total output at 2^26 elements (512 MiB of f64, matching the frame transport ceiling that the response must fit within anyway).

## Verified live behavior

Probed the production repository before choosing the download policy: component bundle file responses (e.g. `circuit.bin`) do not include the `x-checksum-sha256` header, so those files currently download with no content check and a fail-closed requirement would break loading today. The header check remains opportunistic for those files. Closing that gap fully needs per-file sha256 entries in the manifest (or the header) served by the repository API — flagging for a coordinated server-side change.

## Testing
- `cargo test` across the four touched crates: all passing, including new cases for depth limits, element cap, overflow products, and tile count/length mismatches.
- `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --check`: clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stronger SHA‑256 validation and optional pinned checksum enforcement for downloads.
  * Enforced MsgPack nesting depth limits to prevent excessively deep/malformed inputs.
  * Propagated decoding errors instead of swallowing failures.

* **Refactor / API Change**
  * Grid reconstruction now validates sizes/overflows and returns a fallible result (errors for mismatched tiles, overflow, or excessive output).

* **Tests**
  * Added/updated tests for depth limits and reconstruction error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->