### PR TITLE
Introduce recency decay on delivered work for emission weighting

### DIFF
--- a/crates/sn2-types/src/constants.rs
+++ b/crates/sn2-types/src/constants.rs
@@ -19,6 +19,12 @@ pub const BATCHED_PROOF_OF_WEIGHTS_MODEL_ID: &str =
 pub const PERFORMANCE_WINDOW_SIZE: usize = 2000;
 pub const PERFORMANCE_CURVE_POWER: f64 = 1.3;
 pub const PERFORMANCE_MIN_SAMPLES: usize = 100;
+/// Half-life of the recency decay applied to delivered-work buckets when
+/// computing the weight input. Recent verified delivery props the score up;
+/// a miner that stops delivering sees its effective work halve every
+/// half-life instead of coasting on the flat window sum, while brief
+/// restarts cost nothing measurable.
+pub const DELIVERED_WORK_HALF_LIFE_SECS: u64 = 2 * 3600;
 pub const DELIVERED_WORK_BUCKET_SECS: u64 = 3600;
 pub const FAILURE_DEBIT_MULTIPLIER: f64 = 2.0;
 pub const DSLICE_QUEUE_LOW_WATERMARK: usize = 512;

--- a/crates/sn2-validator/src/performance.rs
+++ b/crates/sn2-validator/src/performance.rs
@@ -8,8 +8,9 @@ use sn2_types::{
     CAPACITY_RAMP_MIN_AVAIL_MEM_RATIO, CAPACITY_RATE_BIN_SECS, CAPACITY_RATE_FILTER_BINS,
     CAPACITY_RATE_WINDOW_BINS, CAPACITY_STEP_FRACTION, CAPACITY_TARGET_DEADBAND,
     CAPACITY_TARGET_HEADROOM, CAPACITY_UNIT_REFERENCE_PERCENTILE, CIRCUIT_TIMEOUT_SECONDS,
-    DELIVERED_WORK_BUCKET_SECS, FAILURE_DEBIT_MULTIPLIER, PERFORMANCE_MIN_SAMPLES,
-    PERFORMANCE_RESCHEDULE_PENALTY, PERFORMANCE_WINDOW_SIZE, VERIFICATION_WINDOW_BLOCKS,
+    DELIVERED_WORK_BUCKET_SECS, DELIVERED_WORK_HALF_LIFE_SECS, FAILURE_DEBIT_MULTIPLIER,
+    PERFORMANCE_MIN_SAMPLES, PERFORMANCE_RESCHEDULE_PENALTY, PERFORMANCE_WINDOW_SIZE,
+    VERIFICATION_WINDOW_BLOCKS,
 };
 use tracing::warn;
 
@@ -604,8 +605,21 @@ impl PerformanceTracker {
     }
 
     fn miner_delivered_work(&self, uid: u16) -> f64 {
-        let (credit, debit, _) = self.delivered_breakdown(uid);
-        (credit - debit).max(0.0)
+        let buckets = match self.delivered_work.get(&uid) {
+            Some(b) => b,
+            None => return 0.0,
+        };
+        let ttl = window_ttl() + Duration::from_secs(DELIVERED_WORK_BUCKET_SECS);
+        let half_life = DELIVERED_WORK_HALF_LIFE_SECS as f64;
+        let mut work = 0.0;
+        for (start, bucket) in buckets {
+            let age = start.elapsed();
+            if age <= ttl {
+                let decay = 0.5_f64.powf(age.as_secs_f64() / half_life);
+                work += (bucket.credit - bucket.debit) * decay;
+            }
+        }
+        work.max(0.0)
     }
 
     pub fn delivered_breakdown(&self, uid: u16) -> (f64, f64, u64) {
@@ -1110,7 +1124,10 @@ mod tests {
             .get(&2)
             .map(|&(w, _, _)| w)
             .unwrap_or(0.0);
-        assert_eq!(before, after_unreferenced);
+        assert!(
+            (before - after_unreferenced).abs() < before * 1e-4,
+            "unreferenced debit must not change work: {before} vs {after_unreferenced}"
+        );
 
         for _ in 0..10 {
             tracker.record_reschedule_keyed(2, "A");
@@ -1156,6 +1173,50 @@ mod tests {
             .expect("uid 3 tracked");
         assert_eq!(work, 0.0);
         assert!(count >= PERFORMANCE_MIN_SAMPLES);
+    }
+
+    #[test]
+    fn delivered_work_decays_when_delivery_stops() {
+        let mut tracker = test_tracker();
+        let now = Instant::now();
+        let old = now.checked_sub(Duration::from_secs(3 * 3600)).unwrap();
+        for (uid, at) in [(1u16, old), (2u16, now)] {
+            for _ in 0..50 {
+                tracker.record_with_time(uid, "hk", true, 1.0, false, "A", at);
+            }
+        }
+        let stale = tracker.miner_delivered_work(1);
+        let fresh = tracker.miner_delivered_work(2);
+        assert!(fresh > 0.0);
+        assert!(
+            stale < fresh * 0.5,
+            "3h-old work must decay well below fresh work: stale={stale} fresh={fresh}"
+        );
+        assert!(
+            stale > fresh * 0.1,
+            "decay is a curve, not a cliff: stale={stale} fresh={fresh}"
+        );
+    }
+
+    #[test]
+    fn steady_delivery_props_up_score() {
+        let mut tracker = test_tracker();
+        let now = Instant::now();
+        for h in 0..6u64 {
+            let at = now.checked_sub(Duration::from_secs(h * 3600)).unwrap();
+            for _ in 0..10 {
+                tracker.record_with_time(3, "hk", true, 1.0, false, "A", at);
+            }
+        }
+        let continuous = tracker.miner_delivered_work(3);
+        for _ in 0..10 {
+            tracker.record_with_time(4, "hk", true, 1.0, false, "A", now);
+        }
+        let single_hour = tracker.miner_delivered_work(4);
+        assert!(
+            continuous > single_hour * 2.0,
+            "sustained delivery must outscore a single fresh burst: continuous={continuous} single={single_hour}"
+        );
     }
 
     fn drive_rate(


### PR DESCRIPTION
Emission weight summed delivered verified work over a flat day-long window, so a miner that stopped serving continued to hold a share of emissions for the remainder of the window, diluting active miners for up to a day after going dark. The prior mitigation only zeroed weight while a dispatch cooldown was active, which lasted a single tempo and then restored the coasting share, so the window tail existed regardless of the recent cooldown rework.

Delivered work buckets now decay exponentially with age at a two hour half-life when computing the weight input. Sustained delivery continuously props the score up and behaves as a stable moving average of throughput; a miner that stops delivering sees its effective work halve every half-life, with the superlinear share curve compounding the fall in relative terms. Brief restarts cost nothing measurable, replacing the previous cliff semantics where a routine restart could zero weight for a tempo while a permanent shutdown eventually coasted. Debits decay on the same curve, so a bad hour ages out of punishment at the same rate a good hour ages out of credit.

Tests cover the decay ratio between stale and fresh work, the curve rather than cliff shape, sustained delivery outscoring a single fresh burst of equal hourly volume, and tolerance-based invariance of unreferenced debits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Delivered work now decays over time, so recent activity contributes more than older activity when scores are calculated.
  * Sustained delivery is now rewarded more consistently than a single short burst.

* **Bug Fixes**
  * Improved score stability for cases where unreferenced debit should not affect work totals.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->