### PR TITLE
Resolve fleet-wide cap ramp stall from headroom below the service-time spread

### DIFF
--- a/crates/sn2-types/src/constants.rs
+++ b/crates/sn2-types/src/constants.rs
@@ -56,10 +56,20 @@ pub const CAPACITY_RATE_WINDOW_BINS: usize = 6;
 pub const CAPACITY_RATE_FILTER_BINS: usize = 40;
 pub const CAPACITY_STEP_FRACTION: f64 = 0.10;
 /// Multiple of the knee in-flight depth (delivered rate x uncongested
-/// service time) the cap targets. Above 1.0 so the miner always has queued
-/// work to start the moment a unit completes; the excess is bounded so
-/// measured latencies stay near the uncongested floor.
-pub const CAPACITY_TARGET_HEADROOM: f64 = 1.5;
+/// service time) the cap targets.
+///
+/// This must exceed the workload's typical-to-minimum service time spread,
+/// not merely 1.0. The knee estimator uses per-unit own-best latencies so
+/// congestion cannot inflate it, but that makes it a minimum: below the
+/// knee the delivered rate is cap / typical_service, so the target is
+/// headroom x (min_service / typical_service) x cap, and the self-raising
+/// ramp stalls at any cap unless headroom x min_service > typical_service.
+/// Network jitter and host load routinely put the fastest completion at a
+/// third of the typical one, which froze fleet-wide caps at 1.5. Overshoot
+/// past the knee stays bounded at headroom x knee because own-best cannot
+/// rise under congestion, so a larger headroom costs bounded queueing
+/// latency rather than reintroducing unbounded ramp.
+pub const CAPACITY_TARGET_HEADROOM: f64 = 3.0;
 /// Fractional band above the target inside which the cap holds. Without it
 /// the cap flaps one step up and down around the target every adjustment
 /// interval, spamming capacity events at equilibrium.

--- a/crates/sn2-validator/src/performance.rs
+++ b/crates/sn2-validator/src/performance.rs
@@ -1472,9 +1472,17 @@ mod tests {
             cap >= 40,
             "cap {cap} must escape the spread stall and sustain the knee depth of 40"
         );
+        // Upper bound derived from the invariant under test: the target is
+        // headroom x own-best depth (16 x 1.0s at the 16/s knee rate), and
+        // the cap may legitimately sit anywhere inside the deadband hold
+        // region above it.
+        let own_best_depth = (40.0 / 2.5) * 1.0;
+        let headroom_bound =
+            (own_best_depth * CAPACITY_TARGET_HEADROOM * (1.0 + CAPACITY_TARGET_DEADBAND)).ceil()
+                as usize;
         assert!(
-            cap <= 75,
-            "cap {cap} must stay bounded by headroom x own-best depth"
+            cap <= headroom_bound,
+            "cap {cap} must stay bounded by the headroom target's hold band ({headroom_bound})"
         );
     }
 

--- a/crates/sn2-validator/src/performance.rs
+++ b/crates/sn2-validator/src/performance.rs
@@ -815,9 +815,12 @@ impl PerformanceTracker {
         // knee the delivered rate rises with the cap, so the target is
         // self-raising and doubles as the probe out of a cap-limited
         // measurement; at the knee the rate plateaus while own-best latencies
-        // hold, so the target pins. The latency-budget term keeps a queueing
-        // floor for sub-budget service times, where a depth of rate x budget
-        // costs no measurable latency.
+        // hold, so the target pins. Self-raising holds only while the
+        // headroom exceeds the workload's typical-to-minimum service spread
+        // (see CAPACITY_TARGET_HEADROOM); the estimate here is a minimum by
+        // construction. The latency-budget term keeps a queueing floor for
+        // sub-budget service times, where a depth of rate x budget costs no
+        // measurable latency.
         let knee_depth = rate * uncongested;
         let target = (knee_depth * CAPACITY_TARGET_HEADROOM)
             .max(rate * CAPACITY_LATENCY_BUDGET_SECS)
@@ -826,7 +829,11 @@ impl PerformanceTracker {
         let current = self.adaptive_caps.entry(uid).or_insert(1);
         let cap_from = *current;
         let step = ((cap_from as f64 * CAPACITY_STEP_FRACTION).ceil() as usize).max(1);
-        let target_cap = target.round() as usize;
+        // Ceil, not round: when the self-raising ratio is modest (headroom
+        // barely above the service spread), rounding truncates the target
+        // back onto the current cap at small values and the ramp never
+        // leaves the floor.
+        let target_cap = target.ceil() as usize;
         let cap_to = if target_cap > cap_from {
             (cap_from + step).min(target_cap)
         } else if (cap_from as f64) > target * (1.0 + CAPACITY_TARGET_DEADBAND) {
@@ -1382,8 +1389,8 @@ mod tests {
         drive_queued_closed_loop(&mut tracker, 1, 0.5, 10, 1800, base);
         let cap = tracker.cap_snapshot().get(&1).copied().unwrap_or(0);
         assert!(
-            (12..=25).contains(&cap),
-            "cap {cap} must pin near the knee depth of 10, neither collapsing nor running away"
+            (24..=45).contains(&cap),
+            "cap {cap} must pin at headroom x knee depth of 10, neither collapsing nor running away"
         );
     }
 
@@ -1399,8 +1406,75 @@ mod tests {
         drive_queued_closed_loop(&mut tracker, 1, 5.0, 100, 3600, base);
         let cap = tracker.cap_snapshot().get(&1).copied().unwrap_or(0);
         assert!(
-            (120..=200).contains(&cap),
+            (240..=400).contains(&cap),
             "cap {cap} must sustain the knee depth of 100, not track the budget floor of 15"
+        );
+    }
+
+    /// Closed loop where per-unit latency varies around its mean while
+    /// throughput is set by the mean: completions cycle through a fast, a
+    /// typical, and a slow latency whose average is `mean_service` and whose
+    /// minimum is `min_service`. Own-best latches onto the fast completions,
+    /// so the knee estimate underestimates the sustaining depth by the
+    /// spread ratio — the regime where a too-small headroom stalls the ramp
+    /// at any cap.
+    #[allow(clippy::too_many_arguments)]
+    fn drive_spread_closed_loop(
+        tracker: &mut PerformanceTracker,
+        uid: u16,
+        min_service: f64,
+        mean_service: f64,
+        concurrency: usize,
+        secs: u64,
+        base: Instant,
+    ) -> Instant {
+        let mut now = base;
+        let mut carry = 0.0_f64;
+        let mut completions = 0u64;
+        let pattern = [min_service, mean_service, 2.0 * mean_service - min_service];
+        for s in 0..secs {
+            let cap = tracker
+                .cap_snapshot()
+                .get(&uid)
+                .copied()
+                .unwrap_or(1)
+                .max(1);
+            let in_flight = cap as f64;
+            let overcommit = (in_flight / concurrency as f64).max(1.0);
+            let deliver_f = in_flight.min(concurrency as f64) / mean_service + carry;
+            let deliverable = deliver_f as usize;
+            carry = deliver_f - deliverable as f64;
+            for i in 0..deliverable {
+                let observed = pattern[(completions % 3) as usize] * overcommit;
+                completions += 1;
+                now =
+                    base + Duration::from_millis(s * 1000 + (i as u64 * 1000 / deliverable as u64));
+                tracker.record_with_time(uid, "hk", true, observed, true, "A", now);
+            }
+        }
+        now
+    }
+
+    #[test]
+    fn latency_spread_does_not_stall_ramp() {
+        let mut tracker = test_tracker();
+        tracker.adaptive_caps.insert(1, 1);
+        let base = Instant::now();
+        // Fastest completion at 1s, typical at 2.5s: the knee estimate reads
+        // 0.4x the sustaining depth. Below the knee the target is then
+        // headroom x 0.4 x cap, so any headroom under 2.5 freezes the ramp
+        // at whatever cap it starts from — the fleet-wide stall observed on
+        // 14.12.10. Concurrency 40 at mean 2.5s puts the knee at 40 in
+        // flight; the cap must climb out and sustain it, bounded above.
+        drive_spread_closed_loop(&mut tracker, 1, 1.0, 2.5, 40, 2400, base);
+        let cap = tracker.cap_snapshot().get(&1).copied().unwrap_or(0);
+        assert!(
+            cap >= 40,
+            "cap {cap} must escape the spread stall and sustain the knee depth of 40"
+        );
+        assert!(
+            cap <= 75,
+            "cap {cap} must stay bounded by headroom x own-best depth"
         );
     }
 


### PR DESCRIPTION
Since 14.12.10 deployed, adaptive caps have been frozen fleet-wide in the tens — miners that previously held caps in the hundreds sit flat for days, with occasional unit-sized upticks and no ramp events. This is a stall in the knee-targeting controller from #586, and the failure is mine: the invariant it depends on was never stated, and the closed-loop tests were built in the one regime where it holds trivially.

The controller ramps only while `target > cap`, with `target = CAPACITY_TARGET_HEADROOM x rate x uncongested_service`. The uncongested estimate is a minimum by construction (per-unit own-best latencies, deliberately congestion-proof). Below the knee the delivered rate is `cap / typical_service`, so the target evaluates to `headroom x (min_service / typical_service) x cap`. That makes self-raising conditional: the ramp fires only while `headroom x min_service > typical_service`. With headroom at 1.5, any workload whose fastest completion runs below two thirds of its typical one — routine once network jitter and host load variance are in the response times — pins the target below the cap at every value. The rate is cap-bound, so it cannot grow; the cap is target-bound, so it cannot grow either. The only movement left is unit-sized creep when the max-filter rate estimator catches a delivery burst that ceils the target one above the cap, which matches the observed days-long crawl from single digits into the tens. The prior closed-loop tests drove constant per-unit latency, where min equals typical and the ratio is exactly one, so the stall was structurally invisible to them.

Two changes. Headroom rises to 3.0: self-raising is restored for spreads up to 3x, and the overshoot past the knee stays bounded at headroom x knee because own-best cannot rise under congestion — this is the property that separates a larger headroom from the unbounded pre-#586 ramp, whose utilization signal inflated with the queueing it caused. Bounded queueing depth is the price of tolerating spread, and the budget-floor term already covers the sub-second regime where network noise dominates. Second, the target now ceils rather than rounds: with a modest self-raising ratio, rounding truncates the target back onto the current cap at small values (a ratio of 1.2 rounds 1.2 to 1 and 2.4 to 2), so even workloads inside the tolerated spread could never leave the floor.

The constant's documentation now states the invariant explicitly, and a new spread-aware closed-loop driver cycles completions through a fast, a typical, and a slow latency whose mean sets the throughput — the regime the constant-latency drivers cannot express. The pinned regression: a 2.5x-spread workload starting from cap 1 must escape the stall and sustain its knee depth, bounded above by the own-best-derived ceiling. The existing knee-pinning, budget-floor, demand-tracking, and steady-state-silence tests pass with bounds updated to the new headroom.

Expected effect after deploy: fleet caps resume geometric ramp within minutes at the adjustment cadence, settle near headroom x knee per miner, and capacity event volume returns to ramp transients. If a workload with a spread beyond 3x surfaces, the durable fix is rate-plateau probing (raise the cap, keep it only if the delivered rate follows) rather than a larger constant; happy to follow up with that if telemetry shows residual stalls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased the system’s capacity headroom (target headroom raised) to better absorb load spikes and improve scaling smoothness.
* **Bug Fixes**
  * Improved adaptive capacity ramping so the cap derives more conservatively near the throughput knee and avoids ramp-floor truncation under small headroom.
  * Prevented adaptive cap “spread stalls” under mixed latency patterns, keeping ramp progression bounded.
* **Tests**
  * Updated existing assertions for the revised ramp/cap behavior.
  * Added coverage and a new helper for validating ramp progression under variable per-completion latency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->