### PR TITLE
Introduce one-epoch skiplist for miners the validator cannot reach

### DIFF
--- a/crates/sn2-types/src/constants.rs
+++ b/crates/sn2-types/src/constants.rs
@@ -32,6 +32,13 @@ pub const MAX_CONCURRENT_BENCHMARK_RUNS: usize = 8;
 pub const EXTRA_RUN_MIN_AVAIL_MEM_RATIO: f64 = 0.35;
 pub const DSLICE_QUEUE_LOW_WATERMARK_MAX: usize = 4096;
 
+/// Tempos a hotkey is skiplisted when the validator finds it not connected.
+/// A miner that cannot be reached delivers no proof, and the validator does
+/// not inspect why the connection is gone: an honest restart and a deliberate
+/// disconnect are scored identically, ignored and weighted zero for one epoch,
+/// then retried. One tempo is a Bittensor epoch.
+pub const DISCONNECT_SKIPLIST_TEMPOS: u64 = 1;
+
 pub const VERIFICATION_SAMPLES_PER_TEMPO: u64 = 20;
 pub const VERIFICATION_STRIKES_REQUIRED: u32 = 1;
 pub const VERIFICATION_STRIKES_WINDOW_BLOCKS: u64 = 7200;

--- a/crates/sn2-validator/src/rsv.rs
+++ b/crates/sn2-validator/src/rsv.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use rand::Rng;
 use sn2_types::{
-    RSV_EXPECTED_SUBS_PER_TEMPO, VERIFICATION_COLDSTART_BLOCKS,
+    DISCONNECT_SKIPLIST_TEMPOS, RSV_EXPECTED_SUBS_PER_TEMPO, VERIFICATION_COLDSTART_BLOCKS,
     VERIFICATION_COLDSTART_RETENTION_BLOCKS, VERIFICATION_HISTORY_CAP,
     VERIFICATION_SAMPLES_PER_TEMPO, VERIFICATION_SKIPLIST_TEMPOS, VERIFICATION_STRIKES_REQUIRED,
     VERIFICATION_STRIKES_WINDOW_BLOCKS,
@@ -62,6 +62,24 @@ impl RsvManager {
         let mut rng = rand::rng();
         let roll: u64 = rng.random_range(0..RSV_EXPECTED_SUBS_PER_TEMPO);
         roll < VERIFICATION_SAMPLES_PER_TEMPO
+    }
+
+    pub fn skiplist_disconnect(&mut self, hotkey: &str, current_block: u64, blocks_per_tempo: u64) {
+        let bpt = if blocks_per_tempo == 0 {
+            360
+        } else {
+            blocks_per_tempo
+        };
+        let until = current_block + DISCONNECT_SKIPLIST_TEMPOS * bpt;
+        let entry = self.skiplist.entry(hotkey.to_string()).or_insert(0);
+        if until > *entry {
+            *entry = until;
+            warn!(
+                hotkey = %hotkey,
+                until_block = until,
+                "rsv: miner not connected, skiplisted for one epoch"
+            );
+        }
     }
 
     pub fn record_strike(
@@ -310,6 +328,30 @@ mod tests {
         mgr.observe("hk1", 2000);
         assert_eq!(mgr.coldstart.get("hk1").copied(), Some(1000));
         assert_eq!(mgr.last_seen.get("hk1").copied(), Some(2000));
+    }
+
+    #[test]
+    fn disconnect_skiplists_for_one_epoch_then_expires() {
+        let mut mgr = fresh();
+        let bpt = 360;
+        mgr.skiplist_disconnect("hk1", 1000, bpt);
+        assert!(mgr.is_skiplisted("hk1", 1000));
+        assert!(mgr.is_skiplisted("hk1", 1000 + bpt - 1));
+        assert!(!mgr.is_skiplisted("hk1", 1000 + bpt));
+    }
+
+    #[test]
+    fn disconnect_never_shortens_a_longer_skiplist() {
+        let mut mgr = fresh();
+        // A verification skiplist runs many tempos; a later disconnect must not
+        // cut it short.
+        mgr.record_strike("hk1", 100, 360);
+        assert!(mgr.is_skiplisted("hk1", 100 + 360));
+        mgr.skiplist_disconnect("hk1", 200, 360);
+        assert!(
+            mgr.is_skiplisted("hk1", 100 + 360),
+            "disconnect must not shorten the longer verification skiplist"
+        );
     }
 
     #[test]

--- a/crates/sn2-validator/src/validator_loop/dispatch.rs
+++ b/crates/sn2-validator/src/validator_loop/dispatch.rs
@@ -66,6 +66,9 @@ impl ValidatorLoop {
                         return false;
                     }
                 }
+                if self.rsv.is_skiplisted(&n.hotkey, current_block) {
+                    return false;
+                }
                 if !self.hotkey_reachable(&n.hotkey) {
                     return false;
                 }

--- a/crates/sn2-validator/src/validator_loop/results.rs
+++ b/crates/sn2-validator/src/validator_loop/results.rs
@@ -386,14 +386,21 @@ impl ValidatorLoop {
             }
         }
 
-        // A non-delivery is a non-delivery. The validator never models why a
-        // valid proof failed to arrive: a dead connection, a refused stream, a
-        // timeout, and a bad witness are the same absence of service and debit
-        // the failed work identically. There is no failure taxonomy, no hold,
-        // and no exempt class to shape traffic into, so a miner cannot lower
-        // its debit exposure by choosing how a request fails. Honest restarts
-        // are absorbed by recency decay of delivered work, not by inspecting
-        // the failure.
+        // A miner the validator cannot reach delivered no proof, and the reason
+        // it is unreachable is exactly what a miner would lie about, so the
+        // validator does not ask. Any connection-level failure skiplists the
+        // hotkey for one epoch: ignored and weighted zero, then retried. This
+        // is the punishing counterpart to a debit, not an exemption, so a miner
+        // that drops its connection to shed load is scored worse, never better.
+        if is_disconnect_failure(reason) && !hotkey.is_empty() {
+            self.rsv
+                .skiplist_disconnect(hotkey, self.current_block, self.blocks_per_tempo);
+        }
+
+        // Every non-delivery also debits the failed work. Reaching the miner and
+        // getting a bad or absent proof is priced the same as any other failure;
+        // classification here only adds the epoch skiplist above for the not
+        // connected case, and never removes a debit.
         let failed_circuit_id = match &retry_payload {
             RetryPayload::DSlice(d) => Some(d.circuit.id.as_str()),
             RetryPayload::Rwr(r) => Some(r.circuit_id.as_str()),
@@ -454,6 +461,57 @@ impl ValidatorLoop {
                 }),
             )
             .await;
+        }
+    }
+}
+
+/// Whether a query failure means the validator could not reach the miner: the
+/// connection could not be established, maintained, or opened, or the handshake
+/// found no route. These surface under the "QUIC query" context as `connection`
+/// or `handshake` errors. A query timeout and a handler error both mean the
+/// miner was reached and answered, so they are not disconnects; they debit but
+/// do not skiplist. The validator's own uninitialized endpoint is excluded so a
+/// validator-side startup hiccup cannot skiplist the whole fleet at once.
+fn is_disconnect_failure(reason: &str) -> bool {
+    if reason.contains("QUIC endpoint not initialized") {
+        return false;
+    }
+    reason.starts_with("QUIC query: connection error:")
+        || reason.starts_with("QUIC query: handshake error:")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_disconnect_failure;
+
+    #[test]
+    fn unreachable_miner_failures_are_disconnects() {
+        for msg in [
+            "QUIC query: connection error: Reconnection attempts exhausted for 1.2.3.4:8080 (5/5), awaiting registry refresh",
+            "QUIC query: connection error: Reconnection to 1.2.3.4:8080 in backoff, next retry in 900ms",
+            "QUIC query: connection error: Failed to open stream: connection lost",
+            "QUIC query: handshake error: no authenticated route for hk1 at 1.2.3.4:8080",
+        ] {
+            assert!(is_disconnect_failure(msg), "must be a disconnect: {msg}");
+        }
+    }
+
+    #[test]
+    fn reached_miner_failures_are_not_disconnects() {
+        // The miner answered (handler error, spoof attempt) or was reached and
+        // ran out of time (timeout); none of these are a lost connection, and a
+        // validator-side endpoint fault must never skiplist a miner.
+        for msg in [
+            "handler error: request processing failed",
+            "QUIC query: transport error: query timed out",
+            "verification failed",
+            "QUIC query: connection error: QUIC endpoint not initialized",
+            "handler error: QUIC query: connection error: Reconnection to 1.2.3.4:8080 in backoff",
+        ] {
+            assert!(
+                !is_disconnect_failure(msg),
+                "must not be a disconnect: {msg}"
+            );
         }
     }
 }


### PR DESCRIPTION
The validator cannot verify why a miner is unreachable, and a miner has every incentive to misrepresent it, so the validator stops trying to tell an honest restart from a deliberate disconnect. Any connection-level failure, a connection that cannot be established, maintained, or opened, or a handshake with no route, now skiplists that hotkey for one epoch: it is dropped from dispatch and weighted zero for the epoch, then retried. A miner that is reachable and answers, even with a bad or absent proof, is not a disconnect; it debits the failed work as before but is not skiplisted, so ordinary proof failures and slow responses are unaffected.

This is the punishing counterpart to a debit rather than an exemption. Earlier work treated a lost connection as something to forgive so an honest restart kept its weight; that is precisely the escape a miner would exploit by dropping its connection to shed load. Under this change dropping the connection is scored strictly worse, never better, so there is nothing to game: the only way to avoid the epoch of zero is to stay reachable.

Dispatch now also skips any skiplisted hotkey rather than only zeroing its weight, so a skiplisted miner is genuinely ignored for the epoch and its slots are freed for reachable miners. The skiplist takes the longer of any existing entry, so a multi-epoch verification skiplist is never shortened by a later disconnect. The validator's own uninitialized-endpoint error is excluded so a validator-side startup fault cannot skiplist the fleet. Coverage: connection and handshake failures classify as disconnects while timeouts, handler errors, spoof attempts and the endpoint fault do not; the skiplist spans exactly one epoch and expires; and a disconnect never shortens a longer skiplist.

Known follow-up: a validator-side network event that drops many connections at once would skiplist each affected miner independently. The disable-list path already suppresses action on run-wide failures for this reason; an equivalent mass-disconnect guard on this path is a sensible addition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Validators now apply a temporary skiplist to nodes that disconnect during request handling, reducing repeated retries against unstable endpoints.
  * Skiplisted nodes are excluded from dispatch selection until the skiplist expires.

* **Bug Fixes**
  * Disconnect-related failures now receive different handling from other failures, helping preserve normal retry behavior for non-disconnect issues.
  * Existing longer skiplist periods are no longer shortened by a new disconnect event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->