### PR TITLE
Resolve restart-window dispatch churn and validator-restart cap resets

### DIFF
--- a/crates/sn2-types/src/request.rs
+++ b/crates/sn2-types/src/request.rs
@@ -18,6 +18,11 @@ pub struct DSliceRequest {
     pub task_id: Option<String>,
     pub run_source: RunSource,
     pub retry_count: u32,
+    // The uid whose dispatch of this request most recently failed. Retries
+    // are not miner-affine, so without this a request rescheduled off a dead
+    // or broken miner can burn its entire retry budget against that same
+    // peer before any other miner gets a slot for it.
+    pub last_failed_uid: Option<u16>,
     pub circuit_path: Option<String>,
     pub component_sha: Option<String>,
 }

--- a/crates/sn2-validator/src/miner_client.rs
+++ b/crates/sn2-validator/src/miner_client.rs
@@ -130,6 +130,15 @@ impl MinerQueryClient {
         self.lightning.authenticated_hotkeys().await
     }
 
+    /// Per-address transport connection status ("active", "closed(..)",
+    /// "missing"), keyed as `connection_{ip:port}`.
+    pub async fn connection_stats(&self) -> Result<HashMap<String, String>> {
+        self.lightning
+            .get_connection_stats()
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))
+    }
+
     pub async fn query_miner(
         &self,
         ip: &str,

--- a/crates/sn2-validator/src/performance.rs
+++ b/crates/sn2-validator/src/performance.rs
@@ -56,6 +56,10 @@ const MAX_BUFFERED_CAP_EVENTS: usize = 4096;
 pub enum CapDirection {
     Ramp,
     Backoff,
+    /// Global trim applied under host memory pressure, distinct from the
+    /// controller's demand-tracking backoff so pressure activity is
+    /// attributable in capacity telemetry.
+    PressureTrim,
     #[allow(dead_code)]
     Evict,
     Rehab,
@@ -101,7 +105,14 @@ const UNIT_TIMES_CAP: usize = 256;
 const UNIT_REFERENCE_MIN_SAMPLES: usize = 8;
 const REL_SPEED_WINDOW: usize = 64;
 
-const RESTORED_CAP_MAX: usize = 32;
+/// Upper clamp on adaptive caps restored from disk. The clamp exists to
+/// bound damage from stale persisted state, but since caps became
+/// knee-targeted a persisted value is a measured equilibrium, and clamping
+/// a large fleet to a small constant on every validator restart forces tens
+/// of minutes of fleet-wide re-ramping at the step cadence. Sized above any
+/// knee depth observed in production while still bounding a corrupt or
+/// ancient snapshot.
+const RESTORED_CAP_MAX: usize = 512;
 
 fn window_ttl() -> Duration {
     Duration::from_secs(VERIFICATION_WINDOW_BLOCKS * BLOCK_TIME_SECS)
@@ -409,7 +420,7 @@ impl PerformanceTracker {
                 self.cap_events.push(CapEvent {
                     uid: *uid,
                     hotkey,
-                    direction: CapDirection::Backoff,
+                    direction: CapDirection::PressureTrim,
                     cap_from: *cap,
                     cap_to: new_cap,
                     success_rate: 0.0,
@@ -752,6 +763,21 @@ impl PerformanceTracker {
         times[times.len() / 2]
     }
 
+    /// Whether the miner's completion bins span at least one full rate
+    /// window, so the delivered-rate estimate reflects sustained delivery
+    /// rather than the first seconds after a validator restart. Bins are
+    /// in-memory only: after a restart the estimate starts near zero and
+    /// takes a window to warm, during which a restored equilibrium cap
+    /// would otherwise be trimmed toward a meaningless target.
+    fn rate_window_warm(&self, uid: u16, now: Instant) -> bool {
+        let window_len = CAPACITY_RATE_BIN_SECS * CAPACITY_RATE_WINDOW_BINS as u64;
+        self.completion_bins
+            .get(&uid)
+            .and_then(|bins| bins.front())
+            .map(|(start, _)| now.duration_since(*start).as_secs() >= window_len)
+            .unwrap_or(false)
+    }
+
     fn update_adaptive_cap(&mut self, uid: u16, hotkey: &str, now: Instant) {
         let due = self
             .cap_last_adjusted
@@ -765,6 +791,7 @@ impl PerformanceTracker {
             return;
         }
         self.cap_last_adjusted.insert(uid, now);
+        let warm = self.rate_window_warm(uid, now);
         let rate = self.delivered_rate_estimate(uid, now);
         let uncongested = self.uncongested_service_time(uid);
 
@@ -787,7 +814,7 @@ impl PerformanceTracker {
         let target_cap = target.round() as usize;
         let cap_to = if target_cap > cap_from {
             (cap_from + step).min(target_cap)
-        } else if (cap_from as f64) > target * (1.0 + CAPACITY_TARGET_DEADBAND) {
+        } else if warm && (cap_from as f64) > target * (1.0 + CAPACITY_TARGET_DEADBAND) {
             cap_from.saturating_sub(step).max(target_cap).max(1)
         } else {
             cap_from
@@ -1492,6 +1519,54 @@ mod tests {
         tracker.reset_uid(1, "hk");
         let remaining = tracker.drain_cap_events();
         assert!(remaining.iter().all(|e| e.hotkey == "hk_new"));
+    }
+
+    #[test]
+    fn restored_caps_preserve_measured_equilibria() {
+        let dir = std::env::temp_dir().join(format!("sn2_perf_clamp_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("performance_tracker.json");
+        let mut tracker = PerformanceTracker::new_with_persistence(path.clone());
+        tracker.record_keyed(5, "hk", true, 2.0, false, "A");
+        tracker.record_keyed(6, "hk2", true, 2.0, false, "A");
+        tracker.adaptive_caps.insert(5, 400);
+        tracker.adaptive_caps.insert(6, 100_000);
+        tracker.save();
+        let restored = PerformanceTracker::new_with_persistence(path.clone());
+        assert_eq!(
+            restored.adaptive_caps.get(&5).copied(),
+            Some(400),
+            "a knee-targeted equilibrium must survive a validator restart"
+        );
+        assert_eq!(
+            restored.adaptive_caps.get(&6).copied(),
+            Some(RESTORED_CAP_MAX),
+            "corrupt or ancient snapshots stay bounded"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn restored_cap_holds_through_rate_warmup() {
+        let mut tracker = test_tracker();
+        tracker.adaptive_caps.insert(1, 300);
+        let base = Instant::now();
+        // Under one rate window of history: the delivered-rate estimate is
+        // still warming, so a restored equilibrium cap must not be trimmed
+        // toward the not-yet-meaningful target.
+        let mid = drive_rate(&mut tracker, 1, 2, 60, base);
+        assert_eq!(
+            tracker.cap_snapshot().get(&1).copied(),
+            Some(300),
+            "cap must hold while the rate window warms"
+        );
+        // Once the window is warm, genuine low demand tracks the cap down.
+        drive_rate(&mut tracker, 1, 2, 600, mid + Duration::from_secs(1));
+        let cap = tracker.cap_snapshot().get(&1).copied().unwrap_or(0);
+        assert!(
+            cap < 300,
+            "cap {cap} must track demand once the estimate is warm"
+        );
     }
 
     #[test]

--- a/crates/sn2-validator/src/relay.rs
+++ b/crates/sn2-validator/src/relay.rs
@@ -86,6 +86,7 @@ pub struct RwrSubmission {
     pub inputs: serde_json::Value,
     pub request_id: Option<u32>,
     pub retry_count: u32,
+    pub last_failed_uid: Option<u16>,
 }
 
 const DSPERSE_SEMAPHORE_CAPACITY: usize = 64;
@@ -465,6 +466,7 @@ impl RelayManager {
             inputs,
             request_id: req_id_opt,
             retry_count: 0,
+            last_failed_uid: None,
         };
 
         if let Err(e) = rwr_tx.try_send(submission) {

--- a/crates/sn2-validator/src/stats_reporter.rs
+++ b/crates/sn2-validator/src/stats_reporter.rs
@@ -272,6 +272,7 @@ impl StatsReporter {
                 let direction = match e.direction {
                     CapDirection::Ramp => "ramp",
                     CapDirection::Backoff => "backoff",
+                    CapDirection::PressureTrim => "pressure_trim",
                     CapDirection::Evict => "evict",
                     CapDirection::Rehab => "rehab",
                 };

--- a/crates/sn2-validator/src/validator_loop/dispatch.rs
+++ b/crates/sn2-validator/src/validator_loop/dispatch.rs
@@ -91,6 +91,10 @@ impl ValidatorLoop {
         self.refresh_dispatch_cache_if_stale(&queryable_uids).await;
         let adaptive_timeout = self.dispatch_cache.adaptive_timeout;
 
+        // With a single dispatchable miner there is nowhere else to route a
+        // retry, so the avoidance below would starve the request instead.
+        let avoid_last_failed = queryable_uids.len() > 1;
+
         for uid in queryable_uids {
             if dispatch_budget == 0 {
                 break;
@@ -111,7 +115,7 @@ impl ValidatorLoop {
                 let active = self.miner_active_count.get(&uid).copied().unwrap_or(0);
                 let was_at_capacity = active + 1 >= cap;
 
-                let mut dispatched = match self.select_request(uid).await {
+                let mut dispatched = match self.select_request(uid, avoid_last_failed).await {
                     Some(d) => d,
                     None => break,
                 };
@@ -197,7 +201,20 @@ impl ValidatorLoop {
         self.dispatch_cache.api_eligible = self.compute_api_eligible_from_uids(queryable_uids);
         self.dispatch_cache.authenticated = {
             let guard = self.miner_client.read().await;
-            guard.authenticated_hotkeys().await
+            let mut authenticated = guard.authenticated_hotkeys().await;
+            if let Ok(stats) = guard.connection_stats().await {
+                // Axon IPs are IPv4-only per is_valid_ip, so plain ip:port
+                // matches the transport's address key format.
+                let addr_of: HashMap<&str, String> = self
+                    .config
+                    .metagraph
+                    .neurons
+                    .iter()
+                    .map(|n| (n.hotkey.as_str(), format!("{}:{}", n.axon_ip, n.axon_port)))
+                    .collect();
+                retain_live_hotkeys(&mut authenticated, &stats, &addr_of);
+            }
+            authenticated
         };
         self.dispatch_cache.refreshed_at = Some(Instant::now());
     }
@@ -227,8 +244,19 @@ impl ValidatorLoop {
             .collect()
     }
 
-    async fn select_request(&mut self, uid: u16) -> Option<DispatchedRequest> {
+    async fn select_request(
+        &mut self,
+        uid: u16,
+        avoid_last_failed: bool,
+    ) -> Option<DispatchedRequest> {
         if let Some(rwr) = self.rwr_queue.pop_front() {
+            // A retry goes to any miner but the one that just failed it, so a
+            // request rescheduled off a dead or broken peer cannot burn its
+            // whole retry budget there before another miner sees it.
+            if avoid_last_failed && rwr.last_failed_uid == Some(uid) {
+                self.rwr_queue.push_back(rwr);
+                return None;
+            }
             let circuit = match self.circuit_store.ensure_circuit(&rwr.circuit_id).await {
                 Ok(c) => c,
                 Err(e) => {
@@ -296,6 +324,13 @@ impl ValidatorLoop {
                     .map(|d| (d, RunSource::Benchmark))
             })
         {
+            if avoid_last_failed && dslice.last_failed_uid == Some(uid) {
+                match queue_source {
+                    RunSource::Api => self.api_dslice_queue.push_back(dslice),
+                    RunSource::Benchmark => self.stacked_dslice_queue.push_back(dslice),
+                }
+                return None;
+            }
             let inputs_json = match sn2_types::decode_msgpack_to_json(&dslice.inputs) {
                 Ok(v) => v,
                 Err(e) => {
@@ -508,5 +543,78 @@ impl ValidatorLoop {
                 is_valid_ip(&n.axon_ip)
             })
             .collect()
+    }
+}
+
+/// Drops hotkeys whose transport connection is already closed from the
+/// reachable set. The authenticated set reflects registry bindings, which
+/// outlive a dead connection until the next registry prune (up to a minute);
+/// during that window a restarted miner would otherwise stay in dispatch
+/// rotation and every request routed to it would fail inside the transport,
+/// debiting the miner and burning retries. Permissive on absent stats
+/// entries so a transient miss can never stall dispatch.
+fn retain_live_hotkeys(
+    authenticated: &mut HashSet<String>,
+    stats: &HashMap<String, String>,
+    addr_of: &HashMap<&str, String>,
+) {
+    authenticated.retain(|hk| {
+        let addr = match addr_of.get(hk.as_str()) {
+            Some(a) => a,
+            None => return true,
+        };
+        match stats.get(&format!("connection_{addr}")) {
+            Some(status) => status == "active",
+            None => true,
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::retain_live_hotkeys;
+    use std::collections::{HashMap, HashSet};
+
+    fn setup() -> (HashSet<String>, HashMap<&'static str, String>) {
+        let authenticated: HashSet<String> = ["hk_live", "hk_dead", "hk_unknown"]
+            .map(String::from)
+            .into();
+        let addr_of: HashMap<&str, String> = [
+            ("hk_live", "1.1.1.1:8000".to_string()),
+            ("hk_dead", "2.2.2.2:8000".to_string()),
+            ("hk_unknown", "3.3.3.3:8000".to_string()),
+        ]
+        .into_iter()
+        .collect();
+        (authenticated, addr_of)
+    }
+
+    #[test]
+    fn closed_connections_are_dropped_and_active_kept() {
+        let (mut authenticated, addr_of) = setup();
+        let stats: HashMap<String, String> = [
+            ("connection_1.1.1.1:8000", "active"),
+            (
+                "connection_2.2.2.2:8000",
+                "closed(ApplicationClosed { .. })",
+            ),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+        retain_live_hotkeys(&mut authenticated, &stats, &addr_of);
+        assert!(authenticated.contains("hk_live"));
+        assert!(!authenticated.contains("hk_dead"));
+        // No stats entry for this address: keep, never stall dispatch.
+        assert!(authenticated.contains("hk_unknown"));
+    }
+
+    #[test]
+    fn hotkey_without_metagraph_addr_is_kept() {
+        let (mut authenticated, _) = setup();
+        let addr_of: HashMap<&str, String> = HashMap::new();
+        let stats: HashMap<String, String> = HashMap::new();
+        retain_live_hotkeys(&mut authenticated, &stats, &addr_of);
+        assert_eq!(authenticated.len(), 3);
     }
 }

--- a/crates/sn2-validator/src/validator_loop/dispatch.rs
+++ b/crates/sn2-validator/src/validator_loop/dispatch.rs
@@ -91,9 +91,27 @@ impl ValidatorLoop {
         self.refresh_dispatch_cache_if_stale(&queryable_uids).await;
         let adaptive_timeout = self.dispatch_cache.adaptive_timeout;
 
-        // With a single dispatchable miner there is nowhere else to route a
-        // retry, so the avoidance below would starve the request instead.
-        let avoid_last_failed = queryable_uids.len() > 1;
+        // A retry is only steered away from the miner that failed it while
+        // some other miner can actually take work this round. Registry
+        // eligibility alone is too broad a guard: with every alternative at
+        // capacity, deferring the retry buys nothing but latency, since the
+        // failed miner is the only one with a free slot. The avoidance
+        // check fires inside the failed miner's own slot loop, so requiring
+        // more than one uid with free capacity guarantees an alternative.
+        let uids_with_free_slots = queryable_uids
+            .iter()
+            .filter(|uid| {
+                let cap = self
+                    .dispatch_cache
+                    .capacities
+                    .get(uid)
+                    .copied()
+                    .unwrap_or(1);
+                let active = self.miner_active_count.get(uid).copied().unwrap_or(0);
+                active < cap
+            })
+            .count();
+        let avoid_last_failed = uids_with_free_slots > 1;
 
         for uid in queryable_uids {
             if dispatch_budget == 0 {

--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -886,6 +886,7 @@ impl ValidatorLoop {
                     task_id: None,
                     run_source: plan.run_source,
                     retry_count: 0,
+                    last_failed_uid: None,
                     circuit_path: plan.circuit_path.clone(),
                     component_sha: plan.component_sha.clone(),
                 }])
@@ -1354,6 +1355,7 @@ impl ValidatorLoop {
             task_id: None,
             run_source,
             retry_count: 0,
+            last_failed_uid: None,
             circuit_path: circuit_path.map(String::from),
             component_sha: component_sha.map(String::from),
         }

--- a/crates/sn2-validator/src/validator_loop/results.rs
+++ b/crates/sn2-validator/src/validator_loop/results.rs
@@ -95,10 +95,16 @@ impl ValidatorLoop {
         }
     }
 
-    pub(super) fn attempt_retry(&mut self, retry_payload: RetryPayload, next_retry: u32) -> bool {
+    pub(super) fn attempt_retry(
+        &mut self,
+        retry_payload: RetryPayload,
+        next_retry: u32,
+        failed_uid: u16,
+    ) -> bool {
         match retry_payload {
             RetryPayload::Rwr(mut rwr) => {
                 rwr.retry_count = next_retry;
+                rwr.last_failed_uid = Some(failed_uid);
                 self.rwr_queue.push_back(rwr);
                 self.dispatch_notify.notify_one();
                 true
@@ -106,6 +112,7 @@ impl ValidatorLoop {
             RetryPayload::DSlice(mut dslice) => {
                 if self.run_manager.has_run(&dslice.run_uid) {
                     dslice.retry_count = next_retry;
+                    dslice.last_failed_uid = Some(failed_uid);
                     match dslice.run_source {
                         RunSource::Api => self.api_dslice_queue.push_back(*dslice),
                         RunSource::Benchmark => self.stacked_dslice_queue.push_back(*dslice),
@@ -430,7 +437,7 @@ impl ValidatorLoop {
 
         if !is_verification_failure
             && next_retry <= max_retries
-            && self.attempt_retry(retry_payload, next_retry)
+            && self.attempt_retry(retry_payload, next_retry, uid)
         {
             return;
         }


### PR DESCRIPTION
Follow-up to #585/#588/#589 closing the restart-window gaps that remain now that failure classification is out of the scoring path, plus two validator-restart hardenings and one telemetry distinction. All four are dispatch- or persistence-side only; scoring semantics are untouched.

**Dispatch reachability now consults connection liveness.** #589 relies on the authenticated-route check to keep unreachable peers out of rotation, but the authenticated set reflects registry bindings, which outlive a dead connection until the next registry prune — up to a minute after a miner restart. During that window every dispatch to the restarted miner fails inside the transport at millisecond latency, and with knee-targeted caps now in the hundreds, one routine restart generates hundreds of debits and wasted dispatch slots before the prune catches up. The transport already reports per-address connection status, so the dispatch cache refresh drops hotkeys whose connection is closed from the reachable set, permissively on absent entries so a stats miss can never stall dispatch. This narrows the churn window from the prune cadence to the cache TTL without inspecting failure reasons — the reachability gate simply stops asserting a route that is already known dead.

**Retries avoid the uid that just failed them.** Retries are not miner-affine: a request rescheduled off a dead or broken peer goes to the back of the queue and can be handed straight back to the same peer, whose cap slots are exactly the ones free because everything it touches fails fast. A slice can burn its full retry budget against one dead miner and be marked failed during a routine restart, degrading the run. Each retry now records the uid that failed it and dispatch skips only that one pairing, with the avoidance disabled when a single miner is dispatchable so it can never starve a request.

**Validator restarts no longer reset the fleet's capacity state.** The restored-cap clamp of 32 predates knee targeting: persisted caps are now measured equilibria, and clamping a fleet whose knees sit in the hundreds forces tens of minutes of re-ramping at the step cadence after every validator update, with the delivered-work dip that implies. The clamp rises to 512, bounding only corrupt or ancient snapshots. Independently, completion bins are in-memory, so for the first rate window after a restart the delivered-rate estimate reads near zero and the controller would trim a restored equilibrium cap toward a meaningless target before its first real measurement; downward steps now hold until the miner's bins span a full window. Upward steps are unaffected.

**Memory-pressure trims are now attributable in telemetry.** Pressure trims emitted the same backoff direction as controller demand-tracking, making them indistinguishable in capacity event streams — relevant now that #583/#584 removed the main pressure sources and the open question is whether the trim still fires in production. They emit a distinct `pressure_trim` direction; the addition is a new enum string in the event payload, existing values are unchanged.

Unit coverage: liveness filtering (closed dropped, active kept, absent entries and unmapped hotkeys permissively retained), restored caps preserving measured values while clamping outliers, and a restored cap holding through the warmup window then tracking demand once the estimate is warm. Full suite, clippy, and rustfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retry routing can now steer away from the miner (or dslice) that most recently failed when other miners have free capacity.
  * Dispatch/cache refresh uses live transport connection status to retain only active hotkeys.
  * Added miner connection status reporting for use during dispatch selection.

* **Bug Fixes**
  * Restored adaptive-cap behavior is improved: pressure trims and backoff actions are better distinguished, with longer restore limits and protection through rate warm-up.

* **Tests**
  * Added scenarios covering restored-cap stability across restart/warm-up and hotkey retention based on connection status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->