### PR TITLE
Develop group dispatch for multi-input dim-split slices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,7 +1827,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 [[package]]
 name = "dsperse"
 version = "0.0.0"
-source = "git+https://github.com/inference-labs-inc/dsperse?rev=120bc85fab54ec13bbee64c52dee37478fff7c29#120bc85fab54ec13bbee64c52dee37478fff7c29"
+source = "git+https://github.com/inference-labs-inc/dsperse?rev=415f1d6650dd4725237d33c5fe03bd944f46ea36#415f1d6650dd4725237d33c5fe03bd944f46ea36"
 dependencies = [
  "clap",
  "half 2.7.1",
@@ -4901,7 +4901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -4921,7 +4921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4934,7 +4934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,7 +1827,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 [[package]]
 name = "dsperse"
 version = "0.0.0"
-source = "git+https://github.com/inference-labs-inc/dsperse?rev=11b6765703b5359d01afb5653282786e0d00800f#11b6765703b5359d01afb5653282786e0d00800f"
+source = "git+https://github.com/inference-labs-inc/dsperse?rev=120bc85fab54ec13bbee64c52dee37478fff7c29#120bc85fab54ec13bbee64c52dee37478fff7c29"
 dependencies = [
  "clap",
  "half 2.7.1",
@@ -4901,7 +4901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -4921,7 +4921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4934,7 +4934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ futures-util = "0.3"
 shellexpand = "3.1.2"
 openssl = { version = "0.10", features = ["vendored"] }
 flate2 = "1"
-dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "120bc85fab54ec13bbee64c52dee37478fff7c29" }
+dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "415f1d6650dd4725237d33c5fe03bd944f46ea36" }
 ndarray = { version = "0.17", features = ["serde"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 bittensor-drand = { git = "https://github.com/inference-labs-inc/bittensor-drand.git", rev = "e55ed98", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ futures-util = "0.3"
 shellexpand = "3.1.2"
 openssl = { version = "0.10", features = ["vendored"] }
 flate2 = "1"
-dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "11b6765703b5359d01afb5653282786e0d00800f" }
+dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "120bc85fab54ec13bbee64c52dee37478fff7c29" }
 ndarray = { version = "0.17", features = ["serde"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 bittensor-drand = { git = "https://github.com/inference-labs-inc/bittensor-drand.git", rev = "e55ed98", default-features = false }

--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -253,6 +253,27 @@ impl ValidatorLoop {
             _ => return None,
         };
 
+        if let Some(ds) = Self::group_dim_split(work) {
+            let bundle_expected: usize = params
+                .inputs
+                .iter()
+                .map(|io| io.shape.iter().product::<usize>())
+                .sum();
+            let (primary, secondaries) = Self::group_dim_split_tensors(&work.named_inputs, ds)?;
+            let group_elems = primary.len() / ds.dim_size * ds.elements_per_group;
+            let secondary_elems: usize = secondaries.iter().map(|t| t.len()).sum();
+            let per_request_actual = secondary_elems + group_elems;
+            return if per_request_actual == bundle_expected {
+                None
+            } else {
+                Some(BundleDispatchMismatch {
+                    bundle_expected,
+                    per_request_actual,
+                    strategy: "dim-split-group",
+                })
+            };
+        }
+
         if let Some(ds) = &work.dim_split {
             let bundle_expected: usize = params
                 .inputs
@@ -525,6 +546,7 @@ impl ValidatorLoop {
             total_unsatisfiable += unsatisfiable;
 
             for work in kept {
+                let group_ds = Self::group_dim_split(&work).cloned();
                 let mut input_tensor = work.input;
                 let named_inputs = work.named_inputs;
 
@@ -544,7 +566,43 @@ impl ValidatorLoop {
                     .circuit_store
                     .component_sha(&circuit.id, &work.slice_id);
 
-                let planned = if let Some(ds) = work
+                let planned = if let Some(ds) = group_ds.as_ref() {
+                    let sampled = Self::sample_tile_indices(
+                        ds.num_groups,
+                        clamped_prove_pct,
+                        run_source,
+                        run_uid,
+                        &work.slice_id,
+                    );
+                    if sampled.is_empty() {
+                        self.run_manager.mark_slice_failed(run_uid, &work.slice_id);
+                        self.run_manager.note_slice_skipped(run_uid, &work.slice_id);
+                        continue;
+                    }
+                    let expected: std::collections::HashSet<u32> =
+                        sampled.iter().map(|&i| i as u32).collect();
+                    if let Err(e) = self.run_manager.init_dim_split_counter(
+                        run_uid,
+                        &work.slice_id,
+                        ds.num_groups,
+                        expected,
+                    ) {
+                        warn!(run_uid = %run_uid, slice = %work.slice_id, error = %e, "init_dim_split_counter failed");
+                        self.run_manager.mark_slice_failed(run_uid, &work.slice_id);
+                        self.run_manager.note_slice_skipped(run_uid, &work.slice_id);
+                        continue;
+                    }
+                    let count = sampled.len();
+                    let mut indices: Vec<u32> = sampled.into_iter().map(|i| i as u32).collect();
+                    indices.sort_unstable();
+                    (
+                        PlannedPayload::DimSplit {
+                            ds: ds.clone(),
+                            indices,
+                        },
+                        count,
+                    )
+                } else if let Some(ds) = work
                     .dim_split
                     .as_ref()
                     .filter(|_| Self::dim_split_dispatch_enabled())
@@ -711,13 +769,13 @@ impl ValidatorLoop {
         let mut input_tensor = work.input;
         let named_inputs = work.named_inputs;
 
-        if let Some(&scale) = self
+        let norm_scale = self
             .dslice_input_scales
             .get(&(plan.run_uid.clone(), plan.slice_id.clone()))
-        {
-            if scale > 1.0 {
-                input_tensor.mapv_inplace(|v| v / scale);
-            }
+            .copied()
+            .filter(|&s| s > 1.0);
+        if let Some(scale) = norm_scale {
+            input_tensor.mapv_inplace(|v| v / scale);
         }
 
         match &plan.payload {
@@ -760,6 +818,51 @@ impl ValidatorLoop {
                                 &plan.slice_id,
                                 &plan.run_uid,
                                 tile_bytes,
+                                idx as u32,
+                                plan.run_source,
+                                plan.circuit_path.as_deref(),
+                                plan.component_sha.as_deref(),
+                            )
+                        })
+                        .collect(),
+                )
+            }
+            PlannedPayload::DimSplit { ds, indices } if ds.weight_name.is_none() => {
+                let wanted: std::collections::HashSet<usize> =
+                    indices.iter().map(|&i| i as usize).collect();
+                let (primary, secondaries) = Self::group_dim_split_tensors(&named_inputs, ds)?;
+                let payloads =
+                    match dsperse::pipeline::dim_split_group_payloads(primary, &secondaries, ds) {
+                        Ok(p) => p,
+                        Err(e) => {
+                            warn!(
+                                run_uid = %plan.run_uid,
+                                slice = %plan.slice_id,
+                                error = %e,
+                                "group payload construction failed"
+                            );
+                            return None;
+                        }
+                    };
+                Some(
+                    payloads
+                        .into_iter()
+                        .enumerate()
+                        .filter(|(idx, _)| wanted.contains(idx))
+                        .map(|(idx, mut unit)| {
+                            if let Some(scale) = norm_scale {
+                                for v in unit.iter_mut() {
+                                    *v /= scale;
+                                }
+                            }
+                            let len = unit.len();
+                            let arr = ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&[len]), unit)
+                                .expect("1-D shape from vec");
+                            Self::build_tile_request(
+                                &plan.circuit,
+                                &plan.slice_id,
+                                &plan.run_uid,
+                                crate::tensor::input_data_payload(&arr),
                                 idx as u32,
                                 plan.run_source,
                                 plan.circuit_path.as_deref(),
@@ -954,6 +1057,38 @@ impl ValidatorLoop {
 
     fn is_weight_bound_dim_split(ds: &dsperse::schema::tiling::DimSplitInfo) -> bool {
         ds.weight_name.is_some() && ds.k_dim > 0 && ds.n_dim > 0
+    }
+
+    fn group_dim_split(
+        work: &dsperse::pipeline::SliceWork,
+    ) -> Option<&dsperse::schema::tiling::DimSplitInfo> {
+        let ds = work.slice_meta.dim_split.as_ref()?;
+        if work.named_inputs.len() > 1
+            && ds.weight_name.is_none()
+            && ds.num_groups > 0
+            && ds.elements_per_group > 0
+            && ds.num_groups * ds.elements_per_group == ds.dim_size
+        {
+            Some(ds)
+        } else {
+            None
+        }
+    }
+
+    fn group_dim_split_tensors<'a>(
+        named_inputs: &'a [(String, ndarray::ArrayD<f64>)],
+        ds: &dsperse::schema::tiling::DimSplitInfo,
+    ) -> Option<(&'a ndarray::ArrayD<f64>, Vec<&'a ndarray::ArrayD<f64>>)> {
+        let primary = named_inputs
+            .iter()
+            .find(|(n, _)| n == &ds.input_name)
+            .map(|(_, t)| t)?;
+        let secondaries: Vec<&ndarray::ArrayD<f64>> = named_inputs
+            .iter()
+            .filter(|(n, _)| n != &ds.input_name)
+            .map(|(_, t)| t)
+            .collect();
+        Some((primary, secondaries))
     }
 
     fn dim_split_payloads(
@@ -1397,6 +1532,61 @@ impl ValidatorLoop {
 mod tests {
     use super::ValidatorLoop;
     use dsperse::schema::tiling::{DimSplitInfo, DimSplitKind};
+
+    #[test]
+    fn group_dim_split_requires_multi_input_and_covering_groups() {
+        use dsperse::pipeline::SliceWork;
+        use dsperse::schema::metadata::RunSliceMetadata;
+
+        fn work(named: usize, ds: Option<DimSplitInfo>) -> SliceWork {
+            let named_inputs = (0..named)
+                .map(|i| {
+                    (
+                        format!("t{i}"),
+                        ndarray::ArrayD::from_elem(ndarray::IxDyn(&[4]), 1.0),
+                    )
+                })
+                .collect();
+            SliceWork {
+                slice_id: "slice_0".to_string(),
+                input: ndarray::ArrayD::from_elem(ndarray::IxDyn(&[4]), 1.0),
+                named_inputs,
+                backend: Default::default(),
+                use_circuit: true,
+                tiling: None,
+                channel_split: None,
+                dim_split: None,
+                circuit_path: None,
+                onnx_path: None,
+                slice_meta: RunSliceMetadata {
+                    dim_split: ds,
+                    ..Default::default()
+                },
+            }
+        }
+
+        let group = DimSplitInfo {
+            split_kind: DimSplitKind::BatchDim,
+            weight_name: None,
+            split_dim: 0,
+            dim_size: 4,
+            num_groups: 2,
+            elements_per_group: 2,
+            ..Default::default()
+        };
+        assert!(ValidatorLoop::group_dim_split(&work(2, Some(group.clone()))).is_some());
+        assert!(ValidatorLoop::group_dim_split(&work(1, Some(group.clone()))).is_none());
+        let weight_bound = DimSplitInfo {
+            weight_name: Some("w".to_string()),
+            ..group.clone()
+        };
+        assert!(ValidatorLoop::group_dim_split(&work(2, Some(weight_bound))).is_none());
+        let uncovered = DimSplitInfo {
+            num_groups: 3,
+            ..group
+        };
+        assert!(ValidatorLoop::group_dim_split(&work(2, Some(uncovered))).is_none());
+    }
 
     #[test]
     fn weight_bound_dim_split_requires_full_matmul_metadata() {


### PR DESCRIPTION
Implements inference-labs-inc/subnet-2#572 atop inference-labs-inc/dsperse#208 (pinned by rev; re-pin to the mainline revision once merged).

Slices whose circuits are compiled per group (multiple activation inputs with group-style dim-split metadata) are now planned as group dispatch: sampled group indices register with the existing tile counter machinery, and materialization builds each unit as the slice's secondary tensors followed by one group of the primary along the split dimension, matching the published circuit contract. Input normalization applies the recorded scale to group payloads identically to whole-slice payloads. The bundle preflight sizes these slices by their per-group contract rather than the whole-slice payload, so the 31 slices per model previously excluded as unsatisfiable enter dispatch.

The payload contract was verified end-to-end against production artifacts before this integration: all 29 derived group payloads for an affected attention slice match the compiled circuit exactly, and witness generation against the published bundle succeeds for the first, middle, and last groups (see dsperse#208). Existing miner binaries prove these payloads without modification. Verification after deploy: preflight unsatisfiable counts drop to zero, planned units per run rise accordingly, and verified proofs appear for the recovered slices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced grouped dim-split handling for multi-input workloads when no weight binding is provided, including grouped tile/mismatch dispatch.
* **Bug Fixes**
  * Corrected mismatch detection and planning for grouped dim-split execution paths.
  * Updated input normalization to apply only when the stored scale is greater than 1.0.
* **Chores**
  * Updated an internal workspace dependency revision to the latest version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->