### PR TITLE
Introduce contract-driven group payload planning for dim-split dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,7 +1827,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 [[package]]
 name = "dsperse"
 version = "0.0.0"
-source = "git+https://github.com/inference-labs-inc/dsperse?rev=415f1d6650dd4725237d33c5fe03bd944f46ea36#415f1d6650dd4725237d33c5fe03bd944f46ea36"
+source = "git+https://github.com/inference-labs-inc/dsperse?rev=b66a700d42d5f825c386467dfa002c9147064eec#b66a700d42d5f825c386467dfa002c9147064eec"
 dependencies = [
  "clap",
  "half 2.7.1",
@@ -4901,7 +4901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -4921,7 +4921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4934,7 +4934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ futures-util = "0.3"
 shellexpand = "3.1.2"
 openssl = { version = "0.10", features = ["vendored"] }
 flate2 = "1"
-dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "415f1d6650dd4725237d33c5fe03bd944f46ea36" }
+dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "b66a700d42d5f825c386467dfa002c9147064eec" }
 ndarray = { version = "0.17", features = ["serde"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 bittensor-drand = { git = "https://github.com/inference-labs-inc/bittensor-drand.git", rev = "e55ed98", default-features = false }

--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -259,11 +259,45 @@ impl ValidatorLoop {
                 .iter()
                 .map(|io| io.shape.iter().product::<usize>())
                 .sum();
-            let (primary, secondaries) = Self::group_dim_split_tensors(&work.named_inputs, ds)?;
-            let group_elems = primary.len() / ds.dim_size * ds.elements_per_group;
-            let secondary_elems: usize = secondaries.iter().map(|t| t.len()).sum();
-            let per_request_actual = secondary_elems + group_elems;
-            return if per_request_actual == bundle_expected {
+            let manifest_shapes: Vec<Vec<usize>> = work
+                .named_inputs
+                .iter()
+                .map(|(_, t)| t.shape().to_vec())
+                .collect();
+            let contract: Vec<(String, Vec<usize>)> = params
+                .inputs
+                .iter()
+                .map(|io| (io.name.clone(), io.shape.clone()))
+                .collect();
+            let per_request_actual =
+                match dsperse::pipeline::plan_group_payload(&manifest_shapes, ds, &contract) {
+                    Ok(plan) => plan
+                        .iter()
+                        .map(|part| match part {
+                            dsperse::pipeline::GroupPayloadPart::Whole(i) => {
+                                manifest_shapes[*i].iter().product::<usize>()
+                            }
+                            dsperse::pipeline::GroupPayloadPart::Split(i) => {
+                                manifest_shapes[*i].iter().product::<usize>() / ds.dim_size
+                                    * ds.elements_per_group
+                            }
+                        })
+                        .sum::<usize>(),
+                    Err(_) => 0,
+                };
+            let activation_expected: usize = contract
+                .iter()
+                .take_while(|(_, shape)| {
+                    let n: usize = shape.iter().product();
+                    manifest_shapes.iter().any(|m| {
+                        m.iter().product::<usize>() == n
+                            || m.iter().product::<usize>() / ds.dim_size * ds.elements_per_group
+                                == n
+                    })
+                })
+                .map(|(_, shape)| shape.iter().product::<usize>())
+                .sum();
+            return if per_request_actual > 0 && per_request_actual == activation_expected {
                 None
             } else {
                 Some(BundleDispatchMismatch {
@@ -830,9 +864,39 @@ impl ValidatorLoop {
             PlannedPayload::DimSplit { ds, indices } if ds.weight_name.is_none() => {
                 let wanted: std::collections::HashSet<usize> =
                     indices.iter().map(|&i| i as usize).collect();
-                let (primary, secondaries) = Self::group_dim_split_tensors(&named_inputs, ds)?;
+                let circuit_path = plan.circuit_path.as_deref()?;
+                let backend = dsperse::backend::jstprove::JstproveBackend::new();
+                let params = match backend.load_params(std::path::Path::new(circuit_path)) {
+                    Ok(Some(p)) => p,
+                    _ => {
+                        warn!(
+                            run_uid = %plan.run_uid,
+                            slice = %plan.slice_id,
+                            "group payload construction missing circuit params"
+                        );
+                        return None;
+                    }
+                };
+                let manifest_shapes: Vec<Vec<usize>> = named_inputs
+                    .iter()
+                    .map(|(_, t)| t.shape().to_vec())
+                    .collect();
+                let contract: Vec<(String, Vec<usize>)> = params
+                    .inputs
+                    .iter()
+                    .map(|io| (io.name.clone(), io.shape.clone()))
+                    .collect();
+                let tensors: Vec<&ndarray::ArrayD<f64>> =
+                    named_inputs.iter().map(|(_, t)| t).collect();
                 let payloads =
-                    match dsperse::pipeline::dim_split_group_payloads(primary, &secondaries, ds) {
+                    match dsperse::pipeline::plan_group_payload(&manifest_shapes, ds, &contract)
+                        .and_then(|payload_plan| {
+                            dsperse::pipeline::dim_split_group_payloads_planned(
+                                &tensors,
+                                &payload_plan,
+                                ds,
+                            )
+                        }) {
                         Ok(p) => p,
                         Err(e) => {
                             warn!(
@@ -1073,22 +1137,6 @@ impl ValidatorLoop {
         } else {
             None
         }
-    }
-
-    fn group_dim_split_tensors<'a>(
-        named_inputs: &'a [(String, ndarray::ArrayD<f64>)],
-        ds: &dsperse::schema::tiling::DimSplitInfo,
-    ) -> Option<(&'a ndarray::ArrayD<f64>, Vec<&'a ndarray::ArrayD<f64>>)> {
-        let primary = named_inputs
-            .iter()
-            .find(|(n, _)| n == &ds.input_name)
-            .map(|(_, t)| t)?;
-        let secondaries: Vec<&ndarray::ArrayD<f64>> = named_inputs
-            .iter()
-            .filter(|(n, _)| n != &ds.input_name)
-            .map(|(_, t)| t)
-            .collect();
-        Some((primary, secondaries))
     }
 
     fn dim_split_payloads(


### PR DESCRIPTION
Group payload construction and its dispatch preflight previously inferred each input tensor's treatment from shape arithmetic. A population audit across every multi-input dim-split slice in all production models showed shape rules cannot distinguish contraction slices, whose counterpart tensor is consumed whole per group, from broadcast slices, whose secondaries must be sliced with the primary, when dimension sizes coincide.

Both paths now consult the compiled circuit's declared input contract through the dsperse payload planner: materialization builds each group payload from the plan in contract order, and preflight passes exactly when a plan exists whose activation sizing matches the contract prefix, with trailing initializer entries left to the prover-side extraction path already present in deployed provers since 14.11.0. No prover-side updates are required.

The planner ships with a committed fixture corpus covering every production slice contract and canary tests pinning the contraction and broadcast cases, so payload regressions surface at test time rather than after dispatch. Witness generation against production circuits passes for both structural classes through the planned path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of dimension-split group dispatch so payloads are planned more accurately from the available circuit inputs and parameters.
  * Reduced cases where dispatch/mismatch checks could misreport due to older tensor-splitting logic.
  * Added safer fallback behavior when required circuit parameters can’t be loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->