### PR TITLE
Migrate dsperse pin to 3.8.1 release for template weight initializer extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,9 +1827,10 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 [[package]]
 name = "dsperse"
 version = "0.0.0"
-source = "git+https://github.com/inference-labs-inc/dsperse?rev=6af459e8#6af459e8ccdaf49b48991f7e0f383ac75878e5f7"
+source = "git+https://github.com/inference-labs-inc/dsperse?rev=0e693a13b223e500ee3227627d45d7987a61e663#0e693a13b223e500ee3227627d45d7987a61e663"
 dependencies = [
  "clap",
+ "half 2.7.1",
  "jstprove-io",
  "jstprove_circuits",
  "libc",
@@ -1852,6 +1853,7 @@ dependencies = [
  "uuid",
  "walkdir",
  "zip",
+ "zstd",
 ]
 
 [[package]]
@@ -4899,7 +4901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -4919,7 +4921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4932,7 +4934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ futures-util = "0.3"
 shellexpand = "3.1.2"
 openssl = { version = "0.10", features = ["vendored"] }
 flate2 = "1"
-dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "6af459e8" }
+dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "0e693a13b223e500ee3227627d45d7987a61e663" }
 ndarray = { version = "0.17", features = ["serde"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 bittensor-drand = { git = "https://github.com/inference-labs-inc/bittensor-drand.git", rev = "e55ed98", default-features = false }


### PR DESCRIPTION
## Summary

Advances the `dsperse` git dependency from `6af459e8` to the signed **v3.8.1** release commit `0e693a13`.

## Why

v3.8.1 carries the resolution for initializer extraction on `weights_as_inputs` slices whose weight input is renamed by a split template. DimSplit and ChannelSplit MatMul circuits declare the weight as the placeholder `W`, while the slice ONNX keeps the original initializer name (for example `onnx::MatMul_4162`). The previous by-name extraction never matched the weight, miscounted it as an activation, and witness generation was rejected:

```
activation length mismatch: expected <weight+activation>, got <activation>
```

This surfaced on production models (rfdetr-nano and others) and caused slices to be repeatedly re-dispatched and re-failed.

## Blast radius

Both consumers of the dsperse extraction path are rebuilt by this bump:
- **miner**: generates the witness from the dispatched activation, now resolves the template weight as an initializer.
- **validator**: the dispatch preflight derives the expected activation length through the same function, so it stops false-dropping these DimSplit / ChannelSplit slices.

`jstprove` is unchanged (`87a1859f`).

## Verification

- `cargo build --workspace` clean with the new pin.
- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo fmt --check` clean.
- v3.8.1 was validated end to end before release: the real miner prove path on the published rfdetr-nano slice_68 artifacts went from the activation-length rejection to a generated witness and proof.

Targets `testnet` for promotion to `main` after soak.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace dependencies to improve overall stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->