### PR TITLE
Skip dim-split slices when chunked dispatch is not taken

### DIFF
--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -583,6 +583,10 @@ impl ValidatorLoop {
                         continue;
                     }
                 }
+            } else if work.dim_split.is_some() {
+                self.run_manager.mark_slice_failed(run_uid, &work.slice_id);
+                self.run_manager.note_slice_skipped(run_uid, &work.slice_id);
+                continue;
             } else if let Some(ref tiling) = work.tiling {
                 match Self::stage_tiled_work(
                     &mut staged,


### PR DESCRIPTION
## Problem

Miners receive activation-count mismatch warnings for dim-split slices (e.g. circuit db4c0b86, slices 358/413/120). A dim-split slice must be dispatched as a single chunk ([activation_chunk ++ W_chunk]). When weight-bound dispatch is disabled (SN2_DIM_SPLIT_DISPATCH unset) or otherwise not taken, the slice falls through to the tiled/plain path and the validator sends the FULL tensor to a template circuit that expects one chunk. The miner rejects the size, and is effectively scored on a request it cannot prove.

This is the original DSlice activation-length mismatch surfacing on the miner side; it is disjoint from the validator's pre-existing preflight-skip set.

## Change

When a slice carries dim-split metadata but the weight-bound dispatch path is not taken, mark it skipped (mark_slice_failed + note_slice_skipped) instead of dispatching it through the normal path. This stops the malformed requests and the miner rejections. Those slices remain unverified (unchanged coverage versus today) with zero memory risk.

The full resolution (dispatch W once per k-chunk; miner assembles per-row bound inputs; validator binds on the dispatched W) is tracked separately and will be canary-validated before re-enabling.

Verified: cargo build, cargo clippy --all-targets, cargo fmt --check, test all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of dimension-split work so unsupported cases are now skipped cleanly instead of being sent through alternate staging paths.
  * Added explicit failure recording for slices that cannot use the dimension-split path, reducing unexpected processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->