### PR TITLE
Eliminate dim-split memory blowup that stalled proof verification

### DIFF
--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -801,18 +801,14 @@ impl ValidatorLoop {
                 return None;
             }
         };
-        let units = match dsperse::pipeline::dim_split_bound_inputs(
-            input_tensor,
-            std::path::Path::new(onnx_path),
-            ds,
-        ) {
-            Ok(u) => u,
+        let activations = match dsperse::pipeline::split_for_dim_split_dispatch(input_tensor, ds) {
+            Ok(a) => a,
             Err(e) => {
                 warn!(run_uid = %run_uid, slice = %slice_id, error = %e, "dim_split_bound_inputs failed");
                 return None;
             }
         };
-        let num_units = units.len();
+        let num_units = activations.len();
         if num_units == 0 {
             warn!(run_uid = %run_uid, slice = %slice_id, "dim-split produced zero units");
             return None;
@@ -825,11 +821,30 @@ impl ValidatorLoop {
             return None;
         }
 
-        let mut prepared: Vec<(usize, bytes::Bytes)> = Vec::with_capacity(sampled_indices.len());
-        for (idx, unit) in units.into_iter().enumerate() {
-            if !sampled_indices.contains(&idx) {
-                continue;
+        let (full_weight, trans_b) = match dsperse::pipeline::dim_split_weight_and_transb(
+            std::path::Path::new(onnx_path),
+            ds,
+        ) {
+            Ok(w) => w,
+            Err(e) => {
+                warn!(run_uid = %run_uid, slice = %slice_id, error = %e, "dim_split_bound_inputs failed");
+                return None;
             }
+        };
+        let k_chunks = ds.k_chunks.max(1);
+        let weight_chunks: Vec<Vec<f64>> = (0..k_chunks)
+            .map(|kc| {
+                dsperse::pipeline::dim_split_weight_chunk(&full_weight, ds, kc, trans_b)
+                    .into_iter()
+                    .map(f64::from)
+                    .collect()
+            })
+            .collect();
+
+        let mut prepared: Vec<(usize, bytes::Bytes)> = Vec::with_capacity(sampled_indices.len());
+        for &idx in &sampled_indices {
+            let mut unit = activations[idx].clone();
+            unit.extend_from_slice(&weight_chunks[idx % k_chunks]);
             let len = unit.len();
             let unit_arr = match ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&[len]), unit) {
                 Ok(arr) => arr,


### PR DESCRIPTION
## Problem

On 14.9.7 the validator restored dim-split dispatch but resident memory climbed to 29 GB (full 30 GB RAM + 20 GB swap), thrashing the box. Each combined run took ~18 min to queue and was idle-evicted before any proof verified: verify_tasks stayed 0, zero proof verified, zero combined run complete. Healthy baseline (14.9.5) completed runs in ~2-4 min with verify_tasks 1-9.

Cause: stage_dim_split_work called dim_split_bound_inputs, which materializes every unit's full weight-bound input up front. Each dim-split slice duplicates its weight band across all rows (slice_148: 1160 units x 295104 scalars ~ 2.7 GB) before prove_pct sampling discards ~90% of them.

## Resolution

Sample the unit indices first, then assemble bound inputs only for sampled units, reusing the activation split and per-k-chunk weight bands (built once). Each sampled unit's payload is byte-identical to before (activation_chunk ++ weight_chunk[idx % k_chunks]), so dispatch and validator-side binding are unchanged; only the discarded units are no longer built. Peak memory drops from O(all units) to O(sampled units).

Verified: cargo build, cargo clippy --all-targets, cargo fmt --check, existing dim-split test all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the dim-split staging flow to handle activation and weight preparation separately, making staging more consistent.
  * Updated how selected units are prepared so the correct activation slice and matching weight chunk are combined during staging.
  * Preserved existing fallback behavior when preparation steps fail, keeping the process stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->