### PR TITLE
Resolve group slice path handling and surface contract planning causes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,7 +1827,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 [[package]]
 name = "dsperse"
 version = "0.0.0"
-source = "git+https://github.com/inference-labs-inc/dsperse?rev=b66a700d42d5f825c386467dfa002c9147064eec#b66a700d42d5f825c386467dfa002c9147064eec"
+source = "git+https://github.com/inference-labs-inc/dsperse?rev=fd7f2a603780f54d567183725851f51e273c969d#fd7f2a603780f54d567183725851f51e273c969d"
 dependencies = [
  "clap",
  "half 2.7.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ futures-util = "0.3"
 shellexpand = "3.1.2"
 openssl = { version = "0.10", features = ["vendored"] }
 flate2 = "1"
-dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "b66a700d42d5f825c386467dfa002c9147064eec" }
+dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "fd7f2a603780f54d567183725851f51e273c969d" }
 ndarray = { version = "0.17", features = ["serde"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 bittensor-drand = { git = "https://github.com/inference-labs-inc/bittensor-drand.git", rev = "e55ed98", default-features = false }

--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -248,11 +248,24 @@ impl ValidatorLoop {
         work: &dsperse::pipeline::SliceWork,
     ) -> Option<Vec<dsperse::pipeline::GroupPayloadPart>> {
         let ds = Self::group_dim_split(work)?;
-        let circuit_path = work.circuit_path.as_ref()?;
+        let circuit_path = match work.circuit_path.as_ref() {
+            Some(p) => p,
+            None => {
+                warn!(slice = %work.slice_id, "group contract planning: no circuit path");
+                return None;
+            }
+        };
         let backend = dsperse::backend::jstprove::JstproveBackend::new();
         let params = match backend.load_params(std::path::Path::new(circuit_path)) {
             Ok(Some(p)) => p,
-            _ => return None,
+            Ok(None) => {
+                warn!(slice = %work.slice_id, circuit_path, "group contract planning: bundle has no params");
+                return None;
+            }
+            Err(e) => {
+                warn!(slice = %work.slice_id, circuit_path, error = %e, "group contract planning: params load failed");
+                return None;
+            }
         };
         let manifest_shapes: Vec<Vec<usize>> = work
             .named_inputs
@@ -264,7 +277,13 @@ impl ValidatorLoop {
             .iter()
             .map(|io| (io.name.clone(), io.shape.clone()))
             .collect();
-        dsperse::pipeline::plan_group_payload(&manifest_shapes, ds, &contract).ok()
+        match dsperse::pipeline::plan_group_payload(&manifest_shapes, ds, &contract) {
+            Ok(plan) => Some(plan),
+            Err(e) => {
+                warn!(slice = %work.slice_id, error = %e, "group contract planning: contract match failed");
+                None
+            }
+        }
     }
 
     fn bundle_dispatch_mismatch(


### PR DESCRIPTION
Slice work records carried circuit paths relative to the model slices directory, resolved against the process working directory at parameter load. Group contract planning therefore failed for every grouped slice in deployed environments, and the dispatch preflight introduced earlier had silently passed on the same load failure rather than checking anything. The updated pipeline dependency resolves circuit and onnx paths against the slices directory at slice work construction, reproduced and verified end to end from an arbitrary working directory against production model runs.

Contract planning failures now log their cause distinctly: missing circuit path, bundle without parameters, parameter load error, or contract match failure. Each of these previously collapsed into one silent skip, which extended diagnosis of the underlying path defect by a full release cycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of contract planning when required data is missing or invalid, reducing silent failures.
  * Added clearer warnings when a requested plan cannot be built, making issues easier to detect and diagnose.
  * Better surfaces mismatches during payload planning instead of failing without context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->