### PR TITLE
Resolve group tile output consistency against concat-axis expected regions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,7 +1827,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 [[package]]
 name = "dsperse"
 version = "0.0.0"
-source = "git+https://github.com/inference-labs-inc/dsperse?rev=fd7f2a603780f54d567183725851f51e273c969d#fd7f2a603780f54d567183725851f51e273c969d"
+source = "git+https://github.com/inference-labs-inc/dsperse?rev=c746ea7e85da0772d2980e3462147ef3336e1561#c746ea7e85da0772d2980e3462147ef3336e1561"
 dependencies = [
  "clap",
  "half 2.7.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ futures-util = "0.3"
 shellexpand = "3.1.2"
 openssl = { version = "0.10", features = ["vendored"] }
 flate2 = "1"
-dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "fd7f2a603780f54d567183725851f51e273c969d" }
+dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "c746ea7e85da0772d2980e3462147ef3336e1561" }
 ndarray = { version = "0.17", features = ["serde"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 bittensor-drand = { git = "https://github.com/inference-labs-inc/bittensor-drand.git", rev = "e55ed98", default-features = false }

--- a/crates/sn2-validator/src/incremental_runner.rs
+++ b/crates/sn2-validator/src/incremental_runner.rs
@@ -24,6 +24,38 @@ pub enum OutputConsistency {
 
 const OUTPUT_CONSISTENCY_THRESHOLD: f64 = 0.10;
 
+pub fn group_expected_region(
+    arrays: &[ndarray::ArrayD<f64>],
+    concat_axis: usize,
+    num_groups: usize,
+    tile_idx: u32,
+) -> Option<Vec<f64>> {
+    if num_groups == 0 {
+        return None;
+    }
+    let mut flat = Vec::new();
+    for arr in arrays {
+        if concat_axis >= arr.ndim() || arr.shape()[concat_axis] % num_groups != 0 {
+            return None;
+        }
+        let extent = arr.shape()[concat_axis] / num_groups;
+        let start = tile_idx as usize * extent;
+        if start + extent > arr.shape()[concat_axis] {
+            return None;
+        }
+        let region = arr.slice_axis(
+            ndarray::Axis(concat_axis),
+            ndarray::Slice::from(start..start + extent),
+        );
+        flat.extend(region.as_standard_layout().iter());
+    }
+    if flat.is_empty() {
+        None
+    } else {
+        Some(flat)
+    }
+}
+
 pub fn classify_output_consistency(expected: &[f64], actual: &[f64]) -> OutputConsistency {
     if expected.is_empty() || actual.is_empty() {
         return OutputConsistency::LengthMismatch {
@@ -183,6 +215,7 @@ impl IncrementalRunManager {
         miner_outputs: &[f64],
         input_norm_factor: Option<f64>,
         circuit_output_names: &[String],
+        group_tile: Option<(&dsperse::schema::tiling::DimSplitInfo, u32)>,
     ) -> OutputConsistency {
         let run = match self.runs.get(run_uid) {
             Some(r) => r,
@@ -192,9 +225,21 @@ impl IncrementalRunManager {
             Some(c) => c,
             None => return OutputConsistency::NoExpected,
         };
-        let expected = match combined.outputs_for_names(circuit_output_names) {
-            Some(e) => e,
-            None => return OutputConsistency::NoExpected,
+        let expected = match group_tile {
+            Some((ds, tile_idx)) => {
+                let arrays = match combined.output_arrays_for_names(circuit_output_names) {
+                    Some(a) => a,
+                    None => return OutputConsistency::NoExpected,
+                };
+                match group_expected_region(&arrays, ds.concat_axis, ds.num_groups, tile_idx) {
+                    Some(flat) => flat,
+                    None => return OutputConsistency::NoExpected,
+                }
+            }
+            None => match combined.outputs_for_names(circuit_output_names) {
+                Some(e) => e,
+                None => return OutputConsistency::NoExpected,
+            },
         };
         match input_norm_factor {
             Some(k) if k > 1.0 => {
@@ -203,6 +248,23 @@ impl IncrementalRunManager {
             }
             _ => classify_output_consistency(&expected, miner_outputs),
         }
+    }
+
+    pub fn group_dim_split_meta(
+        &self,
+        run_uid: &str,
+        slice_id: &str,
+    ) -> Option<dsperse::schema::tiling::DimSplitInfo> {
+        let run = self.runs.get(run_uid)?;
+        let combined = run.combined.as_ref()?;
+        let index: usize = slice_id.strip_prefix("slice_")?.parse().ok()?;
+        combined
+            .model_meta()
+            .slices
+            .iter()
+            .find(|s| s.index == index)
+            .and_then(|s| s.dim_split.clone())
+            .filter(|ds| ds.weight_name.is_none())
     }
 
     pub fn is_evicted(&self, run_uid: &str) -> bool {
@@ -567,6 +629,48 @@ impl IncrementalRunManager {
 mod tests {
     use super::*;
 
+    #[test]
+    fn group_region_slices_each_output_along_concat_axis() {
+        let a = ndarray::ArrayD::from_shape_vec(
+            ndarray::IxDyn(&[2, 4, 3]),
+            (0..24).map(|v| v as f64).collect(),
+        )
+        .unwrap();
+        let b = ndarray::ArrayD::from_shape_vec(
+            ndarray::IxDyn(&[1, 4, 2]),
+            (100..108).map(|v| v as f64).collect(),
+        )
+        .unwrap();
+        let region = group_expected_region(&[a.clone(), b.clone()], 1, 2, 1).unwrap();
+        assert_eq!(region.len(), 12 + 4);
+        assert_eq!(region[0], 6.0);
+        assert_eq!(region[12], 104.0);
+        let full: Vec<f64> = group_expected_region(&[a.clone(), b.clone()], 1, 2, 0)
+            .unwrap()
+            .into_iter()
+            .chain(group_expected_region(&[a, b], 1, 2, 1).unwrap())
+            .collect();
+        assert_eq!(full.len(), 32);
+    }
+
+    #[test]
+    fn group_region_rejects_unmappable_shapes() {
+        let a = ndarray::ArrayD::from_shape_vec(
+            ndarray::IxDyn(&[2, 5, 3]),
+            (0..30).map(|v| v as f64).collect(),
+        )
+        .unwrap();
+        assert!(group_expected_region(std::slice::from_ref(&a), 1, 2, 0).is_none());
+        assert!(group_expected_region(std::slice::from_ref(&a), 9, 2, 0).is_none());
+        assert!(group_expected_region(&[a], 1, 0, 0).is_none());
+        let b = ndarray::ArrayD::from_shape_vec(
+            ndarray::IxDyn(&[2, 4, 3]),
+            (0..24).map(|v| v as f64).collect(),
+        )
+        .unwrap();
+        assert!(group_expected_region(&[b], 1, 2, 5).is_none());
+    }
+
     fn make_manager_with_run(run_uid: &str) -> IncrementalRunManager {
         let mut mgr = IncrementalRunManager::new();
         mgr.start_run(
@@ -583,14 +687,14 @@ mod tests {
     #[test]
     fn output_consistency_no_run() {
         let mgr = IncrementalRunManager::new();
-        let result = mgr.verify_output_consistency("nonexistent", &[1.0, 2.0], None, &[]);
+        let result = mgr.verify_output_consistency("nonexistent", &[1.0, 2.0], None, &[], None);
         assert!(matches!(result, OutputConsistency::NoRun));
     }
 
     #[test]
     fn output_consistency_no_combined() {
         let mgr = make_manager_with_run("run-1");
-        let result = mgr.verify_output_consistency("run-1", &[1.0, 2.0], None, &[]);
+        let result = mgr.verify_output_consistency("run-1", &[1.0, 2.0], None, &[], None);
         assert!(matches!(result, OutputConsistency::NoExpected));
     }
 

--- a/crates/sn2-validator/src/validator_loop/results.rs
+++ b/crates/sn2-validator/src/validator_loop/results.rs
@@ -257,47 +257,62 @@ impl ValidatorLoop {
                         .dslice_input_scales
                         .get(&(run_uid.clone(), slice_num.clone()))
                         .copied();
-                    match self.run_manager.verify_output_consistency(
-                        &run_uid,
-                        &miner_outputs,
-                        norm_factor,
-                        &circuit_output_names,
-                    ) {
-                        OutputConsistency::Consistent { max_rel_err } => {
-                            tracing::debug!(
-                                uid = response.uid,
-                                run_uid = %run_uid,
-                                slice = %slice_num,
-                                max_rel_err,
-                                "output consistency verified"
-                            );
+                    let group_ds = tile_idx
+                        .and_then(|_| self.run_manager.group_dim_split_meta(&run_uid, &slice_num));
+                    let group_tile = match (group_ds.as_ref(), tile_idx) {
+                        (Some(ds), Some(idx)) => Some((ds, idx)),
+                        _ => None,
+                    };
+                    if tile_idx.is_some() && group_tile.is_none() {
+                        tracing::debug!(
+                            uid = response.uid,
+                            slice = %slice_num,
+                            "skipping output consistency: tile without group region mapping"
+                        );
+                    } else {
+                        match self.run_manager.verify_output_consistency(
+                            &run_uid,
+                            &miner_outputs,
+                            norm_factor,
+                            &circuit_output_names,
+                            group_tile,
+                        ) {
+                            OutputConsistency::Consistent { max_rel_err } => {
+                                tracing::debug!(
+                                    uid = response.uid,
+                                    run_uid = %run_uid,
+                                    slice = %slice_num,
+                                    max_rel_err,
+                                    "output consistency verified"
+                                );
+                            }
+                            OutputConsistency::Diverged { max_rel_err } => {
+                                let zk_sample: Vec<f64> =
+                                    miner_outputs.iter().copied().take(5).collect();
+                                warn!(
+                                    uid = response.uid,
+                                    run_uid = %run_uid,
+                                    slice = %slice_num,
+                                    max_rel_err,
+                                    norm_factor = ?norm_factor,
+                                    num_outputs = circuit_output_names.len(),
+                                    zk_len = miner_outputs.len(),
+                                    zk_sample = ?zk_sample,
+                                    "output consistency check failed: miner outputs diverge"
+                                );
+                            }
+                            OutputConsistency::LengthMismatch { expected, actual } => {
+                                warn!(
+                                    uid = response.uid,
+                                    run_uid = %run_uid,
+                                    slice = %slice_num,
+                                    expected,
+                                    actual,
+                                    "output consistency check failed: empty outputs"
+                                );
+                            }
+                            OutputConsistency::NoExpected | OutputConsistency::NoRun => {}
                         }
-                        OutputConsistency::Diverged { max_rel_err } => {
-                            let zk_sample: Vec<f64> =
-                                miner_outputs.iter().copied().take(5).collect();
-                            warn!(
-                                uid = response.uid,
-                                run_uid = %run_uid,
-                                slice = %slice_num,
-                                max_rel_err,
-                                norm_factor = ?norm_factor,
-                                num_outputs = circuit_output_names.len(),
-                                zk_len = miner_outputs.len(),
-                                zk_sample = ?zk_sample,
-                                "output consistency check failed: miner outputs diverge"
-                            );
-                        }
-                        OutputConsistency::LengthMismatch { expected, actual } => {
-                            warn!(
-                                uid = response.uid,
-                                run_uid = %run_uid,
-                                slice = %slice_num,
-                                expected,
-                                actual,
-                                "output consistency check failed: empty outputs"
-                            );
-                        }
-                        OutputConsistency::NoExpected | OutputConsistency::NoRun => {}
                     }
                 }
             }


### PR DESCRIPTION
The output consistency check compared each miner response against the full expected output of its slice. For group dim-split tiles the response carries one group's output, so the comparison was against the wrong region and always diverged. This path had been silently skipped in production until the recent path resolution work enabled parameter loading, at which point the miscomparison surfaced as warning noise with no scoring effect.

Group tile responses are now compared against the matching region of each expected output tensor, sliced along the concatenation axis by group index through a shaped output accessor in the pipeline dependency. Tiles without a group region mapping skip the check explicitly. Unit coverage exercises multi-output region slicing, full reassembly across groups, and rejection of unmappable shapes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved output validation for tiled runs so grouped outputs are checked against the correct expected region.
  * Prevents false consistency failures when a tile cannot be matched to a valid grouped expectation, while keeping existing validation behavior for standard runs.

* **Chores**
  * Updated a workspace dependency to a newer revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->