### PR TITLE
Migrate dsperse pin to 3.8.2 for activation-placeholder resolution fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4901,7 +4901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -4921,7 +4921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4934,7 +4934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,7 +1827,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 [[package]]
 name = "dsperse"
 version = "0.0.0"
-source = "git+https://github.com/inference-labs-inc/dsperse?rev=0e693a13b223e500ee3227627d45d7987a61e663#0e693a13b223e500ee3227627d45d7987a61e663"
+source = "git+https://github.com/inference-labs-inc/dsperse?rev=249440cdc9cc24eea07b92e6421bcb586a25774c#249440cdc9cc24eea07b92e6421bcb586a25774c"
 dependencies = [
  "clap",
  "half 2.7.1",
@@ -4901,7 +4901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -4921,7 +4921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4934,7 +4934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ futures-util = "0.3"
 shellexpand = "3.1.2"
 openssl = { version = "0.10", features = ["vendored"] }
 flate2 = "1"
-dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "0e693a13b223e500ee3227627d45d7987a61e663" }
+dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "249440cdc9cc24eea07b92e6421bcb586a25774c" }
 ndarray = { version = "0.17", features = ["serde"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 bittensor-drand = { git = "https://github.com/inference-labs-inc/bittensor-drand.git", rev = "e55ed98", default-features = false }


### PR DESCRIPTION
Advances dsperse 0e693a13 (3.8.1) -> 3.8.2 commit 249440cd.

3.8.2 fixes a regression in the 3.8.1 initializer fallback (dsperse #204): it bound tiled activation placeholders (tile_in, dim_tmpl_in, group_N_in) to unrelated same-size initializers, making decoder bias-add slices (slice_399/slice_442) report expected_activation=0 and reject the dispatched 2048-tile. Verified on real artifacts: failing slice_399 goes from expected=0 to expected=2048 with a valid witness; the DimSplit weight fix (slice_68) is preserved.

Both the miner witness path and the validator dispatch preflight use the same extraction, so this fixes both. Lockfile delta is dsperse-only. Workspace build verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a workspace dependency to a newer pinned version from the same source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->