### PR TITLE
Migrate run activation retention onto settled-tensor release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,7 +1827,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 [[package]]
 name = "dsperse"
 version = "0.0.0"
-source = "git+https://github.com/inference-labs-inc/dsperse?rev=7bfc34963275a6dc12c9b8fcbd86ff3cc0c14d9a#7bfc34963275a6dc12c9b8fcbd86ff3cc0c14d9a"
+source = "git+https://github.com/inference-labs-inc/dsperse?rev=3a4fbf080bb3#3a4fbf080bb326c7651c876fcdb7d5d488aec55b"
 dependencies = [
  "clap",
  "half 2.7.1",
@@ -4901,7 +4901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -4921,7 +4921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4934,7 +4934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ futures-util = "0.3"
 shellexpand = "3.1.2"
 openssl = { version = "0.10", features = ["vendored"] }
 flate2 = "1"
-dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "7bfc34963275a6dc12c9b8fcbd86ff3cc0c14d9a" }
+dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "3a4fbf080bb3" }
 ndarray = { version = "0.17", features = ["serde"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 bittensor-drand = { git = "https://github.com/inference-labs-inc/bittensor-drand.git", rev = "e55ed98", default-features = false }

--- a/crates/sn2-validator/src/validator_loop/maintenance.rs
+++ b/crates/sn2-validator/src/validator_loop/maintenance.rs
@@ -49,7 +49,7 @@ impl ValidatorLoop {
             if now.duration_since(self.timings.bundle_cache_sweep) > Duration::from_secs(60) {
                 let evicted = sn2_verify::evict_idle_bundles(BUNDLE_CACHE_IDLE_TTL_SECS);
                 if evicted > 0 {
-                    debug!(evicted, "evicted idle compiled bundles");
+                    info!(evicted, "evicted idle compiled bundles");
                 }
                 self.timings.bundle_cache_sweep = now;
             }


### PR DESCRIPTION
Each concurrent run retained every intermediate activation tensor of its model for the run's lifetime, though only tensors referenced by pending circuit slices are read after the upfront inference. With several runs pipelined this pinned host memory into the capacity controller's pressure gate within an hour of restart, freezing miner caps well below their measured knees.

The updated pipeline dependency drops unreferenced activations at run construction and releases the remainder as their referencing slices settle, verified against a production model at over ninety-nine percent of activation elements released. Bundle sweep eviction logging moves to info level so cache behavior is observable in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a workspace dependency to a newer revision.
* **Bug Fixes**
  * Improved visibility of background cleanup activity by raising an important cache-eviction message to a higher log level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->