### PR TITLE
Resolve post-restart miner starvation from reconnect errors triggering tempo-long cooldowns

### DIFF
--- a/crates/sn2-types/src/constants.rs
+++ b/crates/sn2-types/src/constants.rs
@@ -57,6 +57,16 @@ pub const IP_REGION_CAP_FRACTION: f64 = 0.25;
 /// recovered miner re-enters dispatch within the same scoring window.
 pub const REHAB_BLOCKS: u64 = 360;
 
+/// Block-height hold applied to a hotkey whose dispatch failed inside the
+/// validator-side transport (reconnect gating, missing authenticated route)
+/// before any request reached the miner. Sized to the 60-second miner
+/// registry refresh cadence that prunes dead connections and resets
+/// reconnect backoff: by the time the hold expires, the transport has
+/// either re-established the route or removed the peer from the
+/// authenticated set. Unlike dispatch cooldowns, these holds gate dispatch
+/// only and never feed the weight skiplist.
+pub const RECONNECT_HOLD_BLOCKS: u64 = 5;
+
 pub const MAX_POW_QUEUE_SIZE: usize = 1024;
 pub const POW_OUTPUT_STRIDE: usize = MAX_POW_QUEUE_SIZE;
 pub const POW_SCORES_OFFSET: usize = 0;

--- a/crates/sn2-validator/src/validator_loop/dispatch.rs
+++ b/crates/sn2-validator/src/validator_loop/dispatch.rs
@@ -66,6 +66,11 @@ impl ValidatorLoop {
                         return false;
                     }
                 }
+                if let Some(&until) = self.reconnect_holds.get(&n.hotkey) {
+                    if current_block < until {
+                        return false;
+                    }
+                }
                 if !self.hotkey_reachable(&n.hotkey) {
                     return false;
                 }

--- a/crates/sn2-validator/src/validator_loop/maintenance.rs
+++ b/crates/sn2-validator/src/validator_loop/maintenance.rs
@@ -249,6 +249,9 @@ impl ValidatorLoop {
     }
 
     pub(super) fn prune_expired_cooldowns(&mut self) {
+        let current_block = self.current_block;
+        self.reconnect_holds
+            .retain(|_, until| current_block < *until);
         let cooldowns_before = self.dispatch_cooldowns.len();
         let expired_hotkeys: Vec<String> = self
             .dispatch_cooldowns

--- a/crates/sn2-validator/src/validator_loop/mod.rs
+++ b/crates/sn2-validator/src/validator_loop/mod.rs
@@ -187,6 +187,12 @@ pub struct ValidatorLoop {
     pub(super) consecutive_metagraph_failures: u32,
     pub(super) dispatch_cache: dispatch::DispatchCache,
     pub(super) dispatch_cooldowns: HashMap<String, u64>,
+    // Short dispatch-only holds for hotkeys whose queries failed inside the
+    // validator-side transport before reaching the miner (reconnect backoff,
+    // reconnect contention, missing authenticated route). Kept separate from
+    // dispatch_cooldowns because those feed the weight skiplist: a miner must
+    // not lose emission weight over the validator's own dead connection.
+    pub(super) reconnect_holds: HashMap<String, u64>,
 }
 
 pub(super) const METAGRAPH_FAILURE_RECONNECT_THRESHOLD: u32 = 3;
@@ -398,6 +404,7 @@ impl ValidatorLoop {
             consecutive_metagraph_failures: 0,
             dispatch_cache: dispatch::DispatchCache::new(),
             dispatch_cooldowns: HashMap::new(),
+            reconnect_holds: HashMap::new(),
         })
     }
 

--- a/crates/sn2-validator/src/validator_loop/results.rs
+++ b/crates/sn2-validator/src/validator_loop/results.rs
@@ -370,18 +370,13 @@ impl ValidatorLoop {
         external_request_hash: Option<u32>,
         reason: &str,
     ) {
-        warn!(uid = uid, rtype = %request_type, retry = retry_count, run_uid = ?run_uid, slice = ?slice_num, tile = ?tile_idx, error = reason, "miner query failed");
+        let transport_failure = is_transport_dispatch_failure(reason);
+        warn!(uid = uid, rtype = %request_type, retry = retry_count, run_uid = ?run_uid, slice = ?slice_num, tile = ?tile_idx, transport = transport_failure, error = reason, "miner query failed");
 
-        if !hotkey.is_empty()
-            && (reason.contains("already in progress") || reason.contains("in backoff"))
-        {
-            let bpt = if self.blocks_per_tempo == 0 {
-                360
-            } else {
-                self.blocks_per_tempo
-            };
-            let until = self.current_block + bpt;
-            self.dispatch_cooldowns.insert(hotkey.to_string(), until);
+        if !hotkey.is_empty() && transport_failure {
+            let until = self.current_block.saturating_add(RECONNECT_HOLD_BLOCKS);
+            let hold = self.reconnect_holds.entry(hotkey.to_string()).or_insert(0);
+            *hold = (*hold).max(until);
         }
 
         let is_verification_failure = reason.starts_with("verification failed")
@@ -398,28 +393,32 @@ impl ValidatorLoop {
             }
         }
 
-        let failed_circuit_id = match &retry_payload {
-            RetryPayload::DSlice(d) => Some(d.circuit.id.as_str()),
-            RetryPayload::Rwr(r) => Some(r.circuit_id.as_str()),
-            RetryPayload::None => None,
-        };
-        let slice_part = slice_num
-            .as_deref()
-            .map(|s| s.strip_prefix("slice_").unwrap_or(s));
-        let work_key = Self::build_work_key(failed_circuit_id, slice_part);
-        self.performance_tracker
-            .record_reschedule_keyed(uid, &work_key);
+        // Transport-gated failures never left the validator: the miner saw no
+        // request, so there is no performance to debit. Everything that did
+        // reach (or could have reached) the miner still counts against it.
+        if !transport_failure {
+            let failed_circuit_id = match &retry_payload {
+                RetryPayload::DSlice(d) => Some(d.circuit.id.as_str()),
+                RetryPayload::Rwr(r) => Some(r.circuit_id.as_str()),
+                RetryPayload::None => None,
+            };
+            let slice_part = slice_num
+                .as_deref()
+                .map(|s| s.strip_prefix("slice_").unwrap_or(s));
+            let work_key = Self::build_work_key(failed_circuit_id, slice_part);
+            self.performance_tracker
+                .record_reschedule_keyed(uid, &work_key);
 
-        let elapsed = 0.0;
-        self.score_manager.update_score(
-            uid,
-            false,
-            elapsed,
-            VALIDATOR_REQUEST_TIMEOUT_SECONDS as f64,
-            0.0,
-            self.config.metagraph.n,
-        );
-        metrics::record_response(false, elapsed);
+            self.score_manager.update_score(
+                uid,
+                false,
+                0.0,
+                VALIDATOR_REQUEST_TIMEOUT_SECONDS as f64,
+                0.0,
+                self.config.metagraph.n,
+            );
+        }
+        metrics::record_response(false, 0.0);
 
         let max_retries = match (&request_type, &retry_payload) {
             (RequestType::DSlice, RetryPayload::DSlice(ref d))
@@ -459,6 +458,87 @@ impl ValidatorLoop {
                 }),
             )
             .await;
+        }
+    }
+}
+
+/// Whether a query failure was raised by the validator-side transport before
+/// any request reached the miner: dial and handshake failures, reconnect
+/// gating (in backoff, contention, attempts exhausted), a missing
+/// authenticated route, an uninitialized endpoint, or a stream that could not
+/// be opened. All of these surface as btlightning `Connection` or `Handshake`
+/// errors under the "QUIC query" context added in `query_miner_quic`, so the
+/// anyhow chain starts with one of the two prefixes below. Failures that can
+/// postdate delivery keep other variants — query timeouts are `transport
+/// error`, mid-stream aborts are `stream error`, and miner-reported errors
+/// are `handler error` with the miner's text *after* the prefix — so a miner
+/// cannot spoof this classification, and genuine miner faults are never
+/// misattributed to the transport.
+///
+/// A restarting miner makes these failures unavoidable: its old connection is
+/// dead for up to the QUIC idle timeout while its hotkey remains in the
+/// authenticated set, so every dispatch in that window fails inside the
+/// transport. Treating those as miner faults previously cost the miner a
+/// full-tempo dispatch cooldown (which also zeroed its weight through the
+/// skiplist path) plus delivered-work debits for requests it never received.
+fn is_transport_dispatch_failure(reason: &str) -> bool {
+    reason.starts_with("QUIC query: connection error:")
+        || reason.starts_with("QUIC query: handshake error:")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_transport_dispatch_failure;
+
+    #[test]
+    fn reconnect_gating_errors_classify_as_transport() {
+        // Exact btlightning reconnect-path messages, wrapped the way
+        // query_miner surfaces them through the anyhow chain.
+        for msg in [
+            "QUIC query: connection error: Reconnection to 1.2.3.4:8080 in backoff, next retry in 900ms",
+            "QUIC query: connection error: Reconnection to 1.2.3.4:8080 already in progress",
+            "QUIC query: connection error: Reconnection attempts exhausted for 1.2.3.4:8080 (5/5), awaiting registry refresh",
+            "QUIC query: connection error: Reconnection to 1.2.3.4:8080 timed out",
+            "QUIC query: handshake error: no authenticated route for hk1 at 1.2.3.4:8080",
+            "QUIC query: connection error: QUIC endpoint not initialized",
+        ] {
+            assert!(
+                is_transport_dispatch_failure(msg),
+                "must classify as transport: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn miner_attributable_failures_are_not_transport() {
+        for msg in [
+            "verification failed",
+            "QUIC query: transport error: query timed out",
+            "QUIC query: stream error: server aborted mid-chunk",
+            "handler error: witness generation failed",
+            "deserializing QUIC payload: invalid type",
+            "decoding miner response value: unsupported msgpack value",
+        ] {
+            assert!(
+                !is_transport_dispatch_failure(msg),
+                "must not classify as transport: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn miner_cannot_spoof_transport_classification() {
+        // Miner-reported errors surface as LightningError::Handler with the
+        // miner's text after the "handler error: " prefix, so embedded
+        // transport markers never reach position zero of the chain.
+        for msg in [
+            "handler error: QUIC query: connection error: Reconnection to 1.2.3.4:8080 in backoff",
+            "handler error: connection error: Reconnection already in progress",
+        ] {
+            assert!(
+                !is_transport_dispatch_failure(msg),
+                "spoofed marker must not classify as transport: {msg}"
+            );
         }
     }
 }


### PR DESCRIPTION
Every ordinary miner restart currently costs that miner roughly a full tempo of dispatch and emission. When a miner process restarts, its QUIC connection dies while its hotkey remains in the authenticated set until the next registry prune, so dispatches in that window enter the transport's reconnect path. The first caller starts the reconnect; concurrent callers are rejected with "Reconnection to ... already in progress", and callers inside the retry interval are rejected with "Reconnection to ... in backoff". The failure handler matched exactly those two substrings (introduced in #503 to skip peers under reconnect contention) and answered with a dispatch cooldown of one full tempo — roughly 72 minutes — although the transport itself now recovers within one 60-second registry refresh (#568). The weight path compounds the ban: hotkeys under a dispatch cooldown are counted as skiplisted in `update_weights`, so the restarted miner's emission weight is zeroed for the window, and each of these failures also debited the miner's delivered work at the failure multiplier for requests that never left the validator. This reproduces the field reports of miners receiving no requests after a restart: the transport-level fixes in #544, #567, and #568 shortened the reconnect itself, but this app-level ban above the transport remained, so the blackout survived those releases.

Failures are now classified by origin. Errors whose chain begins with the transport's connection or handshake context — dial and handshake failures, reconnect gating, missing authenticated routes, unopenable streams — never carried a request to the miner, so they no longer debit delivered work or per-response score. Instead of a tempo-long cooldown they place the hotkey on a short reconnect hold (`RECONNECT_HOLD_BLOCKS = 5`, sized to the registry refresh cadence that resets reconnect backoff and prunes dead connections). The hold lives apart from `dispatch_cooldowns` and gates dispatch only, precisely so it can never reach the weight skiplist. Query timeouts, stream aborts, and miner-reported handler errors keep their current treatment. The prefix match cannot be spoofed by a miner: miner-controlled text only ever appears after the `handler error:` prefix produced by `into_result`, never at the start of the anyhow chain, which the test suite pins.

Unit coverage exercises the classification of every btlightning reconnect-path message as surfaced through the `QUIC query` context, the non-transport treatment of timeouts, stream aborts, handler errors, and payload decode failures, and the spoof case of a miner embedding transport markers in its own error text. Expected effect after deploy: a restarted miner re-enters dispatch within roughly one registry refresh instead of a tempo, restart windows no longer appear as delivered-work debits or zeroed weights, and reconnect storms no longer register as failure spikes attributed to healthy miners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporary connection-related failures so affected nodes are skipped for a short period instead of being retried immediately.
  * Refined failure handling to avoid incorrectly penalizing scores for transport-level issues, while still tracking the failure.
  * Removed expired retry holds automatically, keeping dispatch behavior up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->