### PR TITLE
Introduce mandatory release signature verification across installer and testnet releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      attestations: write
+      id-token: write
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -108,6 +110,23 @@ jobs:
           find . -type f -name 'sn2-*' -exec cp {} ../ \;
           cd ..
           sha256sum sn2-validator-linux-x86_64 sn2-miner-linux-x86_64 sn2-validator-linux-aarch64 sn2-miner-linux-aarch64 sn2-validator-macos-aarch64 sn2-miner-macos-aarch64 > SHA256SUMS
+
+      - name: Attest release binaries
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            sn2-validator-linux-x86_64
+            sn2-miner-linux-x86_64
+            sn2-validator-linux-aarch64
+            sn2-miner-linux-aarch64
+            sn2-validator-macos-aarch64
+            sn2-miner-macos-aarch64
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign SHA256SUMS with cosign keyless
+        run: cosign sign-blob --yes --bundle SHA256SUMS.sigstore.json SHA256SUMS
 
       - name: Create Testnet Release
         run: |
@@ -123,7 +142,8 @@ jobs:
             sn2-miner-linux-aarch64 \
             sn2-validator-macos-aarch64 \
             sn2-miner-macos-aarch64 \
-            SHA256SUMS
+            SHA256SUMS \
+            SHA256SUMS.sigstore.json
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}

--- a/install.sh
+++ b/install.sh
@@ -67,10 +67,22 @@ verify_sums_signature() {
     exit 1
   fi
 
-  if ! curl -fSL --connect-timeout 10 --max-time 30 \
-    -o "${TMP_DIR}/SHA256SUMS.sigstore.json" "$bundle_url"; then
-    echo "Release ${tag} does not publish a SHA256SUMS.sigstore.json signature bundle." >&2
-    echo "Refusing to install an unsigned release." >&2
+  local http_code curl_status=0
+  http_code="$(curl -fsSL --connect-timeout 10 --max-time 30 \
+    -o "${TMP_DIR}/SHA256SUMS.sigstore.json" -w '%{http_code}' \
+    "$bundle_url" 2>"${TMP_DIR}/curl_stderr")" || curl_status=$?
+  if [ "$curl_status" -ne 0 ]; then
+    case "$http_code" in
+      4*)
+        echo "Release ${tag} does not publish a SHA256SUMS.sigstore.json signature bundle (HTTP ${http_code})." >&2
+        echo "Refusing to install an unsigned release." >&2
+        ;;
+      *)
+        echo "Failed to fetch the signature bundle (curl exit ${curl_status}, HTTP ${http_code:-none}):" >&2
+        cat "${TMP_DIR}/curl_stderr" >&2
+        echo "Refusing to install without signature verification; re-run when the network is available." >&2
+        ;;
+    esac
     exit 1
   fi
 

--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,8 @@ REPO="inference-labs-inc/subnet-2"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 NETWORK="$(echo "${NETWORK:-mainnet}" | tr '[:upper:]' '[:lower:]')"
 BINARY="${1:-all}"
+OIDC_ISSUER="https://token.actions.githubusercontent.com"
+SIGNER_IDENTITY_REGEXP="^https://github.com/${REPO}/.github/workflows/release.yml@"
 
 case "$NETWORK" in
   mainnet|testnet) ;;
@@ -36,19 +38,53 @@ detect_platform() {
 }
 
 get_latest_tag() {
-  local api_url
   if [ "$NETWORK" = "testnet" ]; then
-    api_url="https://api.github.com/repos/${REPO}/releases/tags/testnet-latest"
+    curl -fsSL --connect-timeout 10 --max-time 30 \
+      "https://api.github.com/repos/${REPO}/releases?per_page=30" 2>/dev/null |
+      grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/' |
+      grep '^testnet-' | head -1 || true
   else
-    api_url="https://api.github.com/repos/${REPO}/releases/latest"
+    curl -fsSL --connect-timeout 10 --max-time 30 \
+      "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null |
+      grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/' || true
   fi
-  curl -fsSL --connect-timeout 10 --max-time 30 "$api_url" 2>/dev/null | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/' || true
 }
 
 download_sums() {
   local tag="$1"
   local sums_url="https://github.com/${REPO}/releases/download/${tag}/SHA256SUMS"
   curl -fSL --connect-timeout 10 --max-time 30 -o "${TMP_DIR}/SHA256SUMS" "$sums_url"
+  verify_sums_signature "$tag"
+}
+
+verify_sums_signature() {
+  local tag="$1"
+  local bundle_url="https://github.com/${REPO}/releases/download/${tag}/SHA256SUMS.sigstore.json"
+
+  if ! command -v cosign &>/dev/null; then
+    echo "cosign is required to verify the release signature but is not installed." >&2
+    echo "Install it from https://docs.sigstore.dev/cosign/system_config/installation/ and re-run." >&2
+    exit 1
+  fi
+
+  if ! curl -fSL --connect-timeout 10 --max-time 30 \
+    -o "${TMP_DIR}/SHA256SUMS.sigstore.json" "$bundle_url"; then
+    echo "Release ${tag} does not publish a SHA256SUMS.sigstore.json signature bundle." >&2
+    echo "Refusing to install an unsigned release." >&2
+    exit 1
+  fi
+
+  echo "Verifying SHA256SUMS signature against the ${REPO} release workflow identity..."
+  if ! cosign verify-blob \
+    --bundle "${TMP_DIR}/SHA256SUMS.sigstore.json" \
+    --certificate-identity-regexp "$SIGNER_IDENTITY_REGEXP" \
+    --certificate-oidc-issuer "$OIDC_ISSUER" \
+    "${TMP_DIR}/SHA256SUMS"; then
+    echo "Signature verification FAILED for SHA256SUMS (${tag})." >&2
+    echo "Refusing to install. The release may have been tampered with." >&2
+    exit 1
+  fi
+  echo "Signature verified."
 }
 
 download_and_verify() {


### PR DESCRIPTION
## Summary

The release pipeline already signs `SHA256SUMS` with cosign keyless and attests binaries for tagged (mainnet) releases — but nothing on the consuming side ever checked those artifacts, and testnet releases published no signing material at all. This change completes the chain on both ends.

### install.sh
- `SHA256SUMS` is now verified with `cosign verify-blob` against the published `SHA256SUMS.sigstore.json` bundle before any binary checksum is trusted. The certificate identity is pinned to this repository's release workflow (`^https://github.com/inference-labs-inc/subnet-2/.github/workflows/release.yml@`) and the GitHub Actions OIDC issuer, so a checksum file replaced by anyone other than this repo's release workflow is rejected.
- Strictly fail-closed: installation is refused when cosign is not installed, when the release has no signature bundle, or when verification does not pass. There is no unsigned fallback.
- Resolved a pre-existing defect: the testnet path queried a `testnet-latest` tag that no workflow creates (the API returns 404), so `NETWORK=testnet` installs could not resolve a release at all. The installer now selects the newest `testnet-*` release tag.

### release.yml
- The testnet release job now mirrors the mainnet job's signing: build provenance attestation for all six binaries and cosign keyless signing of `SHA256SUMS`, with the bundle published as a release asset. After the first testnet release from this branch, testnet installs verify identically to mainnet.

## Verification performed
- `cosign verify-blob` against the live 14.9.2 release assets: passes (`Verified OK`).
- Tampered `SHA256SUMS`: rejected.
- Wrong workflow identity regexp: rejected (`no matching CertificateIdentity`; observed SAN is exactly `.../release.yml@refs/tags/14.9.2`).
- Full `install.sh` run on macOS arm64 against mainnet: signature verified, checksum verified, binary installed.
- Full run against testnet: resolves `testnet-70e0e883` and refuses it as unsigned — expected until the first signed testnet release is cut from this branch.
- `shellcheck` and `actionlint`: clean.

## Deployment note
`NETWORK=testnet` installs remain refused until the next push to `testnet` produces a signed release. This is not a regression — the testnet path was already inoperable due to the dangling `testnet-latest` lookup. Operators must have cosign installed; the auto-updater is unaffected (it already performs its own attestation verification against pinned trust roots).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release artifacts now include cryptographic signatures and provenance attestations for stronger authenticity.
  * Testnet releases upload signature/provenance assets alongside binaries.

* **Bug Fixes / Safety**
  * Installer now enforces signature verification and will abort if verification or signature artifacts are missing or invalid.
  * Installation requires a signature-verification tool to validate downloaded checksums before proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->