### PR TITLE
Eliminate transport failure classification from the dispatch scoring path

### DIFF
--- a/crates/sn2-types/src/constants.rs
+++ b/crates/sn2-types/src/constants.rs
@@ -71,16 +71,6 @@ pub const IP_REGION_CAP_FRACTION: f64 = 0.25;
 /// recovered miner re-enters dispatch within the same scoring window.
 pub const REHAB_BLOCKS: u64 = 360;
 
-/// Block-height hold applied to a hotkey whose dispatch failed inside the
-/// validator-side transport (reconnect gating, missing authenticated route)
-/// before any request reached the miner. Sized to the 60-second miner
-/// registry refresh cadence that prunes dead connections and resets
-/// reconnect backoff: by the time the hold expires, the transport has
-/// either re-established the route or removed the peer from the
-/// authenticated set. Unlike dispatch cooldowns, these holds gate dispatch
-/// only and never feed the weight skiplist.
-pub const RECONNECT_HOLD_BLOCKS: u64 = 5;
-
 pub const MAX_POW_QUEUE_SIZE: usize = 1024;
 pub const POW_OUTPUT_STRIDE: usize = MAX_POW_QUEUE_SIZE;
 pub const POW_SCORES_OFFSET: usize = 0;

--- a/crates/sn2-validator/src/validator_loop/dispatch.rs
+++ b/crates/sn2-validator/src/validator_loop/dispatch.rs
@@ -66,11 +66,6 @@ impl ValidatorLoop {
                         return false;
                     }
                 }
-                if let Some(&until) = self.reconnect_holds.get(&n.hotkey) {
-                    if current_block < until {
-                        return false;
-                    }
-                }
                 if !self.hotkey_reachable(&n.hotkey) {
                     return false;
                 }

--- a/crates/sn2-validator/src/validator_loop/maintenance.rs
+++ b/crates/sn2-validator/src/validator_loop/maintenance.rs
@@ -249,9 +249,6 @@ impl ValidatorLoop {
     }
 
     pub(super) fn prune_expired_cooldowns(&mut self) {
-        let current_block = self.current_block;
-        self.reconnect_holds
-            .retain(|_, until| current_block < *until);
         let cooldowns_before = self.dispatch_cooldowns.len();
         let expired_hotkeys: Vec<String> = self
             .dispatch_cooldowns

--- a/crates/sn2-validator/src/validator_loop/mod.rs
+++ b/crates/sn2-validator/src/validator_loop/mod.rs
@@ -187,12 +187,6 @@ pub struct ValidatorLoop {
     pub(super) consecutive_metagraph_failures: u32,
     pub(super) dispatch_cache: dispatch::DispatchCache,
     pub(super) dispatch_cooldowns: HashMap<String, u64>,
-    // Short dispatch-only holds for hotkeys whose queries failed inside the
-    // validator-side transport before reaching the miner (reconnect backoff,
-    // reconnect contention, missing authenticated route). Kept separate from
-    // dispatch_cooldowns because those feed the weight skiplist: a miner must
-    // not lose emission weight over the validator's own dead connection.
-    pub(super) reconnect_holds: HashMap<String, u64>,
 }
 
 pub(super) const METAGRAPH_FAILURE_RECONNECT_THRESHOLD: u32 = 3;
@@ -404,7 +398,6 @@ impl ValidatorLoop {
             consecutive_metagraph_failures: 0,
             dispatch_cache: dispatch::DispatchCache::new(),
             dispatch_cooldowns: HashMap::new(),
-            reconnect_holds: HashMap::new(),
         })
     }
 

--- a/crates/sn2-validator/src/validator_loop/results.rs
+++ b/crates/sn2-validator/src/validator_loop/results.rs
@@ -370,14 +370,7 @@ impl ValidatorLoop {
         external_request_hash: Option<u32>,
         reason: &str,
     ) {
-        let transport_failure = is_transport_dispatch_failure(reason);
-        warn!(uid = uid, rtype = %request_type, retry = retry_count, run_uid = ?run_uid, slice = ?slice_num, tile = ?tile_idx, transport = transport_failure, error = reason, "miner query failed");
-
-        if !hotkey.is_empty() && transport_failure {
-            let until = self.current_block.saturating_add(RECONNECT_HOLD_BLOCKS);
-            let hold = self.reconnect_holds.entry(hotkey.to_string()).or_insert(0);
-            *hold = (*hold).max(until);
-        }
+        warn!(uid = uid, rtype = %request_type, retry = retry_count, run_uid = ?run_uid, slice = ?slice_num, tile = ?tile_idx, error = reason, "miner query failed");
 
         let is_verification_failure = reason.starts_with("verification failed")
             && matches!(
@@ -393,15 +386,14 @@ impl ValidatorLoop {
             }
         }
 
-        // A non-delivery is a non-delivery. The validator does not model why a
+        // A non-delivery is a non-delivery. The validator never models why a
         // valid proof failed to arrive: a dead connection, a refused stream, a
-        // timeout, and a bad witness are all the same absence of service and
-        // all debit the failed work. Classification gates only dispatch
-        // efficiency (the reconnect hold above), never scoring, so a miner
-        // cannot launder shed load into an exempt failure class by resetting
-        // streams before the payload is read. Honest restarts are made
-        // painless by recency decay of delivered work, not by exempting the
-        // failures a restart produces.
+        // timeout, and a bad witness are the same absence of service and debit
+        // the failed work identically. There is no failure taxonomy, no hold,
+        // and no exempt class to shape traffic into, so a miner cannot lower
+        // its debit exposure by choosing how a request fails. Honest restarts
+        // are absorbed by recency decay of delivered work, not by inspecting
+        // the failure.
         let failed_circuit_id = match &retry_payload {
             RetryPayload::DSlice(d) => Some(d.circuit.id.as_str()),
             RetryPayload::Rwr(r) => Some(r.circuit_id.as_str()),
@@ -462,76 +454,6 @@ impl ValidatorLoop {
                 }),
             )
             .await;
-        }
-    }
-}
-
-/// Whether a query failure was raised by the validator-side transport: dial
-/// and handshake failures, reconnect gating, a missing authenticated route,
-/// an uninitialized endpoint, or a stream that could not be opened. Used only
-/// to place the hotkey on a short dispatch hold so a demonstrably unreachable
-/// peer is not re-hammered every cycle; it does not affect scoring. Every
-/// non-delivery debits the failed work regardless of this classification, so
-/// a miner cannot avoid a debit by failing early, and the hold is a pure
-/// efficiency measure rather than a punishment or an exemption.
-fn is_transport_dispatch_failure(reason: &str) -> bool {
-    reason.starts_with("QUIC query: connection error:")
-        || reason.starts_with("QUIC query: handshake error:")
-}
-
-#[cfg(test)]
-mod tests {
-    use super::is_transport_dispatch_failure;
-
-    #[test]
-    fn reconnect_gating_errors_classify_as_transport() {
-        // Exact btlightning reconnect-path messages, wrapped the way
-        // query_miner surfaces them through the anyhow chain.
-        for msg in [
-            "QUIC query: connection error: Reconnection to 1.2.3.4:8080 in backoff, next retry in 900ms",
-            "QUIC query: connection error: Reconnection to 1.2.3.4:8080 already in progress",
-            "QUIC query: connection error: Reconnection attempts exhausted for 1.2.3.4:8080 (5/5), awaiting registry refresh",
-            "QUIC query: connection error: Reconnection to 1.2.3.4:8080 timed out",
-            "QUIC query: handshake error: no authenticated route for hk1 at 1.2.3.4:8080",
-            "QUIC query: connection error: QUIC endpoint not initialized",
-        ] {
-            assert!(
-                is_transport_dispatch_failure(msg),
-                "must classify as transport: {msg}"
-            );
-        }
-    }
-
-    #[test]
-    fn miner_attributable_failures_are_not_transport() {
-        for msg in [
-            "verification failed",
-            "QUIC query: transport error: query timed out",
-            "QUIC query: stream error: server aborted mid-chunk",
-            "handler error: witness generation failed",
-            "deserializing QUIC payload: invalid type",
-            "decoding miner response value: unsupported msgpack value",
-        ] {
-            assert!(
-                !is_transport_dispatch_failure(msg),
-                "must not classify as transport: {msg}"
-            );
-        }
-    }
-
-    #[test]
-    fn miner_cannot_spoof_transport_classification() {
-        // Miner-reported errors surface as LightningError::Handler with the
-        // miner's text after the "handler error: " prefix, so embedded
-        // transport markers never reach position zero of the chain.
-        for msg in [
-            "handler error: QUIC query: connection error: Reconnection to 1.2.3.4:8080 in backoff",
-            "handler error: connection error: Reconnection already in progress",
-        ] {
-            assert!(
-                !is_transport_dispatch_failure(msg),
-                "spoofed marker must not classify as transport: {msg}"
-            );
         }
     }
 }


### PR DESCRIPTION
A prior change introduced a per-failure taxonomy that inspected the reason string of a failed dispatch and, when it matched a validator-side transport prefix, placed the hotkey on a short dispatch hold rather than re-dispatching. Scoring was already made classification-free, but the hold still leaked into scoring through cadence: a held hotkey is not dispatched, so it is not debited for the duration of the hold, while a hotkey that failed by timeout or bad witness stayed in rotation and accrued debits every cycle. A miner able to shape how its requests fail could therefore steer them into the held class and carry a materially lighter debit load for the same absence of service.

This removes the taxonomy entirely. There is no reason-string inspection, no hold map, no hold constant, and no separate dispatch gate. Every dispatch that does not return a valid proof debits the failed work identically, against the same reference, and the hotkey remains in normal rotation. Reachability is still gated where it always was, by the authenticated-route check, so a peer with no route is not dispatched to in the first place; the deleted hold only ever covered the narrow window where a route existed but the connection was mid-reconnect, and that window is now simply scored as the non-delivery it is.

The validator no longer models why a proof failed to arrive. Honest restarts are absorbed by recency decay of delivered work, which ages a brief burst of debits back out on the same curve as credit, so the protection for transient outages is a property of time rather than of failure type and cannot be steered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed reconnect-hold restrictions from validator dispatch and failure handling.
  * Miner queries that fail are now handled with simpler warning and retry behavior.
  * Cooldown cleanup no longer tracks or prunes reconnect-hold state.
  * This change may result in faster resumption of dispatching after reconnect-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->