### PR TITLE
Implement dim-split per-chunk dispatch and weight binding (dsperse 3.8.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,7 +1827,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 [[package]]
 name = "dsperse"
 version = "0.0.0"
-source = "git+https://github.com/inference-labs-inc/dsperse?rev=249440cdc9cc24eea07b92e6421bcb586a25774c#249440cdc9cc24eea07b92e6421bcb586a25774c"
+source = "git+https://github.com/inference-labs-inc/dsperse?rev=9738ab6509c3e6a1588b0cc234739f8e02283422#9738ab6509c3e6a1588b0cc234739f8e02283422"
 dependencies = [
  "clap",
  "half 2.7.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ futures-util = "0.3"
 shellexpand = "3.1.2"
 openssl = { version = "0.10", features = ["vendored"] }
 flate2 = "1"
-dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "249440cdc9cc24eea07b92e6421bcb586a25774c" }
+dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "9738ab6509c3e6a1588b0cc234739f8e02283422" }
 ndarray = { version = "0.17", features = ["serde"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 bittensor-drand = { git = "https://github.com/inference-labs-inc/bittensor-drand.git", rev = "e55ed98", default-features = false }

--- a/crates/sn2-miner/src/dsperse.rs
+++ b/crates/sn2-miner/src/dsperse.rs
@@ -270,16 +270,22 @@ impl DSperseClient {
             let params = backend
                 .load_params(&circuit_path)
                 .map_err(|e| anyhow::anyhow!("loading circuit params: {e}"))?;
-            let inits = match params.as_ref() {
+            let (activations, inits) = match params.as_ref() {
                 Some(p) if p.weights_as_inputs => {
-                    dsperse::pipeline::extract_onnx_initializers(&onnx_path, p)
-                        .map_err(|e| anyhow::anyhow!("extracting initializers: {e}"))?
+                    match dsperse::pipeline::split_inline_wai_inputs(p, &input_flat) {
+                        Some(split) => split,
+                        None => {
+                            let inits = dsperse::pipeline::extract_onnx_initializers(&onnx_path, p)
+                                .map_err(|e| anyhow::anyhow!("extracting initializers: {e}"))?;
+                            (input_flat.clone(), inits)
+                        }
+                    }
                 }
-                _ => Vec::new(),
+                _ => (input_flat.clone(), Vec::new()),
             };
 
             let witness_bytes = backend
-                .witness_f64(&circuit_path, &input_flat, &inits)
+                .witness_f64(&circuit_path, &activations, &inits)
                 .map_err(|e| anyhow::anyhow!("witness generation: {e}"))?;
 
             let dims = params.as_ref().map(|p| p.effective_input_dims());

--- a/crates/sn2-validator/src/incremental_runner.rs
+++ b/crates/sn2-validator/src/incremental_runner.rs
@@ -277,6 +277,50 @@ impl IncrementalRunManager {
         Ok(())
     }
 
+    pub fn init_dim_split_counter(
+        &mut self,
+        run_uid: &str,
+        slice_id: &str,
+        total_units: usize,
+        expected_indices: HashSet<u32>,
+    ) -> anyhow::Result<()> {
+        if total_units == 0 {
+            return Err(anyhow::anyhow!(
+                "dim-split counter init requires total_units > 0 for run {run_uid}, slice {slice_id}"
+            ));
+        }
+        if expected_indices.is_empty() {
+            return Err(anyhow::anyhow!(
+                "dim-split counter init requires at least one expected unit for run {run_uid}, slice {slice_id}"
+            ));
+        }
+        if let Some(&max_idx) = expected_indices.iter().max() {
+            if (max_idx as usize) >= total_units {
+                return Err(anyhow::anyhow!(
+                    "expected unit index {max_idx} exceeds total_units {total_units} for run {run_uid}, slice {slice_id}"
+                ));
+            }
+        }
+        let expected_count = expected_indices.len();
+        let key = (run_uid.to_string(), slice_id.to_string());
+        use std::collections::hash_map::Entry;
+        match self.tile_counters.entry(key) {
+            Entry::Vacant(e) => {
+                e.insert(TileCounter {
+                    grid_total: total_units,
+                    expected: expected_indices,
+                    received: HashSet::with_capacity(expected_count),
+                });
+            }
+            Entry::Occupied(_) => {
+                return Err(anyhow::anyhow!(
+                    "tile counter already exists for run {run_uid}, slice {slice_id}"
+                ));
+            }
+        }
+        Ok(())
+    }
+
     pub fn record_tile(
         &mut self,
         run_uid: &str,

--- a/crates/sn2-validator/src/response_processor.rs
+++ b/crates/sn2-validator/src/response_processor.rs
@@ -80,6 +80,21 @@ fn build_expected_inputs(
         return Some(flat);
     }
 
+    let backend = dsperse::backend::jstprove::JstproveBackend::new();
+    let params = backend
+        .load_params(std::path::Path::new(circuit_path))
+        .ok()
+        .flatten()?;
+
+    let full_input_sum: usize = params
+        .inputs
+        .iter()
+        .map(|io| io.shape.iter().product::<usize>())
+        .sum();
+    if flat.len() == full_input_sum {
+        return Some(flat);
+    }
+
     let bundle_path = std::path::Path::new(circuit_path);
     let slice_dir = bundle_path.parent().and_then(|p| p.parent())?;
     let payload_dir = slice_dir.join("payload");
@@ -89,12 +104,6 @@ fn build_expected_inputs(
         .filter_map(|e| e.ok())
         .map(|e| e.path())
         .find(|p| p.extension().is_some_and(|e| e == "onnx"))?;
-
-    let backend = dsperse::backend::jstprove::JstproveBackend::new();
-    let params = backend
-        .load_params(std::path::Path::new(circuit_path))
-        .ok()
-        .flatten()?;
 
     match dsperse::pipeline::extract_onnx_initializers(&onnx_path, &params) {
         Ok(inits) => {

--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -250,6 +250,25 @@ impl ValidatorLoop {
             _ => return None,
         };
 
+        if let Some(ds) = &work.dim_split {
+            let bundle_expected: usize = params
+                .inputs
+                .iter()
+                .map(|io| io.shape.iter().product::<usize>())
+                .sum();
+            let k_chunk_size = ds.k_dim.div_ceil(ds.k_chunks.max(1));
+            let per_request_actual = k_chunk_size.saturating_mul(1 + ds.n_dim);
+            return if per_request_actual == bundle_expected {
+                None
+            } else {
+                Some(BundleDispatchMismatch {
+                    bundle_expected,
+                    per_request_actual,
+                    strategy: "dim-split",
+                })
+            };
+        }
+
         let initializer_count = if params.weights_as_inputs {
             let onnx = work.onnx_path.as_ref()?;
             match dsperse::pipeline::extract_onnx_initializers(std::path::Path::new(onnx), &params)
@@ -267,10 +286,7 @@ impl ValidatorLoop {
             .map(|io| io.shape.iter().product::<usize>())
             .sum();
 
-        let (per_request_actual, strategy) = if let Some(ds) = &work.dim_split {
-            let k_chunk_size = ds.k_dim.div_ceil(ds.k_chunks.max(1));
-            (k_chunk_size.saturating_mul(1 + ds.n_dim), "dim-split")
-        } else if let Some(tiling) = &work.tiling {
+        let (per_request_actual, strategy) = if let Some(tiling) = &work.tiling {
             let n = std::cmp::max(work.named_inputs.len(), 1);
             let per_input = if tiling.ndim == 1 {
                 tiling.segment_size.unwrap_or(0)

--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -267,7 +267,10 @@ impl ValidatorLoop {
             .map(|io| io.shape.iter().product::<usize>())
             .sum();
 
-        let (per_request_actual, strategy) = if let Some(tiling) = &work.tiling {
+        let (per_request_actual, strategy) = if let Some(ds) = &work.dim_split {
+            let k_chunk_size = ds.k_dim.div_ceil(ds.k_chunks.max(1));
+            (k_chunk_size.saturating_mul(1 + ds.n_dim), "dim-split")
+        } else if let Some(tiling) = &work.tiling {
             let n = std::cmp::max(work.named_inputs.len(), 1);
             let per_input = if tiling.ndim == 1 {
                 tiling.segment_size.unwrap_or(0)
@@ -537,7 +540,28 @@ impl ValidatorLoop {
                 .circuit_store
                 .component_sha(&circuit.id, &work.slice_id);
 
-            let queued = if let Some(ref tiling) = work.tiling {
+            let queued = if let Some(ref ds) = work.dim_split {
+                match Self::stage_dim_split_work(
+                    &mut staged,
+                    &mut self.run_manager,
+                    run_uid,
+                    circuit,
+                    &work.slice_id,
+                    work.circuit_path.as_deref(),
+                    work.onnx_path.as_deref(),
+                    comp_sha,
+                    ds,
+                    &input_tensor,
+                    run_source,
+                    clamped_prove_pct,
+                ) {
+                    Some(n) => n,
+                    None => {
+                        self.teardown_run(run_uid).await;
+                        return;
+                    }
+                }
+            } else if let Some(ref tiling) = work.tiling {
                 match Self::stage_tiled_work(
                     &mut staged,
                     &mut self.run_manager,
@@ -716,6 +740,110 @@ impl ValidatorLoop {
                 slice_id,
                 run_uid,
                 tile_bytes,
+                idx as u32,
+                run_source,
+                circuit_path,
+                component_sha,
+            ));
+        }
+
+        Some(staged_count)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn stage_dim_split_work(
+        staged: &mut StagedWork,
+        run_manager: &mut crate::incremental_runner::IncrementalRunManager,
+        run_uid: &str,
+        circuit: &Arc<Circuit>,
+        slice_id: &str,
+        circuit_path: Option<&str>,
+        onnx_path: Option<&str>,
+        component_sha: Option<&str>,
+        ds: &dsperse::schema::tiling::DimSplitInfo,
+        input_tensor: &ndarray::ArrayD<f64>,
+        run_source: RunSource,
+        prove_pct: f64,
+    ) -> Option<usize> {
+        let onnx_path = match onnx_path {
+            Some(p) => p,
+            None => {
+                warn!(
+                    run_uid = %run_uid,
+                    slice = %slice_id,
+                    "dim-split slice missing onnx_path, cannot bind chunk weights"
+                );
+                return None;
+            }
+        };
+        let units = match dsperse::pipeline::dim_split_bound_inputs(
+            input_tensor,
+            std::path::Path::new(onnx_path),
+            ds,
+        ) {
+            Ok(u) => u,
+            Err(e) => {
+                warn!(run_uid = %run_uid, slice = %slice_id, error = %e, "dim_split_bound_inputs failed");
+                return None;
+            }
+        };
+        let num_units = units.len();
+        if num_units == 0 {
+            warn!(run_uid = %run_uid, slice = %slice_id, "dim-split produced zero units");
+            return None;
+        }
+
+        let sampled_indices =
+            Self::sample_tile_indices(num_units, prove_pct, run_source, run_uid, slice_id);
+        if sampled_indices.is_empty() {
+            warn!(run_uid = %run_uid, slice = %slice_id, "prove_pct sampled zero dim-split units");
+            return None;
+        }
+
+        let mut prepared: Vec<(usize, bytes::Bytes)> = Vec::with_capacity(sampled_indices.len());
+        for (idx, unit) in units.into_iter().enumerate() {
+            if !sampled_indices.contains(&idx) {
+                continue;
+            }
+            let len = unit.len();
+            let unit_arr = match ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&[len]), unit) {
+                Ok(arr) => arr,
+                Err(e) => {
+                    warn!(
+                        run_uid = %run_uid,
+                        slice = %slice_id,
+                        unit_idx = idx,
+                        error = %e,
+                        "skipping dim-split unit: from_shape_vec rejected 1-D shape"
+                    );
+                    continue;
+                }
+            };
+            let unit_bytes = crate::tensor::input_data_payload(&unit_arr);
+            prepared.push((idx, unit_bytes));
+        }
+
+        if prepared.is_empty() {
+            warn!(run_uid = %run_uid, slice = %slice_id, "no dim-split units survived staging");
+            return None;
+        }
+
+        let expected_indices: std::collections::HashSet<u32> =
+            prepared.iter().map(|(idx, _)| *idx as u32).collect();
+        if let Err(e) =
+            run_manager.init_dim_split_counter(run_uid, slice_id, num_units, expected_indices)
+        {
+            warn!(run_uid = %run_uid, slice = %slice_id, error = %e, "init_dim_split_counter failed");
+            return None;
+        }
+
+        let staged_count = prepared.len();
+        for (idx, unit_bytes) in prepared {
+            staged.stage_request(Self::build_tile_request(
+                circuit,
+                slice_id,
+                run_uid,
+                unit_bytes,
                 idx as u32,
                 run_source,
                 circuit_path,


### PR DESCRIPTION
## Summary

Dim-split matmul slices compile to a shared template circuit `(dim_tmpl_in, W)` with the weight as a runtime input, so one slice is a circuit instance per `(row, k-chunk)` with a distinct weight band. The dispatch forwarded the full untiled activation tensor to this template, which the per-chunk circuit rejected on its activation-length contract (the `expected 192, got 222720` family of mismatches miners reported).

The validator now expands each dim-split slice into its `(row, k-chunk)` units and dispatches each as the bound public-input vector `[dim_tmpl_in_chunk ++ W_chunk]`, materializing the weight band on the validator so verification binds the dispatched weight (taken from the dispatched task inputs, never a miner echo). The miner reconstructs the activation/weight partition from the circuit's declared input shapes. No wire/protocol change.

Pairs with dsperse v3.8.3 (re-pinned here).

## Changes

- `stage_dim_split_work` dispatch + dim-split preflight branch (dslice.rs).
- `init_dim_split_counter` reusing the tile counter (incremental_runner.rs).
- Miner inline weights-as-inputs split, ONNX extraction fallback (sn2-miner).
- `build_expected_inputs` binds the inline payload directly when its length matches the full declared input sum (response_processor.rs).
- dsperse pin migrated to the v3.8.3 commit; lockfile updated to the new rev only.

## Validation

- `cargo build --locked` green against the released dsperse rev.
- End-to-end witness against the real model-950b4647 slice_148 dim-template: the inline `[192 ++ 192x1536]` split feeds the actual circuit and generates a valid witness; the prior activation-length gate is cleared.
- Output-consistency returns `NoExpected` for the partial `dim_tmpl_out`, so units are not falsely flagged.
- Security gate: `cargo deny` clean; `cargo audit` exit 0.

Note: `cargo audit` surfaces RUSTSEC-2026-0186 (memmap2 `unsound`) as a non-blocking warning, transitive via `tract-onnx` and pre-existing on `testnet`, not introduced here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end support for processing and validating “dim-split” work items, including new staging logic and per-unit dispatch behavior.
  * Enhanced weight-as-input handling so input preparation can automatically split inline inputs into activations and initializers when available.
* **Bug Fixes**
  * Reduced unnecessary weight-initializer extraction during response verification when complete flattened inputs are already provided.
  * Improved dispatch sizing/category matching for dim-split requests to ensure correct payload expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->