### PR TITLE
Merge testnet into main for 14.9.3 release

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -35,8 +35,9 @@ jobs:
       RUSTC_WRAPPER: sccache
       CARGO_INCREMENTAL: "0"
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           ref: ${{ inputs.ref || github.ref }}
 
       - name: Install system dependencies
@@ -111,8 +112,9 @@ jobs:
       RUSTC_WRAPPER: sccache
       CARGO_INCREMENTAL: "0"
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           ref: ${{ inputs.ref || github.ref }}
 
       - name: Assert aarch64 runner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -42,7 +44,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -62,5 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - run: cargo fmt --all -- --check

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -23,7 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,8 +31,9 @@ jobs:
       CARGO_INCREMENTAL: "0"
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha || 'testnet' }}
 
       - name: Install system dependencies
@@ -166,8 +167,9 @@ jobs:
       security-events: write
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           ref: testnet
 
       - name: Build and push Docker image

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -32,7 +32,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Build and push Docker image
         id: push-testnet
@@ -123,7 +125,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ steps.resolve-tag.outputs.tag_sha }}
           persist-credentials: false
@@ -161,7 +163,7 @@ jobs:
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to container registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -202,7 +204,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Security tab
         if: steps.trivy-release.conclusion == 'success'
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:
           sarif_file: trivy-results.sarif
           category: trivy-image-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      attestations: write
+      id-token: write
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -108,6 +110,23 @@ jobs:
           find . -type f -name 'sn2-*' -exec cp {} ../ \;
           cd ..
           sha256sum sn2-validator-linux-x86_64 sn2-miner-linux-x86_64 sn2-validator-linux-aarch64 sn2-miner-linux-aarch64 sn2-validator-macos-aarch64 sn2-miner-macos-aarch64 > SHA256SUMS
+
+      - name: Attest release binaries
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            sn2-validator-linux-x86_64
+            sn2-miner-linux-x86_64
+            sn2-validator-linux-aarch64
+            sn2-miner-linux-aarch64
+            sn2-validator-macos-aarch64
+            sn2-miner-macos-aarch64
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign SHA256SUMS with cosign keyless
+        run: cosign sign-blob --yes --bundle SHA256SUMS.sigstore.json SHA256SUMS
 
       - name: Create Testnet Release
         run: |
@@ -123,7 +142,8 @@ jobs:
             sn2-miner-linux-aarch64 \
             sn2-validator-macos-aarch64 \
             sn2-miner-macos-aarch64 \
-            SHA256SUMS
+            SHA256SUMS \
+            SHA256SUMS.sigstore.json
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,9 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,7 +19,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
@@ -31,7 +31,7 @@ jobs:
           publish_results: false
 
       - name: Upload SARIF results
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:
           sarif_file: results.sarif
           category: scorecard

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,7 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Cache cargo-audit binary
         id: cache-audit
@@ -58,7 +60,9 @@ jobs:
       image: semgrep/semgrep
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Run Semgrep
         run: |
@@ -87,7 +91,7 @@ jobs:
 
       - name: Upload SARIF results to GitHub
         if: always() && hashFiles('semgrep-results.sarif') != ''
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:
           sarif_file: semgrep-results.sarif
           category: semgrep
@@ -100,7 +104,9 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Scan repository
         uses: ./.github/actions/trivy-sarif
@@ -129,22 +135,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
-      - uses: EmbarkStudios/cargo-deny-action@a531616d8ce3b9177443e48a1159bc945a099823 # v2.0.19
+      - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
 
   secrets-detection:
     name: Secret Detection
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: TruffleHog OSS (Pull Request)
         if: github.event_name == 'pull_request'
-        uses: trufflesecurity/trufflehog@17456f8c7d042d8c82c9a8ca9e937231f9f42e26 # v3.95.2
+        uses: trufflesecurity/trufflehog@d411fff7b8879a62509f3fa98c07f247ac089a51 # v3.95.5
         with:
           path: ./
           base: ${{ github.event.pull_request.base.sha }}
@@ -153,7 +162,7 @@ jobs:
 
       - name: TruffleHog OSS (Push)
         if: github.event_name == 'push'
-        uses: trufflesecurity/trufflehog@17456f8c7d042d8c82c9a8ca9e937231f9f42e26 # v3.95.2
+        uses: trufflesecurity/trufflehog@d411fff7b8879a62509f3fa98c07f247ac089a51 # v3.95.5
         with:
           path: ./
           base: ${{ github.event.before }}
@@ -162,14 +171,14 @@ jobs:
 
       - name: TruffleHog OSS (Schedule)
         if: github.event_name == 'schedule'
-        uses: trufflesecurity/trufflehog@17456f8c7d042d8c82c9a8ca9e937231f9f42e26 # v3.95.2
+        uses: trufflesecurity/trufflehog@d411fff7b8879a62509f3fa98c07f247ac089a51 # v3.95.5
         with:
           path: ./
           extra_args: --debug --only-verified
 
       - name: TruffleHog OSS (Release gate)
         if: github.event_name == 'workflow_call'
-        uses: trufflesecurity/trufflehog@17456f8c7d042d8c82c9a8ca9e937231f9f42e26 # v3.95.2
+        uses: trufflesecurity/trufflehog@d411fff7b8879a62509f3fa98c07f247ac089a51 # v3.95.5
         with:
           path: ./
           extra_args: --debug --only-verified

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -189,7 +189,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1787,7 +1787,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2043,7 +2043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3282,7 +3282,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4147,7 +4147,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5480,7 +5480,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5569,7 +5569,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6465,7 +6465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7011,9 +7011,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -7030,7 +7030,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8232,7 +8232,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,9 +1827,10 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 [[package]]
 name = "dsperse"
 version = "0.0.0"
-source = "git+https://github.com/inference-labs-inc/dsperse?rev=6af459e8#6af459e8ccdaf49b48991f7e0f383ac75878e5f7"
+source = "git+https://github.com/inference-labs-inc/dsperse?rev=0e693a13b223e500ee3227627d45d7987a61e663#0e693a13b223e500ee3227627d45d7987a61e663"
 dependencies = [
  "clap",
+ "half 2.7.1",
  "jstprove-io",
  "jstprove_circuits",
  "libc",
@@ -1852,6 +1853,7 @@ dependencies = [
  "uuid",
  "walkdir",
  "zip",
+ "zstd",
 ]
 
 [[package]]
@@ -4899,7 +4901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -4919,7 +4921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4932,7 +4934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ futures-util = "0.3"
 shellexpand = "3.1.2"
 openssl = { version = "0.10", features = ["vendored"] }
 flate2 = "1"
-dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "6af459e8" }
+dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "0e693a13b223e500ee3227627d45d7987a61e663" }
 ndarray = { version = "0.17", features = ["serde"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 bittensor-drand = { git = "https://github.com/inference-labs-inc/bittensor-drand.git", rev = "e55ed98", default-features = false }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG SN2_PLATFORM=linux/amd64
-FROM --platform=$SN2_PLATFORM rust:1.95.0-bookworm@sha256:503651ea31e66ecb74623beabde781059a5978df1595a9e8ed03974d5fec1bf0 AS chef
+FROM --platform=$SN2_PLATFORM rust:1.96.0-bookworm@sha256:19817ead3289c8c631c73df281e18b59b172f6a31f4f563290f69cddd06c30e9 AS chef
 
 RUN cargo install cargo-chef --locked
 RUN apt-get update && apt-get install -y \
@@ -38,7 +38,7 @@ RUN CARGO_VERSION="${SN2_VERSION#v}" && \
     cargo build --release --locked --bin sn2-validator --bin sn2-miner
 
 ARG SN2_PLATFORM=linux/amd64
-FROM --platform=$SN2_PLATFORM debian:bookworm-20260518-slim@sha256:0104b334637a5f19aa9c983a91b54c89887c0984081f2068983107a6f6c21eeb AS runtime
+FROM --platform=$SN2_PLATFORM debian:bookworm-20260610-slim@sha256:96e378d7e6531ac9a15ad505478fcc2e69f371b10f5cdf87857c4b8188404716 AS runtime
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     jq \

--- a/crates/sn2-circuit-store/src/lib.rs
+++ b/crates/sn2-circuit-store/src/lib.rs
@@ -462,6 +462,10 @@ impl CircuitStore {
         circuit_id: &str,
         data: &serde_json::Value,
     ) -> Result<(Circuit, Vec<(String, String)>)> {
+        anyhow::ensure!(
+            is_sha256_hex(circuit_id),
+            "invalid circuit id {circuit_id:?}: expected 64-character sha256 hex"
+        );
         let cache_path = self.cache_dir.join(format!("model_{circuit_id}"));
         let is_fresh = !cache_path.exists();
         std::fs::create_dir_all(&cache_path)
@@ -648,7 +652,11 @@ impl CircuitStore {
                     .get("sha256")
                     .and_then(|v| v.as_str())
                     .context("component missing sha256")?
-                    .to_string();
+                    .to_lowercase();
+                anyhow::ensure!(
+                    is_sha256_hex(&sha),
+                    "component {name}: invalid sha256 {sha:?}"
+                );
                 let files: Vec<String> = comp
                     .get("files")
                     .and_then(|v| v.as_array())
@@ -658,28 +666,34 @@ impl CircuitStore {
                             .collect()
                     })
                     .unwrap_or_default();
-                let weights: Vec<WeightRef> = comp
-                    .get("weights")
-                    .and_then(|v| v.as_array())
-                    .map(|arr| {
-                        arr.iter()
-                            .enumerate()
-                            .filter_map(|(i, w)| {
-                                let wb_sha = w.get("sha256")?.as_str()?.to_string();
-                                let fallback = format!("{name}_weight_{i}.onnx");
-                                let filename = w
-                                    .get("filename")
-                                    .and_then(|v| v.as_str())
-                                    .unwrap_or(&fallback)
-                                    .to_string();
-                                Some(WeightRef {
-                                    sha: wb_sha,
-                                    filename,
-                                })
-                            })
-                            .collect()
-                    })
-                    .unwrap_or_default();
+                let mut weights: Vec<WeightRef> = Vec::new();
+                if let Some(arr) = comp.get("weights").and_then(|v| v.as_array()) {
+                    for (i, w) in arr.iter().enumerate() {
+                        let Some(wb_sha) = w.get("sha256").and_then(|v| v.as_str()) else {
+                            warn!(
+                                component = %name,
+                                index = i,
+                                "skipping weight entry with missing sha256"
+                            );
+                            continue;
+                        };
+                        let wb_sha = wb_sha.to_lowercase();
+                        anyhow::ensure!(
+                            is_sha256_hex(&wb_sha),
+                            "component {name}: invalid weight blob sha256 {wb_sha:?}"
+                        );
+                        let fallback = format!("{name}_weight_{i}.onnx");
+                        let filename = w
+                            .get("filename")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or(&fallback)
+                            .to_string();
+                        weights.push(WeightRef {
+                            sha: wb_sha,
+                            filename,
+                        });
+                    }
+                }
                 let has_circuit = files.iter().any(|f| f == "circuit.bin");
                 Ok(ParsedComponent {
                     name,
@@ -808,7 +822,7 @@ impl CircuitStore {
                     "{}/components/{}/files/{}",
                     self.api_url, comp.sha, filename
                 );
-                self.download_file(&url, &dest)
+                self.download_file(&url, &dest, None)
                     .await
                     .with_context(|| format!("downloading {}/{}", comp.name, filename))?;
             }
@@ -830,7 +844,7 @@ impl CircuitStore {
                 continue;
             }
             let url = format!("{}/models/wb/{}", self.api_url, wb.sha);
-            self.download_file(&url, &dest)
+            self.download_file(&url, &dest, Some(&wb.sha))
                 .await
                 .with_context(|| format!("downloading weight blob for {}", comp.name))?;
             Self::write_weight_sha_stamp(&dest, &wb.sha);
@@ -1016,7 +1030,12 @@ impl CircuitStore {
                 .get("sha256")
                 .and_then(|v| v.as_str())
                 .filter(|s| !s.is_empty())
-                .context("model artifact missing sha256")?;
+                .context("model artifact missing sha256")?
+                .to_lowercase();
+            anyhow::ensure!(
+                is_sha256_hex(&sha),
+                "model artifact: invalid sha256 {sha:?}"
+            );
             let raw_filename = artifact
                 .get("filename")
                 .and_then(|v| v.as_str())
@@ -1027,7 +1046,7 @@ impl CircuitStore {
                 continue;
             }
             let url = format!("{}/models/wb/{}", self.api_url, sha);
-            self.download_file(&url, &dest)
+            self.download_file(&url, &dest, Some(&sha))
                 .await
                 .with_context(|| format!("downloading model artifact {filename}"))?;
             info!(filename, "downloaded model artifact");
@@ -1121,7 +1140,7 @@ impl CircuitStore {
     ) -> Option<(String, Circuit)> {
         let dir_name = entry.file_name().to_string_lossy().to_string();
         let circuit_id = match dir_name.strip_prefix("model_") {
-            Some(id) if id.len() == 64 => id.to_string(),
+            Some(id) if is_sha256_hex(id) => id.to_string(),
             _ => return None,
         };
 
@@ -1157,12 +1176,29 @@ impl CircuitStore {
         }
     }
 
-    async fn download_file(&self, url: &str, dest: &Path) -> Result<()> {
-        download_file_static(&self.http, url, dest).await
+    async fn download_file(
+        &self,
+        url: &str,
+        dest: &Path,
+        pinned_sha256: Option<&str>,
+    ) -> Result<()> {
+        download_file_static(&self.http, url, dest, pinned_sha256).await
     }
 }
 
-async fn download_file_static(http: &reqwest::Client, url: &str, dest: &Path) -> Result<()> {
+async fn download_file_static(
+    http: &reqwest::Client,
+    url: &str,
+    dest: &Path,
+    pinned_sha256: Option<&str>,
+) -> Result<()> {
+    if let Some(pinned) = pinned_sha256 {
+        anyhow::ensure!(
+            is_sha256_hex(pinned),
+            "pinned sha256 for {url} is not 64-character hex: {pinned:?}"
+        );
+    }
+
     let resp = http
         .get(url)
         .timeout(std::time::Duration::from_secs(300))
@@ -1174,11 +1210,14 @@ async fn download_file_static(http: &reqwest::Client, url: &str, dest: &Path) ->
         anyhow::bail!("download returned {}", resp.status());
     }
 
-    let expected_sha256 = resp
-        .headers()
-        .get("x-checksum-sha256")
-        .and_then(|v| v.to_str().ok())
+    let expected_sha256 = pinned_sha256
         .map(|s| s.trim().to_lowercase())
+        .or_else(|| {
+            resp.headers()
+                .get("x-checksum-sha256")
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.trim().to_lowercase())
+        })
         .or_else(|| {
             let segment = url.rsplit('/').next()?;
             let clean = segment.split('?').next()?;

--- a/crates/sn2-types/src/circuit.rs
+++ b/crates/sn2-types/src/circuit.rs
@@ -76,8 +76,11 @@ impl Circuit {
             _ => return Ok(()),
         };
 
-        let value = rmpv::decode::read_value(&mut &inputs[..])
-            .map_err(|e| format!("decoding msgpack inputs: {e}"))?;
+        let value = rmpv::decode::read_value_with_max_depth(
+            &mut &inputs[..],
+            crate::tensor_codec::MSGPACK_MAX_DEPTH,
+        )
+        .map_err(|e| format!("decoding msgpack inputs: {e}"))?;
 
         let entries = match &value {
             rmpv::Value::Map(entries) => entries,

--- a/crates/sn2-types/src/tensor_codec.rs
+++ b/crates/sn2-types/src/tensor_codec.rs
@@ -7,6 +7,7 @@ use std::io::Read;
 const MAX_TENSOR_ELEMENTS: usize = 16_777_216;
 const MAX_PROTOBUF_BYTES: usize = 128 * 1024 * 1024;
 const MAX_PROTO_SHAPE_DIMS: usize = 32;
+pub const MSGPACK_MAX_DEPTH: usize = 64;
 
 pub fn decode_gzipped_protobuf_tensor(gzipped: &[u8], shape: &[usize]) -> Result<ArrayD<f64>> {
     let expected = shape
@@ -327,9 +328,12 @@ pub fn input_data_payload(arr: &ArrayD<f64>) -> bytes::Bytes {
 }
 
 pub fn decode_msgpack_value(bytes: &[u8]) -> anyhow::Result<rmpv::Value> {
-    rmpv::decode::read_value(&mut &bytes[..]).context("decoding msgpack value")
+    rmpv::decode::read_value_with_max_depth(&mut &bytes[..], MSGPACK_MAX_DEPTH)
+        .context("decoding msgpack value")
 }
 
 pub fn decode_msgpack_to_json(bytes: &[u8]) -> anyhow::Result<serde_json::Value> {
-    rmp_serde::from_slice::<serde_json::Value>(bytes).context("decoding msgpack to json")
+    let mut deserializer = rmp_serde::Deserializer::from_read_ref(bytes);
+    deserializer.set_max_depth(MSGPACK_MAX_DEPTH);
+    serde::Deserialize::deserialize(&mut deserializer).context("decoding msgpack to json")
 }

--- a/crates/sn2-validator/src/miner_client.rs
+++ b/crates/sn2-validator/src/miner_client.rs
@@ -7,6 +7,7 @@ use btlightning::{LightningClient, QuicAxonInfo, QuicRequest, Signer};
 use rmpv::Value as RmpvValue;
 use serde_json::Value as JsonValue;
 use sn2_chain::Wallet;
+use sn2_types::tensor_codec::MSGPACK_MAX_DEPTH;
 use tracing::{debug, info};
 
 /// Converts an `rmpv::Value` tree into a `serde_json::Value`, hex-encoding any
@@ -14,8 +15,16 @@ use tracing::{debug, info};
 /// validator pipeline. This is the wire-boundary adapter that lets miners emit
 /// binary proof/witness/public_signals without forcing changes through
 /// `MinerResponse`, the verifier, the proof uploader, and the relay.
-fn rmpv_to_json_value(value: RmpvValue) -> JsonValue {
-    match value {
+fn rmpv_to_json_value(value: RmpvValue) -> Result<JsonValue> {
+    rmpv_to_json_value_bounded(value, 0)
+}
+
+fn rmpv_to_json_value_bounded(value: RmpvValue, depth: usize) -> Result<JsonValue> {
+    anyhow::ensure!(
+        depth <= MSGPACK_MAX_DEPTH,
+        "miner response nesting depth exceeds {MSGPACK_MAX_DEPTH}"
+    );
+    Ok(match value {
         RmpvValue::Nil => JsonValue::Null,
         RmpvValue::Boolean(b) => JsonValue::Bool(b),
         RmpvValue::Integer(i) => {
@@ -42,9 +51,12 @@ fn rmpv_to_json_value(value: RmpvValue) -> JsonValue {
             .map(JsonValue::String)
             .unwrap_or(JsonValue::Null),
         RmpvValue::Binary(bytes) => JsonValue::String(hex::encode(bytes)),
-        RmpvValue::Array(items) => {
-            JsonValue::Array(items.into_iter().map(rmpv_to_json_value).collect())
-        }
+        RmpvValue::Array(items) => JsonValue::Array(
+            items
+                .into_iter()
+                .map(|item| rmpv_to_json_value_bounded(item, depth + 1))
+                .collect::<Result<Vec<_>>>()?,
+        ),
         RmpvValue::Map(pairs) => {
             let mut obj = serde_json::Map::with_capacity(pairs.len());
             for (k, v) in pairs {
@@ -63,12 +75,12 @@ fn rmpv_to_json_value(value: RmpvValue) -> JsonValue {
                     RmpvValue::Integer(i) => i.to_string(),
                     other => format!("{other}"),
                 };
-                obj.insert(key, rmpv_to_json_value(v));
+                obj.insert(key, rmpv_to_json_value_bounded(v, depth + 1)?);
             }
             JsonValue::Object(obj)
         }
         RmpvValue::Ext(_, _) => JsonValue::Null,
-    }
+    })
 }
 
 struct WalletSigner(Arc<Wallet>);
@@ -162,7 +174,10 @@ impl MinerQueryClient {
 
         let mut obj = serde_json::Map::with_capacity(response.data.len());
         for (k, v) in response.data {
-            obj.insert(k, rmpv_to_json_value(v));
+            obj.insert(
+                k,
+                rmpv_to_json_value(v).context("decoding miner response value")?,
+            );
         }
         let resp_body = serde_json::Value::Object(obj);
         Ok((resp_body, elapsed))
@@ -180,7 +195,7 @@ mod tests {
             RmpvValue::String("proof".into()),
             RmpvValue::Binary(bytes.clone()),
         )]);
-        let json = rmpv_to_json_value(value);
+        let json = rmpv_to_json_value(value).unwrap();
         assert_eq!(json["proof"], JsonValue::String(hex::encode(&bytes)));
     }
 
@@ -190,7 +205,7 @@ mod tests {
             RmpvValue::String("proof".into()),
             RmpvValue::String("deadbeef".into()),
         )]);
-        let json = rmpv_to_json_value(value);
+        let json = rmpv_to_json_value(value).unwrap();
         assert_eq!(json["proof"], JsonValue::String("deadbeef".into()));
     }
 
@@ -204,7 +219,7 @@ mod tests {
             0x02,
         ];
         let value = rmpv::decode::read_value(&mut std::io::Cursor::new(bytes)).expect("decode");
-        let json = rmpv_to_json_value(value);
+        let json = rmpv_to_json_value(value).unwrap();
         let obj = json.as_object().expect("map");
         assert_eq!(obj.len(), 2, "non-utf8 keys must not collide");
         assert!(obj.keys().all(|k| k.starts_with("__msgpack_str_hex:")));
@@ -218,8 +233,27 @@ mod tests {
             RmpvValue::Binary(vec![0x01, 0x02]),
             RmpvValue::String("abc".into()),
         ]);
-        let json = rmpv_to_json_value(value);
+        let json = rmpv_to_json_value(value).unwrap();
         assert_eq!(json[0], JsonValue::String("0102".into()));
         assert_eq!(json[1], JsonValue::String("abc".into()));
+    }
+
+    #[test]
+    fn nesting_beyond_depth_limit_is_rejected() {
+        let mut value = RmpvValue::Nil;
+        for _ in 0..=MSGPACK_MAX_DEPTH {
+            value = RmpvValue::Array(vec![value]);
+        }
+        let err = rmpv_to_json_value(value).unwrap_err().to_string();
+        assert!(err.contains("nesting depth"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn nesting_at_depth_limit_is_accepted() {
+        let mut value = RmpvValue::Boolean(true);
+        for _ in 0..MSGPACK_MAX_DEPTH {
+            value = RmpvValue::Array(vec![value]);
+        }
+        assert!(rmpv_to_json_value(value).is_ok());
     }
 }

--- a/crates/sn2-verify/src/reconstruct.rs
+++ b/crates/sn2-verify/src/reconstruct.rs
@@ -1,3 +1,7 @@
+use anyhow::{bail, Result};
+
+const MAX_OUTPUT_ELEMENTS: usize = 1 << 26;
+
 pub fn grid_reconstruct(
     tiles: &[&[f64]],
     tiles_y: usize,
@@ -5,10 +9,42 @@ pub fn grid_reconstruct(
     channels: usize,
     tile_h: usize,
     tile_w: usize,
-) -> Vec<f64> {
-    let out_h = tiles_y * tile_h;
-    let out_w = tiles_x * tile_w;
-    let mut output = vec![0.0f64; channels * out_h * out_w];
+) -> Result<Vec<f64>> {
+    let expected_tiles = tiles_y
+        .checked_mul(tiles_x)
+        .ok_or_else(|| anyhow::anyhow!("tile grid {tiles_y}x{tiles_x} overflows"))?;
+    if tiles.len() != expected_tiles {
+        bail!("tile count {} != grid {tiles_y}x{tiles_x}", tiles.len());
+    }
+    let tile_elements = channels
+        .checked_mul(tile_h)
+        .and_then(|v| v.checked_mul(tile_w))
+        .ok_or_else(|| anyhow::anyhow!("tile shape {channels}x{tile_h}x{tile_w} overflows"))?;
+    let out_h = tiles_y
+        .checked_mul(tile_h)
+        .ok_or_else(|| anyhow::anyhow!("output height {tiles_y}*{tile_h} overflows"))?;
+    let out_w = tiles_x
+        .checked_mul(tile_w)
+        .ok_or_else(|| anyhow::anyhow!("output width {tiles_x}*{tile_w} overflows"))?;
+    let total_elements = channels
+        .checked_mul(out_h)
+        .and_then(|v| v.checked_mul(out_w))
+        .ok_or_else(|| anyhow::anyhow!("output shape {channels}x{out_h}x{out_w} overflows"))?;
+    if total_elements > MAX_OUTPUT_ELEMENTS {
+        bail!(
+            "output shape {channels}x{out_h}x{out_w} has {total_elements} elements, max is {MAX_OUTPUT_ELEMENTS}"
+        );
+    }
+    for (idx, tile) in tiles.iter().enumerate() {
+        if tile.len() != tile_elements {
+            bail!(
+                "tile {idx} length {} != expected {tile_elements}",
+                tile.len()
+            );
+        }
+    }
+
+    let mut output = vec![0.0f64; total_elements];
 
     for ty in 0..tiles_y {
         for tx in 0..tiles_x {
@@ -26,7 +62,7 @@ pub fn grid_reconstruct(
         }
     }
 
-    output
+    Ok(output)
 }
 
 #[cfg(test)]
@@ -41,7 +77,7 @@ mod tests {
         let t3: Vec<f64> = vec![13.0, 14.0, 15.0, 16.0];
         let tiles: Vec<&[f64]> = vec![&t0, &t1, &t2, &t3];
 
-        let result = grid_reconstruct(&tiles, 2, 2, 1, 2, 2);
+        let result = grid_reconstruct(&tiles, 2, 2, 1, 2, 2).unwrap();
 
         assert_eq!(result.len(), 4 * 4);
         #[rustfmt::skip]
@@ -75,7 +111,7 @@ mod tests {
         }
         let tiles: Vec<&[f64]> = tiles_data.iter().map(|v| v.as_slice()).collect();
 
-        let result = grid_reconstruct(&tiles, 2, 2, c, h, w);
+        let result = grid_reconstruct(&tiles, 2, 2, c, h, w).unwrap();
 
         assert_eq!(result.len(), c * 4 * 4);
 
@@ -106,7 +142,7 @@ mod tests {
     fn test_1x1_grid() {
         let tile: Vec<f64> = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let tiles: Vec<&[f64]> = vec![&tile];
-        let result = grid_reconstruct(&tiles, 1, 1, 2, 1, 3);
+        let result = grid_reconstruct(&tiles, 1, 1, 2, 1, 3).unwrap();
         assert_eq!(result, tile);
     }
 
@@ -120,7 +156,40 @@ mod tests {
             tiles_data.push((0..c * h * w).map(|i| (t * 100 + i) as f64).collect());
         }
         let tiles: Vec<&[f64]> = tiles_data.iter().map(|v| v.as_slice()).collect();
-        let result = grid_reconstruct(&tiles, 3, 2, c, h, w);
+        let result = grid_reconstruct(&tiles, 3, 2, c, h, w).unwrap();
         assert_eq!(result.len(), c * 6 * 6);
+    }
+
+    #[test]
+    fn test_rejects_output_above_element_cap() {
+        let tile: Vec<f64> = vec![0.0; 4];
+        let tiles: Vec<&[f64]> = vec![&tile];
+        let result = grid_reconstruct(&tiles, 1, 1, 2, 8192, 8192);
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("max is"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn test_rejects_overflowing_shape_product() {
+        let tile: Vec<f64> = vec![0.0; 4];
+        let tiles: Vec<&[f64]> = vec![&tile];
+        let result = grid_reconstruct(&tiles, 1, 1, usize::MAX, usize::MAX, usize::MAX);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_rejects_tile_count_mismatch() {
+        let tile: Vec<f64> = vec![0.0; 4];
+        let tiles: Vec<&[f64]> = vec![&tile];
+        let result = grid_reconstruct(&tiles, 2, 2, 1, 2, 2);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_rejects_tile_length_mismatch() {
+        let short: Vec<f64> = vec![0.0; 3];
+        let tiles: Vec<&[f64]> = vec![&short];
+        let result = grid_reconstruct(&tiles, 1, 1, 1, 2, 2);
+        assert!(result.is_err());
     }
 }

--- a/crates/sn2-verify/src/store.rs
+++ b/crates/sn2-verify/src/store.rs
@@ -163,9 +163,7 @@ impl TileStore {
             tile_refs.push(&entry.data);
         }
 
-        Ok(reconstruct::grid_reconstruct(
-            &tile_refs, tiles_y, tiles_x, channels, tile_h, tile_w,
-        ))
+        reconstruct::grid_reconstruct(&tile_refs, tiles_y, tiles_x, channels, tile_h, tile_w)
     }
 
     pub fn evict(&self, keys: &[String]) -> Result<usize> {

--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,8 @@ REPO="inference-labs-inc/subnet-2"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 NETWORK="$(echo "${NETWORK:-mainnet}" | tr '[:upper:]' '[:lower:]')"
 BINARY="${1:-all}"
+OIDC_ISSUER="https://token.actions.githubusercontent.com"
+SIGNER_IDENTITY_REGEXP="^https://github.com/${REPO}/.github/workflows/release.yml@"
 
 case "$NETWORK" in
   mainnet|testnet) ;;
@@ -36,19 +38,65 @@ detect_platform() {
 }
 
 get_latest_tag() {
-  local api_url
   if [ "$NETWORK" = "testnet" ]; then
-    api_url="https://api.github.com/repos/${REPO}/releases/tags/testnet-latest"
+    curl -fsSL --connect-timeout 10 --max-time 30 \
+      "https://api.github.com/repos/${REPO}/releases?per_page=30" 2>/dev/null |
+      grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/' |
+      grep '^testnet-' | head -1 || true
   else
-    api_url="https://api.github.com/repos/${REPO}/releases/latest"
+    curl -fsSL --connect-timeout 10 --max-time 30 \
+      "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null |
+      grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/' || true
   fi
-  curl -fsSL --connect-timeout 10 --max-time 30 "$api_url" 2>/dev/null | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/' || true
 }
 
 download_sums() {
   local tag="$1"
   local sums_url="https://github.com/${REPO}/releases/download/${tag}/SHA256SUMS"
   curl -fSL --connect-timeout 10 --max-time 30 -o "${TMP_DIR}/SHA256SUMS" "$sums_url"
+  verify_sums_signature "$tag"
+}
+
+verify_sums_signature() {
+  local tag="$1"
+  local bundle_url="https://github.com/${REPO}/releases/download/${tag}/SHA256SUMS.sigstore.json"
+
+  if ! command -v cosign &>/dev/null; then
+    echo "cosign is required to verify the release signature but is not installed." >&2
+    echo "Install it from https://docs.sigstore.dev/cosign/system_config/installation/ and re-run." >&2
+    exit 1
+  fi
+
+  local http_code curl_status=0
+  http_code="$(curl -fsSL --connect-timeout 10 --max-time 30 \
+    -o "${TMP_DIR}/SHA256SUMS.sigstore.json" -w '%{http_code}' \
+    "$bundle_url" 2>"${TMP_DIR}/curl_stderr")" || curl_status=$?
+  if [ "$curl_status" -ne 0 ]; then
+    case "$http_code" in
+      4*)
+        echo "Release ${tag} does not publish a SHA256SUMS.sigstore.json signature bundle (HTTP ${http_code})." >&2
+        echo "Refusing to install an unsigned release." >&2
+        ;;
+      *)
+        echo "Failed to fetch the signature bundle (curl exit ${curl_status}, HTTP ${http_code:-none}):" >&2
+        cat "${TMP_DIR}/curl_stderr" >&2
+        echo "Refusing to install without signature verification; re-run when the network is available." >&2
+        ;;
+    esac
+    exit 1
+  fi
+
+  echo "Verifying SHA256SUMS signature against the ${REPO} release workflow identity..."
+  if ! cosign verify-blob \
+    --bundle "${TMP_DIR}/SHA256SUMS.sigstore.json" \
+    --certificate-identity-regexp "$SIGNER_IDENTITY_REGEXP" \
+    --certificate-oidc-issuer "$OIDC_ISSUER" \
+    "${TMP_DIR}/SHA256SUMS"; then
+    echo "Signature verification FAILED for SHA256SUMS (${tag})." >&2
+    echo "Refusing to install. The release may have been tampered with." >&2
+    exit 1
+  fi
+  echo "Signature verified."
 }
 
 download_and_verify() {


### PR DESCRIPTION
Promotes testnet to main for the 14.9.3 mainnet release.

Included:
- #540 dsperse 3.8.1: resolves split-weight circuit slices (rfdetr-nano family) failing witness generation
- #539 dependency supply-chain remediation and CI workflow pinning
- #535 circuit artifact integrity and decode-depth coverage hardening
- #536 mandatory release signature verification in installer and testnet releases

Not included: the quinn-proto 0.11.15 QUIC reassembly cap (separate PR to testnet), queued for the next patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release binaries now include cryptographic attestations and signatures for enhanced security verification.
  * Install script now verifies release integrity using Sigstore before installation.

* **Bug Fixes**
  * Added validation limits for nested data structures to prevent malformed input issues.
  * Added checksum validation for downloaded artifacts and components.

* **Chores**
  * Updated GitHub Actions workflow dependencies and tooling.
  * Updated Rust toolchain and base container images to latest stable versions.
  * Updated external dependency revisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->