### PR TITLE
Resolve stale circuit artifacts persisting across artifact generations

### DIFF
--- a/crates/sn2-circuit-store/src/lib.rs
+++ b/crates/sn2-circuit-store/src/lib.rs
@@ -740,12 +740,12 @@ impl CircuitStore {
                     if !comp_dir.exists() {
                         true
                     } else if comp.has_circuit {
-                        let has_circuit_bin = comp_dir
-                            .join("jstprove")
-                            .join("circuit.bundle")
-                            .join("circuit.bin")
-                            .exists();
-                        !has_circuit_bin
+                        info!(
+                            name = comp.name,
+                            sha = comp.sha,
+                            "component present without generation stamp, will re-download"
+                        );
+                        true
                     } else {
                         let payload_dir = comp_dir.join("payload");
                         let has_payload = match payload_dir.read_dir() {
@@ -833,9 +833,19 @@ impl CircuitStore {
             let filename = Self::sanitize_name(&wb.filename, "weight blob file")?;
             let dest = payload_dir.join(filename);
             if dest.exists() && !force {
-                continue;
+                let stamp_matches = std::fs::read_to_string(Self::sha_stamp_path(&dest))
+                    .map(|s| s.trim() == wb.sha)
+                    .unwrap_or(false);
+                if stamp_matches {
+                    continue;
+                }
+                info!(
+                    component = comp.name,
+                    sha = %wb.sha,
+                    "weight blob present without matching stamp, re-downloading"
+                );
             }
-            if force && dest.exists() {
+            if dest.exists() {
                 let _ = std::fs::remove_file(&dest);
                 let _ = std::fs::remove_file(Self::sha_stamp_path(&dest));
             }


### PR DESCRIPTION
Components cached before generation stamping existed were presumed current whenever their files existed: the missing-stamp branch of staleness detection only re-downloaded when circuit.bin was absent, and weight blobs skipped on file existence without consulting their own sha stamps. A miner that downloaded artifacts during any earlier generation therefore kept incompatible circuit bundles indefinitely and rejected every payload the current network dispatches with activation length mismatches, while cache clears that left files behind changed nothing (as reported in #558 and observed live on an affected miner failing tens of thousands of requests with zero verified proofs).

Missing-stamp components now re-download and stamp, and weight blobs re-fetch when their stamp is absent or differs. Steady-state startup cost is unchanged (stamp reads only, no hashing); caches from before stamping pay a one-time re-fetch, which is exactly the repair they need. Affected miners self-heal on their next restart with no manual cache surgery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stale component detection so components with missing generation data are re-downloaded more reliably.
  - Weight files are now verified against their expected checksum before being reused, preventing outdated or mismatched files from being kept.
  - If an existing weight file does not match its recorded checksum, it is removed and fetched again automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->