### PR TITLE
Introduce default-off flag to gate dim-split weight-bound dispatch

### DIFF
--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -559,6 +559,7 @@ impl ValidatorLoop {
             let queued = if let Some(ds) = work
                 .dim_split
                 .as_ref()
+                .filter(|_| Self::dim_split_dispatch_enabled())
                 .filter(|ds| Self::is_weight_bound_dim_split(ds))
             {
                 match Self::stage_dim_split_work(
@@ -769,6 +770,15 @@ impl ValidatorLoop {
         }
 
         Some(staged_count)
+    }
+
+    fn dim_split_dispatch_enabled() -> bool {
+        static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        *ENABLED.get_or_init(|| {
+            std::env::var("SN2_DIM_SPLIT_DISPATCH")
+                .map(|v| matches!(v.trim(), "1" | "true" | "TRUE" | "on" | "yes"))
+                .unwrap_or(false)
+        })
     }
 
     fn is_weight_bound_dim_split(ds: &dsperse::schema::tiling::DimSplitInfo) -> bool {


### PR DESCRIPTION
## Context

The weights-as-inputs dim-split dispatch materializes each slice's weight band duplicated across every row. Benchmark runs prove at 100% (sampling disabled), so a single run stages ~30 GB and exhausts validator RAM, halting proof verification. Two forward fixes (teardown guard, sampled materialization) did not bound this because benchmark mode builds every unit.

## Change

Gate the weight-bound dim-split dispatch behind SN2_DIM_SPLIT_DISPATCH, defaulting OFF. With the flag unset, dim-split slices fall through to their prior dispatch path, restoring the low-memory verification behavior that ran healthily for months. The flag allows controlled re-enablement once the full-prove materialization cost is solved (streaming/batched dispatch) and validated on a canary.

No soundness change for the default path; this restores known-good behavior. Existing dim-split metadata test retained.

Verified: cargo build, cargo clippy --all-targets, cargo fmt --check, test all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a runtime toggle for dim-split dispatch, allowing the feature to be enabled or disabled through an environment setting.
  * Only recognized “on” values will activate the behavior; otherwise dim-split work is skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->