### PR TITLE
break adaptive-cap allocation feedback loop

### DIFF
--- a/crates/sn2-types/src/constants.rs
+++ b/crates/sn2-types/src/constants.rs
@@ -68,6 +68,10 @@ pub const BUNDLE_CACHE_IDLE_TTL_SECS: u64 = 120;
 pub const CAPACITY_ADJUST_INTERVAL_SECS: u64 = 15;
 pub const CAPACITY_UNIT_REFERENCE_PERCENTILE: f64 = 0.1;
 pub const CAPACITY_RAMP_MIN_AVAIL_MEM_RATIO: f64 = 0.20;
+/// Memory availability at which validator-wide dispatch pressure begins to
+/// recover. The gap above the ramp-block threshold provides hysteresis so a
+/// host near the boundary does not alternate between throttling and recovery.
+pub const CAPACITY_PRESSURE_RECOVERY_MIN_AVAIL_MEM_RATIO: f64 = 0.25;
 pub const CAPACITY_PRESSURE_BACKOFF_FACTOR: f64 = 0.10;
 pub const IP_REGION_CAP_FRACTION: f64 = 0.25;
 

--- a/crates/sn2-validator/src/metrics_server.rs
+++ b/crates/sn2-validator/src/metrics_server.rs
@@ -27,6 +27,33 @@ pub fn set_active_tasks(count: usize) {
     gauge!("sn2_active_tasks").set(count as f64);
 }
 
+pub fn set_dispatch_pressure(scale: f64, memory_available_ratio: Option<f64>) {
+    gauge!("sn2_dispatch_pressure_scale").set(scale);
+    if let Some(ratio) = memory_available_ratio {
+        gauge!("sn2_host_memory_available_ratio").set(ratio);
+    }
+}
+
+pub fn record_dispatch_pressure_change(direction: &str) {
+    counter!(
+        "sn2_dispatch_pressure_changes_total",
+        "direction" => direction.to_string()
+    )
+    .increment(1);
+}
+
+pub fn record_dispatch_allocation(
+    fair_slots: usize,
+    residual_slots: usize,
+    starved_miners: usize,
+    utilization: f64,
+) {
+    counter!("sn2_dispatch_fair_slots_total").increment(fair_slots as u64);
+    counter!("sn2_dispatch_residual_slots_total").increment(residual_slots as u64);
+    counter!("sn2_dispatch_starved_miners_total").increment(starved_miners as u64);
+    histogram!("sn2_dispatch_slot_utilization_ratio").record(utilization.clamp(0.0, 1.0));
+}
+
 pub fn set_metagraph_n(n: u16) {
     gauge!("sn2_metagraph_n").set(n as f64);
 }

--- a/crates/sn2-validator/src/performance.rs
+++ b/crates/sn2-validator/src/performance.rs
@@ -1,16 +1,15 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use sn2_types::{
     ADAPTIVE_TIMEOUT_MIN_SAMPLES, ADAPTIVE_TIMEOUT_MULTIPLIER, ADAPTIVE_TIMEOUT_PERCENTILE,
     BLOCK_TIME_SECS, CAPACITY_ADJUST_INTERVAL_SECS, CAPACITY_LATENCY_BUDGET_SECS,
-    CAPACITY_RAMP_MIN_AVAIL_MEM_RATIO, CAPACITY_RATE_BIN_SECS, CAPACITY_RATE_FILTER_BINS,
-    CAPACITY_RATE_WINDOW_BINS, CAPACITY_STEP_FRACTION, CAPACITY_TARGET_DEADBAND,
-    CAPACITY_TARGET_HEADROOM, CAPACITY_UNIT_REFERENCE_PERCENTILE, CIRCUIT_TIMEOUT_SECONDS,
-    DELIVERED_WORK_BUCKET_SECS, DELIVERED_WORK_HALF_LIFE_SECS, FAILURE_DEBIT_MULTIPLIER,
-    PERFORMANCE_MIN_SAMPLES, PERFORMANCE_RESCHEDULE_PENALTY, PERFORMANCE_WINDOW_SIZE,
-    VERIFICATION_WINDOW_BLOCKS,
+    CAPACITY_RATE_BIN_SECS, CAPACITY_RATE_FILTER_BINS, CAPACITY_RATE_WINDOW_BINS,
+    CAPACITY_STEP_FRACTION, CAPACITY_TARGET_DEADBAND, CAPACITY_TARGET_HEADROOM,
+    CAPACITY_UNIT_REFERENCE_PERCENTILE, CIRCUIT_TIMEOUT_SECONDS, DELIVERED_WORK_BUCKET_SECS,
+    DELIVERED_WORK_HALF_LIFE_SECS, FAILURE_DEBIT_MULTIPLIER, PERFORMANCE_RESCHEDULE_PENALTY,
+    PERFORMANCE_WINDOW_SIZE, VERIFICATION_WINDOW_BLOCKS,
 };
 use tracing::warn;
 
@@ -40,12 +39,6 @@ fn parse_meminfo_avail_ratio(raw: &str) -> Option<f64> {
         (Some(t), Some(a)) if t > 0 => Some(a as f64 / t as f64),
         _ => None,
     }
-}
-
-pub(crate) fn cap_ramp_blocked_by_memory_pressure() -> bool {
-    host_memory_available_ratio()
-        .map(|r| r < CAPACITY_RAMP_MIN_AVAIL_MEM_RATIO)
-        .unwrap_or(false)
 }
 
 type WindowEntry = (Instant, bool, f64);
@@ -91,6 +84,7 @@ pub struct PerformanceTracker {
     delivered_work: HashMap<u16, VecDeque<(Instant, WorkBucket)>>,
     completion_bins: HashMap<u16, VecDeque<(Instant, u32)>>,
     cap_last_adjusted: HashMap<u16, Instant>,
+    capacity_growth_paused: bool,
     total_records: u64,
     persistence_path: Option<PathBuf>,
 }
@@ -203,6 +197,7 @@ impl PerformanceTracker {
             delivered_work: HashMap::new(),
             completion_bins: HashMap::new(),
             cap_last_adjusted: HashMap::new(),
+            capacity_growth_paused: false,
             total_records: 0,
             persistence_path: Some(path),
         };
@@ -310,19 +305,23 @@ impl PerformanceTracker {
         }
 
         if success {
-            let bins = self.completion_bins.entry(uid).or_default();
-            let bin_len = Duration::from_secs(CAPACITY_RATE_BIN_SECS);
-            match bins.back_mut() {
-                Some((start, count)) if now.duration_since(*start) < bin_len => *count += 1,
-                _ => bins.push_back((now, 1)),
-            }
-            while bins.len() > CAPACITY_RATE_FILTER_BINS {
-                bins.pop_front();
-            }
             self.at_cap_last_touched.insert(uid, now);
-            self.update_adaptive_cap(uid, hotkey, now);
+            // A successful completion measures delivered work regardless of
+            // validator demand, but only a dispatch that filled the miner's
+            // cap proves enough work was offered to learn from that rate.
+            if was_at_capacity {
+                let bins = self.completion_bins.entry(uid).or_default();
+                let bin_len = Duration::from_secs(CAPACITY_RATE_BIN_SECS);
+                match bins.back_mut() {
+                    Some((start, count)) if now.duration_since(*start) < bin_len => *count += 1,
+                    _ => bins.push_back((now, 1)),
+                }
+                while bins.len() > CAPACITY_RATE_FILTER_BINS {
+                    bins.pop_front();
+                }
+                self.update_adaptive_cap(uid, hotkey, now);
+            }
         }
-        let _ = was_at_capacity;
     }
 
     #[cfg(test)]
@@ -380,14 +379,12 @@ impl PerformanceTracker {
     pub fn miner_capacities(&self) -> HashMap<u16, usize> {
         self.windows
             .iter()
-            .map(|(&uid, w)| {
-                if w.len() < PERFORMANCE_MIN_SAMPLES {
-                    (uid, 1)
-                } else {
-                    (uid, self.adaptive_caps.get(&uid).copied().unwrap_or(1))
-                }
-            })
+            .map(|(&uid, _)| (uid, self.adaptive_caps.get(&uid).copied().unwrap_or(1)))
             .collect()
+    }
+
+    pub fn set_capacity_growth_paused(&mut self, paused: bool) {
+        self.capacity_growth_paused = paused;
     }
 
     pub fn evict_all_stale(&mut self) {
@@ -395,51 +392,6 @@ impl PerformanceTracker {
             evict_expired(w);
         }
         self.windows.retain(|_, w| !w.is_empty());
-    }
-
-    /// Globally trim every adaptive cap by `factor` (rounded to at least 1
-    /// decrement) when the validator host is under memory pressure. Returns
-    /// the number of caps that actually decreased, for monitoring.
-    pub fn backoff_all_caps_under_pressure(
-        &mut self,
-        factor: f64,
-        uid_hotkeys: &HashMap<u16, String>,
-    ) -> usize {
-        if !cap_ramp_blocked_by_memory_pressure() {
-            return 0;
-        }
-        let factor = factor.clamp(0.0, 1.0);
-        let mut changed = 0usize;
-        for (uid, cap) in self.adaptive_caps.iter_mut() {
-            if *cap <= 1 {
-                continue;
-            }
-            let decrement = ((*cap as f64) * factor).round() as usize;
-            let decrement = decrement.max(1);
-            let new_cap = cap.saturating_sub(decrement).max(1);
-            if new_cap < *cap {
-                let hotkey = uid_hotkeys.get(uid).cloned().unwrap_or_default();
-                self.cap_events.push(CapEvent {
-                    uid: *uid,
-                    hotkey,
-                    direction: CapDirection::Backoff,
-                    cap_from: *cap,
-                    cap_to: new_cap,
-                    success_rate: 0.0,
-                    at: Instant::now(),
-                });
-                *cap = new_cap;
-                if let Some(r) = self.at_cap_results.get_mut(uid) {
-                    r.clear();
-                }
-                changed += 1;
-            }
-        }
-        if self.cap_events.len() > MAX_BUFFERED_CAP_EVENTS {
-            let drop = self.cap_events.len() - MAX_BUFFERED_CAP_EVENTS;
-            self.cap_events.drain(0..drop);
-        }
-        changed
     }
 
     pub fn save(&self) {
@@ -607,13 +559,6 @@ impl PerformanceTracker {
                 let cap = self.adaptive_caps.get(&uid).copied().unwrap_or(1);
                 (uid, (work, cap, w.len()))
             })
-            .collect()
-    }
-
-    pub fn sample_counts(&self) -> HashMap<u16, usize> {
-        self.windows
-            .iter()
-            .map(|(&uid, w)| (uid, w.len()))
             .collect()
     }
 
@@ -803,9 +748,6 @@ impl PerformanceTracker {
         if !due {
             return;
         }
-        if cap_ramp_blocked_by_memory_pressure() {
-            return;
-        }
         self.cap_last_adjusted.insert(uid, now);
         let rate = self.delivered_rate_estimate(uid, now);
         let uncongested = self.uncongested_service_time(uid);
@@ -827,7 +769,7 @@ impl PerformanceTracker {
         let cap_from = *current;
         let step = ((cap_from as f64 * CAPACITY_STEP_FRACTION).ceil() as usize).max(1);
         let target_cap = target.round() as usize;
-        let cap_to = if target_cap > cap_from {
+        let cap_to = if target_cap > cap_from && !self.capacity_growth_paused {
             (cap_from + step).min(target_cap)
         } else if (cap_from as f64) > target * (1.0 + CAPACITY_TARGET_DEADBAND) {
             cap_from.saturating_sub(step).max(target_cap).max(1)
@@ -870,7 +812,11 @@ impl PerformanceTracker {
         std::mem::take(&mut self.pending_evictions)
     }
 
-    pub fn decay_idle_caps(&mut self, uid_hotkeys: &HashMap<u16, String>) -> usize {
+    pub fn decay_idle_caps(
+        &mut self,
+        uid_hotkeys: &HashMap<u16, String>,
+        queryable_uids: &HashSet<u16>,
+    ) -> usize {
         let now = Instant::now();
         let idle = Duration::from_secs(CAP_DECAY_IDLE_SECS);
         let mut decayed = 0usize;
@@ -878,6 +824,11 @@ impl PerformanceTracker {
             .adaptive_caps
             .iter()
             .filter(|(_, &cap)| cap > 0)
+            // A queryable miner may be idle only because the validator has no
+            // work to offer. Preserve its learned cap until there is actual
+            // saturated evidence; decay is reserved for miners that are no
+            // longer dispatchable.
+            .filter(|(uid, _)| !queryable_uids.contains(uid))
             .filter(|(uid, _)| {
                 self.at_cap_last_touched
                     .get(uid)
@@ -949,6 +900,7 @@ impl PerformanceTracker {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sn2_types::PERFORMANCE_MIN_SAMPLES;
 
     fn test_tracker() -> PerformanceTracker {
         PerformanceTracker {
@@ -967,6 +919,7 @@ mod tests {
             delivered_work: HashMap::new(),
             completion_bins: HashMap::new(),
             cap_last_adjusted: HashMap::new(),
+            capacity_growth_paused: false,
             total_records: 0,
             persistence_path: None,
         }
@@ -1065,6 +1018,16 @@ mod tests {
         tracker.record(1, "hk", true, 5.0, false);
         let caps = tracker.miner_capacities();
         assert_eq!(caps.get(&1).copied().unwrap_or(0), 1);
+    }
+
+    #[test]
+    fn miner_capacities_expose_learned_cap_before_scoring_sample_gate() {
+        let mut tracker = test_tracker();
+        tracker.adaptive_caps.insert(1, 7);
+        tracker.record(1, "hk", true, 5.0, false);
+
+        assert!(tracker.windows.get(&1).unwrap().len() < PERFORMANCE_MIN_SAMPLES);
+        assert_eq!(tracker.miner_capacities().get(&1).copied(), Some(7));
     }
 
     #[test]
@@ -1434,17 +1397,104 @@ mod tests {
     }
 
     #[test]
-    fn closed_loop_settles_at_demand_when_supply_limited() {
+    fn capacity_growth_pause_blocks_only_ramps_and_recovers() {
+        let base = Instant::now();
+
+        let mut ramping = test_tracker();
+        ramping.adaptive_caps.insert(1, 1);
+        ramping.set_capacity_growth_paused(true);
+        let mid = drive_rate(&mut ramping, 1, 40, 120, base);
+        assert_eq!(ramping.cap_snapshot().get(&1).copied(), Some(1));
+        assert!(ramping
+            .drain_cap_events()
+            .iter()
+            .all(|event| event.direction != CapDirection::Ramp));
+
+        ramping.set_capacity_growth_paused(false);
+        drive_rate(&mut ramping, 1, 40, 60, mid + Duration::from_secs(1));
+        assert!(ramping.cap_snapshot().get(&1).copied().unwrap_or(1) > 1);
+
+        let mut backing_off = test_tracker();
+        backing_off.adaptive_caps.insert(2, 64);
+        backing_off.set_capacity_growth_paused(true);
+        drive_rate(&mut backing_off, 2, 1, 120, base);
+        assert!(backing_off.cap_snapshot().get(&2).copied().unwrap_or(64) < 64);
+        assert!(backing_off
+            .drain_cap_events()
+            .iter()
+            .any(|event| event.direction == CapDirection::Backoff));
+    }
+
+    #[test]
+    fn supply_limited_successes_do_not_change_learned_caps() {
         let mut tracker = test_tracker();
         tracker.adaptive_caps.insert(1, 64);
+        tracker.adaptive_caps.insert(2, 1);
         let base = Instant::now();
-        drive_closed_loop(&mut tracker, 1, 0.05, 8, 900, base);
-        let cap = tracker.cap_snapshot().get(&1).copied().unwrap_or(0);
-        assert!(
-            cap < 32,
-            "supply-limited miner must not hold inflated cap: cap={cap}"
+        for second in 0..180u64 {
+            tracker.record_with_time(
+                1,
+                "low-demand",
+                true,
+                0.05,
+                false,
+                "A",
+                base + Duration::from_secs(second),
+            );
+            for completion in 0..40u64 {
+                let at = base + Duration::from_millis(second * 1000 + completion * 1000 / 40);
+                tracker.record_with_time(2, "high-rate-but-not-full", true, 0.05, false, "A", at);
+            }
+        }
+
+        let caps = tracker.cap_snapshot();
+        assert_eq!(
+            caps.get(&1).copied(),
+            Some(64),
+            "low validator demand must not back off a learned cap"
         );
-        assert!(cap >= 1, "cap never drops below floor");
+        assert_eq!(
+            caps.get(&2).copied(),
+            Some(1),
+            "unsaturated delivery rate must not ramp a learned cap"
+        );
+        assert!(tracker.miner_delivered_work(1) > 0.0);
+        assert!(tracker.miner_delivered_work(2) > 0.0);
+        assert!(tracker.drain_cap_events().is_empty());
+    }
+
+    #[test]
+    fn unsaturated_rates_do_not_contaminate_later_saturated_rate() {
+        let mut tracker = test_tracker();
+        let base = Instant::now();
+        for second in 0..60u64 {
+            tracker.record_with_time(
+                1,
+                "low-demand",
+                true,
+                0.05,
+                false,
+                "A",
+                base + Duration::from_secs(second),
+            );
+            for completion in 0..40u64 {
+                let at = base + Duration::from_millis(second * 1000 + completion * 1000 / 40);
+                tracker.record_with_time(2, "high-demand", true, 0.05, false, "A", at);
+            }
+        }
+
+        let saturated_at = base + Duration::from_secs(61);
+        assert_eq!(tracker.delivered_rate_estimate(1, saturated_at), 0.0);
+        assert_eq!(tracker.delivered_rate_estimate(2, saturated_at), 0.0);
+
+        tracker.record_with_time(1, "low-demand", true, 0.05, true, "A", saturated_at);
+        tracker.record_with_time(2, "high-demand", true, 0.05, true, "A", saturated_at);
+
+        assert_eq!(
+            tracker.delivered_rate_estimate(1, saturated_at),
+            tracker.delivered_rate_estimate(2, saturated_at),
+            "the later saturated rate must not inherit either unsaturated history"
+        );
     }
 
     #[test]
@@ -1583,15 +1633,27 @@ mod tests {
         let mut tracker = test_tracker();
         tracker.adaptive_caps.insert(3, 2);
         let hotkeys: HashMap<u16, String> = [(3u16, "hk".to_string())].into_iter().collect();
-        assert_eq!(tracker.decay_idle_caps(&hotkeys), 1);
+        assert_eq!(tracker.decay_idle_caps(&hotkeys, &HashSet::new()), 1);
         assert_eq!(tracker.adaptive_caps.get(&3).copied(), Some(1));
-        assert_eq!(tracker.decay_idle_caps(&hotkeys), 0);
+        assert_eq!(tracker.decay_idle_caps(&hotkeys, &HashSet::new()), 0);
         assert_eq!(tracker.adaptive_caps.get(&3).copied(), Some(1));
         assert!(tracker.drain_pending_evictions().is_empty());
         assert!(!tracker
             .drain_cap_events()
             .iter()
             .any(|e| matches!(e.direction, CapDirection::Evict)));
+    }
+
+    #[test]
+    fn idle_decay_preserves_queryable_supply_starved_miner() {
+        let mut tracker = test_tracker();
+        tracker.adaptive_caps.insert(3, 8);
+        let hotkeys: HashMap<u16, String> = [(3u16, "hk".to_string())].into_iter().collect();
+        let queryable = HashSet::from([3u16]);
+
+        assert_eq!(tracker.decay_idle_caps(&hotkeys, &queryable), 0);
+        assert_eq!(tracker.adaptive_caps.get(&3).copied(), Some(8));
+        assert!(tracker.drain_cap_events().is_empty());
     }
 
     #[test]

--- a/crates/sn2-validator/src/validator_loop/dispatch.rs
+++ b/crates/sn2-validator/src/validator_loop/dispatch.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
-use rand::seq::SliceRandom;
 use sn2_types::*;
 
 use super::verification::pre_decide_sample;
@@ -13,12 +12,95 @@ use crate::relay::FRAME_PROOF_RESULT;
 
 const DISPATCH_CACHE_TTL: Duration = Duration::from_millis(2000);
 
+#[derive(Default)]
+struct FairDispatchState {
+    /// Monotonic service order keyed by hotkey. A missing hotkey is older than
+    /// every miner that has already received work, which lets newly eligible
+    /// miners enter the rotation without resetting established miners.
+    last_served: HashMap<String, u64>,
+    last_served_at: HashMap<String, Instant>,
+    service_sequence: u64,
+}
+
+impl FairDispatchState {
+    fn select_next(&self, candidates: &[DispatchCandidate]) -> Option<usize> {
+        candidates
+            .iter()
+            .enumerate()
+            .filter(|(_, candidate)| {
+                candidate.available && candidate.projected_active < candidate.cap
+            })
+            .min_by(|(_, left), (_, right)| {
+                left.projected_active
+                    .cmp(&right.projected_active)
+                    .then_with(|| {
+                        self.last_served
+                            .get(&left.hotkey)
+                            .copied()
+                            .unwrap_or(0)
+                            .cmp(&self.last_served.get(&right.hotkey).copied().unwrap_or(0))
+                    })
+                    .then_with(|| left.hotkey.cmp(&right.hotkey))
+            })
+            .map(|(index, _)| index)
+    }
+
+    fn record_dispatch(&mut self, hotkey: &str) {
+        self.service_sequence = self.service_sequence.saturating_add(1);
+        self.last_served
+            .insert(hotkey.to_string(), self.service_sequence);
+        self.last_served_at
+            .insert(hotkey.to_string(), Instant::now());
+    }
+
+    fn prune(&mut self, metagraph_hotkeys: &HashSet<String>) {
+        self.last_served
+            .retain(|hotkey, _| metagraph_hotkeys.contains(hotkey));
+        self.last_served_at
+            .retain(|hotkey, _| metagraph_hotkeys.contains(hotkey));
+    }
+}
+
+struct DispatchCandidate {
+    uid: u16,
+    hotkey: String,
+    ip: String,
+    port: u16,
+    cap: usize,
+    initial_active: usize,
+    projected_active: usize,
+    dispatched: usize,
+    available: bool,
+}
+
+impl DispatchCandidate {
+    fn batch_reached_capacity(&self) -> bool {
+        self.dispatched > 0 && self.projected_active >= self.cap
+    }
+}
+
+fn effective_dispatch_ceiling(
+    configured: Option<usize>,
+    learned_capacity: usize,
+    pressure_scale: f64,
+) -> usize {
+    let configured = configured.unwrap_or(usize::MAX);
+    if learned_capacity == 0 || pressure_scale >= 1.0 {
+        return configured;
+    }
+
+    let pressure_ceiling =
+        ((learned_capacity as f64 * pressure_scale.clamp(0.0, 1.0)).floor() as usize).max(1);
+    configured.min(pressure_ceiling)
+}
+
 pub(crate) struct DispatchCache {
     pub capacities: HashMap<u16, usize>,
     pub adaptive_timeout: f64,
     pub api_eligible: HashSet<u16>,
     pub authenticated: HashSet<String>,
     pub refreshed_at: Option<Instant>,
+    fairness: FairDispatchState,
 }
 
 impl DispatchCache {
@@ -29,6 +111,7 @@ impl DispatchCache {
             api_eligible: HashSet::new(),
             authenticated: HashSet::new(),
             refreshed_at: None,
+            fairness: FairDispatchState::default(),
         }
     }
 }
@@ -43,11 +126,6 @@ impl ValidatorLoop {
         let active_count = self.tasks.len();
         let total_pipeline =
             active_count + self.verify_tasks.len() + self.pending_verifications.len();
-        let dispatch_ceiling = self.config.dispatch_ceiling.unwrap_or(usize::MAX);
-        if total_pipeline >= dispatch_ceiling {
-            return Ok(());
-        }
-        let mut dispatch_budget = dispatch_ceiling - total_pipeline;
 
         metrics::set_active_tasks(active_count);
 
@@ -55,7 +133,7 @@ impl ValidatorLoop {
         self.refill_dslice_queues();
 
         let current_block = self.current_block;
-        let mut queryable_uids: Vec<u16> = self
+        let queryable_miners: Vec<(u16, String, String, u16)> = self
             .config
             .metagraph
             .neurons
@@ -83,72 +161,201 @@ impl ValidatorLoop {
                 }
                 is_valid_ip(&n.axon_ip)
             })
-            .map(|n| n.uid)
+            .map(|n| (n.uid, n.hotkey.clone(), n.axon_ip.clone(), n.axon_port))
             .collect();
-        queryable_uids.shuffle(&mut rand::rng());
-        let sample_counts = self.performance_tracker.sample_counts();
-        queryable_uids.sort_by_key(|uid| {
-            sample_counts.get(uid).copied().unwrap_or(0) >= PERFORMANCE_MIN_SAMPLES
-        });
+
+        let queryable_uids: Vec<u16> = queryable_miners.iter().map(|(uid, _, _, _)| *uid).collect();
 
         self.refresh_dispatch_cache_if_stale(&queryable_uids).await;
         let adaptive_timeout = self.dispatch_cache.adaptive_timeout;
 
-        for uid in queryable_uids {
-            if dispatch_budget == 0 {
+        // Retain service history for temporarily unreachable/cooling-down
+        // miners, but discard hotkeys that have actually left the metagraph.
+        let metagraph_hotkeys: HashSet<String> = self
+            .config
+            .metagraph
+            .neurons
+            .iter()
+            .map(|neuron| neuron.hotkey.clone())
+            .collect();
+        self.dispatch_cache.fairness.prune(&metagraph_hotkeys);
+
+        let mut candidates: Vec<DispatchCandidate> = queryable_miners
+            .into_iter()
+            .map(|(uid, hotkey, ip, port)| {
+                let cap = self
+                    .dispatch_cache
+                    .capacities
+                    .get(&uid)
+                    .copied()
+                    .unwrap_or(1);
+                let active = self.miner_active_count.get(&uid).copied().unwrap_or(0);
+                DispatchCandidate {
+                    uid,
+                    hotkey,
+                    ip,
+                    port,
+                    cap,
+                    initial_active: active,
+                    projected_active: active,
+                    dispatched: 0,
+                    available: true,
+                }
+            })
+            .collect();
+
+        let learned_capacity = candidates.iter().fold(0usize, |total, candidate| {
+            total.saturating_add(candidate.cap)
+        });
+        let pressure_scale = self.dispatch_pressure.scale();
+        let dispatch_ceiling = effective_dispatch_ceiling(
+            self.config.dispatch_ceiling,
+            learned_capacity,
+            pressure_scale,
+        );
+        let queued_work =
+            self.rwr_queue.len() + self.api_dslice_queue.len() + self.stacked_dslice_queue.len();
+        if queued_work == 0 {
+            return Ok(());
+        }
+        let dispatchable_headroom = candidates.iter().fold(0usize, |total, candidate| {
+            total.saturating_add(candidate.cap.saturating_sub(candidate.projected_active))
+        });
+
+        if total_pipeline >= dispatch_ceiling {
+            return Ok(());
+        }
+        let mut dispatch_budget = dispatch_ceiling - total_pipeline;
+        let dispatch_opportunity = dispatch_budget.min(dispatchable_headroom).min(queued_work);
+        let should_record_allocation = dispatch_opportunity > 0;
+        let mut prepared_dispatches: Vec<(usize, DispatchedRequest)> = Vec::new();
+        let mut fair_slots = 0usize;
+        let mut residual_slots = 0usize;
+
+        while dispatch_budget > 0 {
+            if self.rwr_queue.is_empty()
+                && self.api_dslice_queue.is_empty()
+                && self.stacked_dslice_queue.is_empty()
+            {
                 break;
             }
-            let cap = self
-                .dispatch_cache
-                .capacities
-                .get(&uid)
-                .copied()
-                .unwrap_or(1);
-            let active_now = self.miner_active_count.get(&uid).copied().unwrap_or(0);
-            if active_now >= cap {
-                continue;
-            }
-            let slots_for_miner = (cap - active_now).min(dispatch_budget);
+            let Some(index) = self.dispatch_cache.fairness.select_next(&candidates) else {
+                break;
+            };
+            let uid = candidates[index].uid;
 
-            for _slot in 0..slots_for_miner {
-                let active = self.miner_active_count.get(&uid).copied().unwrap_or(0);
-                let was_at_capacity = active + 1 >= cap;
-
-                let mut dispatched = match self.select_request(uid).await {
-                    Some(d) => d,
-                    None => break,
-                };
-
-                let timeout = if self.dispatch_cache.api_eligible.contains(&uid) {
-                    API_TIMEOUT_SECONDS
-                } else {
-                    adaptive_timeout
-                };
-
-                let (ip, port, hotkey) = match self.config.metagraph.get_neuron(uid) {
-                    Some(n) => (n.axon_ip.clone(), n.axon_port, n.hotkey.clone()),
-                    None => break,
-                };
-
-                // Pre-decide the RSV sample before the miner task is spawned.
-                // Force-verify paths (PoW, customer RWR, external-hash, API
-                // dslice) bypass the roll; benchmark dslices take the random
-                // 4% sample. For non-sampled benchmark dispatches we drop
-                // task_inputs immediately so the validator's local input copy
-                // is not retained for the full request lifetime.
-                dispatched.pre_sampled = pre_decide_sample(
-                    &dispatched,
-                    &hotkey,
-                    self.current_block,
-                    self.blocks_per_tempo,
-                    &mut self.rsv,
-                );
-                if !dispatched.pre_sampled {
-                    dispatched.task_inputs = None;
+            let mut dispatched = match self.select_request(uid).await {
+                Some(dispatched) => dispatched,
+                None => {
+                    // A rejected/colliding queue item must not spin forever.
+                    // Other miners still get one opportunity to consume any
+                    // remaining valid work during this dispatch pass.
+                    candidates[index].available = false;
+                    continue;
                 }
+            };
 
-                self.spawn_miner_task(uid, ip, port, hotkey, was_at_capacity, timeout, dispatched);
-                dispatch_budget = dispatch_budget.saturating_sub(1);
+            let hotkey = candidates[index].hotkey.clone();
+
+            // Pre-decide the RSV sample before the miner task is prepared.
+            // Force-verify paths (PoW, customer RWR, external-hash, API
+            // dslice) bypass the roll; benchmark dslices take the random
+            // 4% sample. For non-sampled benchmark dispatches we drop
+            // task_inputs immediately so the validator's local input copy
+            // is not retained for the full request lifetime.
+            dispatched.pre_sampled = pre_decide_sample(
+                &dispatched,
+                &hotkey,
+                self.current_block,
+                self.blocks_per_tempo,
+                &mut self.rsv,
+            );
+            if !dispatched.pre_sampled {
+                dispatched.task_inputs = None;
+            }
+
+            let contenders = candidates
+                .iter()
+                .filter(|candidate| {
+                    candidate.available && candidate.projected_active < candidate.cap
+                })
+                .count();
+            if contenders > 1 {
+                fair_slots += 1;
+            } else {
+                residual_slots += 1;
+            }
+            candidates[index].projected_active += 1;
+            candidates[index].dispatched += 1;
+            self.dispatch_cache.fairness.record_dispatch(&hotkey);
+            prepared_dispatches.push((index, dispatched));
+            dispatch_budget -= 1;
+        }
+
+        // Saturation is a property of the completed allocation batch, not
+        // only of the final request that happened to fill a miner's cap. Mark
+        // every request in a batch that reaches the cap so completion-rate
+        // learning observes the whole offered load even when several task
+        // completions were drained before this dispatch call ran.
+        for (index, dispatched) in prepared_dispatches {
+            let candidate = &candidates[index];
+            let uid = candidate.uid;
+            let ip = candidate.ip.clone();
+            let port = candidate.port;
+            let hotkey = candidate.hotkey.clone();
+            let was_at_capacity = candidate.batch_reached_capacity();
+            let timeout = if self.dispatch_cache.api_eligible.contains(&uid) {
+                API_TIMEOUT_SECONDS
+            } else {
+                adaptive_timeout
+            };
+            self.spawn_miner_task(uid, ip, port, hotkey, was_at_capacity, timeout, dispatched);
+        }
+
+        if should_record_allocation {
+            let dispatched = candidates
+                .iter()
+                .map(|candidate| candidate.dispatched)
+                .sum::<usize>();
+            let starved_miners = if dispatch_budget == 0 {
+                candidates
+                    .iter()
+                    .filter(|candidate| {
+                        candidate.initial_active == 0
+                            && candidate.dispatched == 0
+                            && candidate.cap > 0
+                    })
+                    .count()
+            } else {
+                0
+            };
+            let utilization = dispatched as f64 / dispatch_opportunity as f64;
+            metrics::record_dispatch_allocation(
+                fair_slots,
+                residual_slots,
+                starved_miners,
+                utilization,
+            );
+
+            if tracing::enabled!(tracing::Level::DEBUG) {
+                for candidate in &candidates {
+                    let last_dispatch_age_secs = self
+                        .dispatch_cache
+                        .fairness
+                        .last_served_at
+                        .get(&candidate.hotkey)
+                        .map(|at| at.elapsed().as_secs_f64());
+                    tracing::debug!(
+                        uid = candidate.uid,
+                        learned_cap = candidate.cap,
+                        effective_cap = candidate.cap.min(dispatch_ceiling),
+                        active_depth = candidate.projected_active,
+                        dispatched = candidate.dispatched,
+                        last_dispatch_age_secs = ?last_dispatch_age_secs,
+                        pressure_scale,
+                        "fair dispatch allocation"
+                    );
+                }
             }
         }
 
@@ -511,5 +718,142 @@ impl ValidatorLoop {
                 is_valid_ip(&n.axon_ip)
             })
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candidate(hotkey: &str, cap: usize, projected_active: usize) -> DispatchCandidate {
+        DispatchCandidate {
+            uid: 0,
+            hotkey: hotkey.to_string(),
+            ip: String::new(),
+            port: 0,
+            cap,
+            initial_active: projected_active,
+            projected_active,
+            dispatched: 0,
+            available: true,
+        }
+    }
+
+    fn allocate(
+        state: &mut FairDispatchState,
+        candidates: &mut [DispatchCandidate],
+        budget: usize,
+    ) -> HashMap<String, usize> {
+        let mut allocations = HashMap::new();
+        for _ in 0..budget {
+            let Some(index) = state.select_next(candidates) else {
+                break;
+            };
+            candidates[index].projected_active += 1;
+            candidates[index].dispatched += 1;
+            let hotkey = candidates[index].hotkey.clone();
+            state.record_dispatch(&hotkey);
+            *allocations.entry(hotkey).or_insert(0) += 1;
+        }
+        allocations
+    }
+
+    #[test]
+    fn progressive_allocation_fills_small_caps_then_sends_residual_to_large_cap() {
+        let mut state = FairDispatchState::default();
+        let mut candidates = vec![
+            candidate("top", 300, 0),
+            candidate("new-eight", 8, 0),
+            candidate("new-nine", 9, 0),
+            candidate("cold", 1, 0),
+        ];
+
+        let allocations = allocate(&mut state, &mut candidates, 100);
+
+        assert_eq!(allocations.get("cold"), Some(&1));
+        assert_eq!(allocations.get("new-eight"), Some(&8));
+        assert_eq!(allocations.get("new-nine"), Some(&9));
+        assert_eq!(allocations.get("top"), Some(&82));
+    }
+
+    #[test]
+    fn persistent_service_order_rotates_when_budget_is_smaller_than_miner_count() {
+        let mut state = FairDispatchState::default();
+        let miners = ["a", "b", "c", "d"];
+
+        let mut first_pass: Vec<_> = miners
+            .iter()
+            .map(|hotkey| candidate(hotkey, 10, 0))
+            .collect();
+        let first = allocate(&mut state, &mut first_pass, 2);
+        assert_eq!(
+            first.keys().cloned().collect::<HashSet<_>>(),
+            HashSet::from(["a".to_string(), "b".to_string(),])
+        );
+
+        // Model both first-pass requests completing before the next dispatch
+        // call. The persistent sequence must favor the miners not yet served.
+        let mut second_pass: Vec<_> = miners
+            .iter()
+            .map(|hotkey| candidate(hotkey, 10, 0))
+            .collect();
+        let second = allocate(&mut state, &mut second_pass, 2);
+        assert_eq!(
+            second.keys().cloned().collect::<HashSet<_>>(),
+            HashSet::from(["c".to_string(), "d".to_string(),])
+        );
+    }
+
+    #[test]
+    fn projected_depth_precedes_service_age() {
+        let mut state = FairDispatchState::default();
+        state.record_dispatch("shallow");
+        let candidates = vec![
+            candidate("old-but-deep", 10, 5),
+            candidate("shallow", 10, 2),
+        ];
+
+        let selected = state.select_next(&candidates).unwrap();
+
+        assert_eq!(candidates[selected].hotkey, "shallow");
+    }
+
+    #[test]
+    fn service_history_is_only_pruned_for_removed_hotkeys() {
+        let mut state = FairDispatchState::default();
+        state.record_dispatch("still-registered");
+        state.record_dispatch("removed");
+
+        state.prune(&HashSet::from(["still-registered".to_string()]));
+
+        assert!(state.last_served.contains_key("still-registered"));
+        assert!(!state.last_served.contains_key("removed"));
+        assert!(state.last_served_at.contains_key("still-registered"));
+        assert!(!state.last_served_at.contains_key("removed"));
+    }
+
+    #[test]
+    fn every_request_in_a_full_refill_batch_is_saturated() {
+        let mut state = FairDispatchState::default();
+        let mut full = vec![candidate("full", 10, 5)];
+        let allocations = allocate(&mut state, &mut full, 5);
+        assert_eq!(allocations.get("full"), Some(&5));
+        assert!(full[0].batch_reached_capacity());
+
+        let mut partial = vec![candidate("partial", 10, 5)];
+        let allocations = allocate(&mut state, &mut partial, 4);
+        assert_eq!(allocations.get("partial"), Some(&4));
+        assert!(!partial[0].batch_reached_capacity());
+    }
+
+    #[test]
+    fn pressure_ceiling_is_additional_and_inactive_at_full_scale() {
+        assert_eq!(effective_dispatch_ceiling(None, 400, 1.0), usize::MAX);
+        assert_eq!(effective_dispatch_ceiling(None, 400, 0.9), 360);
+        assert_eq!(effective_dispatch_ceiling(Some(200), 400, 0.9), 200);
+        assert_eq!(effective_dispatch_ceiling(Some(500), 400, 0.9), 360);
+        assert_eq!(effective_dispatch_ceiling(Some(0), 400, 0.9), 0);
+        assert_eq!(effective_dispatch_ceiling(Some(500), 0, 0.9), 500);
+        assert_eq!(effective_dispatch_ceiling(None, 1, 0.01), 1);
     }
 }

--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -69,6 +69,24 @@ pub(crate) struct PlannedSliceWork {
 
 const PLAN_MATERIALIZE_BATCH: usize = 16;
 
+fn effective_staging_capacity(
+    learned_capacity: usize,
+    pressure_scale: f64,
+    configured_ceiling: Option<usize>,
+) -> usize {
+    if learned_capacity == 0 {
+        return 0;
+    }
+    let pressure_adjusted = if pressure_scale >= 1.0 {
+        learned_capacity
+    } else {
+        ((learned_capacity as f64 * pressure_scale.clamp(0.0, 1.0)).floor() as usize).max(1)
+    };
+    configured_ceiling
+        .map(|ceiling| pressure_adjusted.min(ceiling))
+        .unwrap_or(pressure_adjusted)
+}
+
 impl ValidatorLoop {
     pub(super) fn decode_submission_tensor(
         submission: &DsperseSubmission,
@@ -796,15 +814,34 @@ impl ValidatorLoop {
             return;
         }
         let queued = self.api_dslice_queue.len() + self.stacked_dslice_queue.len();
-        let caps_sum: usize = self
-            .performance_tracker
-            .miner_capacities()
-            .values()
-            .copied()
-            .sum();
-        let low = caps_sum
+        let learned_caps = self.performance_tracker.miner_capacities();
+        let caps_sum = self
+            .get_queryable_neurons()
+            .iter()
+            .filter(|neuron| {
+                !self.rsv.is_skiplisted(&neuron.hotkey, self.current_block)
+                    && self
+                        .dispatch_cooldowns
+                        .get(&neuron.hotkey)
+                        .is_none_or(|&until| self.current_block >= until)
+            })
+            .fold(0usize, |total, neuron| {
+                // Unseen queryable miners enter dispatch at cap one, so they
+                // must also contribute to benchmark staging before reaching
+                // the scoring sample gate.
+                total.saturating_add(learned_caps.get(&neuron.uid).copied().unwrap_or(1))
+            });
+        let effective_caps_sum = effective_staging_capacity(
+            caps_sum,
+            self.dispatch_pressure.scale(),
+            self.config.dispatch_ceiling,
+        );
+        if effective_caps_sum == 0 {
+            return;
+        }
+        let low = effective_caps_sum
             .saturating_mul(2)
-            .clamp(DSLICE_QUEUE_LOW_WATERMARK, DSLICE_QUEUE_LOW_WATERMARK_MAX);
+            .clamp(1, DSLICE_QUEUE_LOW_WATERMARK_MAX);
         if queued >= low {
             return;
         }
@@ -1615,8 +1652,18 @@ impl ValidatorLoop {
 
 #[cfg(test)]
 mod tests {
-    use super::ValidatorLoop;
+    use super::{effective_staging_capacity, ValidatorLoop};
     use dsperse::schema::tiling::{DimSplitInfo, DimSplitKind};
+
+    #[test]
+    fn staging_capacity_respects_pressure_and_configured_ceiling() {
+        assert_eq!(effective_staging_capacity(400, 1.0, None), 400);
+        assert_eq!(effective_staging_capacity(400, 0.9, None), 360);
+        assert_eq!(effective_staging_capacity(400, 0.01, None), 4);
+        assert_eq!(effective_staging_capacity(400, 0.9, Some(200)), 200);
+        assert_eq!(effective_staging_capacity(400, 0.9, Some(0)), 0);
+        assert_eq!(effective_staging_capacity(0, 0.9, Some(200)), 0);
+    }
 
     #[test]
     fn group_dim_split_requires_multi_input_and_covering_groups() {

--- a/crates/sn2-validator/src/validator_loop/maintenance.rs
+++ b/crates/sn2-validator/src/validator_loop/maintenance.rs
@@ -11,6 +11,49 @@ use super::{is_valid_ip, ValidatorLoop, WeightTaskResult};
 use crate::metrics_server as metrics;
 use sn2_circuit_store::CircuitStore;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DispatchPressureChange {
+    Reduced,
+    Recovered,
+}
+
+/// Ephemeral validator-host backpressure. This deliberately lives outside the
+/// performance tracker: host memory availability is not evidence about any
+/// miner's capacity and must never rewrite a learned per-miner cap.
+pub(super) struct DispatchPressure {
+    scale: f64,
+}
+
+impl DispatchPressure {
+    pub(super) fn new() -> Self {
+        Self { scale: 1.0 }
+    }
+
+    pub(super) fn scale(&self) -> f64 {
+        self.scale
+    }
+
+    fn update(&mut self, memory_available_ratio: Option<f64>) -> Option<DispatchPressureChange> {
+        let ratio = memory_available_ratio?;
+        let previous = self.scale;
+        let change = if ratio < CAPACITY_RAMP_MIN_AVAIL_MEM_RATIO {
+            self.scale *= 1.0 - CAPACITY_PRESSURE_BACKOFF_FACTOR;
+            DispatchPressureChange::Reduced
+        } else if ratio > CAPACITY_PRESSURE_RECOVERY_MIN_AVAIL_MEM_RATIO && self.scale < 1.0 {
+            self.scale = (self.scale + CAPACITY_PRESSURE_BACKOFF_FACTOR).min(1.0);
+            DispatchPressureChange::Recovered
+        } else {
+            return None;
+        };
+
+        if (self.scale - previous).abs() <= f64::EPSILON {
+            None
+        } else {
+            Some(change)
+        }
+    }
+}
+
 impl ValidatorLoop {
     pub(super) async fn run_periodic_tasks(&mut self) -> Result<()> {
         let now = std::time::Instant::now();
@@ -132,20 +175,59 @@ impl ValidatorLoop {
             let queue_size = self.rwr_queue.len()
                 + self.api_dslice_queue.len()
                 + self.stacked_dslice_queue.len();
-            let queryable_count = self.get_queryable_neurons().len();
+            let queryable_uids: HashSet<u16> = self
+                .get_queryable_neurons()
+                .into_iter()
+                .filter(|neuron| {
+                    !self.rsv.is_skiplisted(&neuron.hotkey, self.current_block)
+                        && self
+                            .dispatch_cooldowns
+                            .get(&neuron.hotkey)
+                            .is_none_or(|&until| self.current_block >= until)
+                })
+                .map(|neuron| neuron.uid)
+                .collect();
+            let queryable_count = queryable_uids.len();
             let dsperse_count = self.circuit_store.get_dsperse_circuits().len();
-            let pressure_backoffs = self.performance_tracker.backoff_all_caps_under_pressure(
-                CAPACITY_PRESSURE_BACKOFF_FACTOR,
-                &self.uid_hotkeys,
-            );
-            if pressure_backoffs > 0 {
-                warn!(
-                    decremented = pressure_backoffs,
-                    factor = CAPACITY_PRESSURE_BACKOFF_FACTOR,
-                    "host memory pressure: trimming adaptive caps across all miners"
-                );
+            let memory_available_ratio = crate::performance::host_memory_available_ratio();
+            let previous_pressure_scale = self.dispatch_pressure.scale();
+            let pressure_change = self.dispatch_pressure.update(memory_available_ratio);
+            let dispatch_pressure_scale = self.dispatch_pressure.scale();
+            self.performance_tracker
+                .set_capacity_growth_paused(dispatch_pressure_scale < 1.0);
+            metrics::set_dispatch_pressure(dispatch_pressure_scale, memory_available_ratio);
+            if let Some(change) = pressure_change {
+                let direction = match change {
+                    DispatchPressureChange::Reduced => "reduced",
+                    DispatchPressureChange::Recovered => "recovered",
+                };
+                metrics::record_dispatch_pressure_change(direction);
+                match change {
+                    DispatchPressureChange::Reduced => warn!(
+                        direction,
+                        memory_available_ratio = ?memory_available_ratio,
+                        previous_dispatch_scale = previous_pressure_scale,
+                        dispatch_scale = dispatch_pressure_scale,
+                        "validator-wide dispatch pressure changed"
+                    ),
+                    DispatchPressureChange::Recovered => info!(
+                        direction,
+                        memory_available_ratio = ?memory_available_ratio,
+                        previous_dispatch_scale = previous_pressure_scale,
+                        dispatch_scale = dispatch_pressure_scale,
+                        "validator-wide dispatch pressure changed"
+                    ),
+                }
             }
-            let idle_decayed = self.performance_tracker.decay_idle_caps(&self.uid_hotkeys);
+            // A global ceiling can intentionally leave otherwise healthy
+            // miners idle. Do not interpret that validator-side throttling as
+            // evidence that their learned caps should decay.
+            let idle_decayed = if dispatch_pressure_scale >= 1.0 {
+                self.performance_tracker
+                    .decay_idle_caps(&self.uid_hotkeys, &queryable_uids)
+            } else {
+                0
+            };
             if idle_decayed > 0 {
                 info!(decremented = idle_decayed, "decayed idle adaptive caps");
             }
@@ -161,7 +243,8 @@ impl ValidatorLoop {
                 verification_concurrency = self.verification_concurrency,
                 verify_tasks = self.verify_tasks.len(),
                 pending_verifications = self.pending_verifications.len(),
-                pressure_backoffs = pressure_backoffs,
+                memory_available_ratio = ?memory_available_ratio,
+                dispatch_pressure_scale,
                 "health"
             );
             if let Some(reporter) = &mut self.stats_reporter {
@@ -581,5 +664,59 @@ impl ValidatorLoop {
         });
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dispatch_pressure_uses_hysteresis_and_recovers_to_one() {
+        let mut pressure = DispatchPressure::new();
+
+        assert_eq!(
+            pressure.update(Some(CAPACITY_RAMP_MIN_AVAIL_MEM_RATIO - 0.01)),
+            Some(DispatchPressureChange::Reduced)
+        );
+        assert!((pressure.scale() - 0.9).abs() < 1e-12);
+
+        assert_eq!(
+            pressure.update(Some(CAPACITY_RAMP_MIN_AVAIL_MEM_RATIO - 0.01)),
+            Some(DispatchPressureChange::Reduced)
+        );
+        assert!((pressure.scale() - 0.81).abs() < 1e-12);
+
+        assert_eq!(pressure.update(Some(0.22)), None);
+        assert_eq!(
+            pressure.update(Some(CAPACITY_RAMP_MIN_AVAIL_MEM_RATIO)),
+            None
+        );
+        assert_eq!(
+            pressure.update(Some(CAPACITY_PRESSURE_RECOVERY_MIN_AVAIL_MEM_RATIO)),
+            None
+        );
+        assert!((pressure.scale() - 0.81).abs() < 1e-12);
+
+        assert_eq!(
+            pressure.update(Some(CAPACITY_PRESSURE_RECOVERY_MIN_AVAIL_MEM_RATIO + 0.01)),
+            Some(DispatchPressureChange::Recovered)
+        );
+        assert!((pressure.scale() - 0.91).abs() < 1e-12);
+        assert_eq!(
+            pressure.update(Some(CAPACITY_PRESSURE_RECOVERY_MIN_AVAIL_MEM_RATIO + 0.01)),
+            Some(DispatchPressureChange::Recovered)
+        );
+        assert!((pressure.scale() - 1.0).abs() < 1e-12);
+        assert_eq!(pressure.update(Some(0.90)), None);
+    }
+
+    #[test]
+    fn dispatch_pressure_holds_when_memory_measurement_is_unavailable() {
+        let mut pressure = DispatchPressure::new();
+        pressure.update(Some(0.10));
+        let reduced = pressure.scale();
+        assert_eq!(pressure.update(None), None);
+        assert_eq!(pressure.scale(), reduced);
     }
 }

--- a/crates/sn2-validator/src/validator_loop/mod.rs
+++ b/crates/sn2-validator/src/validator_loop/mod.rs
@@ -187,6 +187,7 @@ pub struct ValidatorLoop {
     pub(super) consecutive_metagraph_failures: u32,
     pub(super) dispatch_cache: dispatch::DispatchCache,
     pub(super) dispatch_cooldowns: HashMap<String, u64>,
+    dispatch_pressure: maintenance::DispatchPressure,
 }
 
 pub(super) const METAGRAPH_FAILURE_RECONNECT_THRESHOLD: u32 = 3;
@@ -398,6 +399,7 @@ impl ValidatorLoop {
             consecutive_metagraph_failures: 0,
             dispatch_cache: dispatch::DispatchCache::new(),
             dispatch_cooldowns: HashMap::new(),
+            dispatch_pressure: maintenance::DispatchPressure::new(),
         })
     }
 


### PR DESCRIPTION
- Replaces greedy whole-cap dispatch with persistent max-min fair allocation.
- Ensures healthy miners receive baseline work before high-cap miners consume residual capacity.
- Prevents starvation across dispatch cycles using persistent per-hotkey rotation.
- Makes learned capacity usable before the 100-sample scoring threshold.
- Updates adaptive capacity only from saturated dispatch batches.
- Replaces synchronized per-miner memory-pressure backoffs with a temporary validator-wide dispatch ceiling.
- Aligns benchmark staging with miner eligibility, memory pressure, and configured dispatch limits.
- Adds metrics for fair/residual slots, starvation, utilization, memory availability, and pressure scaling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fair, capacity-aware request scheduling to improve service rotation across miners.
  * Added adaptive dispatch pressure management based on available host memory.
  * Added hysteresis for pressure recovery to help stabilize capacity adjustments.
  * Added allocation, pressure, and utilization metrics for improved visibility.
  * Preserved capacity for queryable miners during idle-cap maintenance.

* **Bug Fixes**
  * Prevented capacity growth during elevated memory pressure while allowing recovery as conditions improve.
  * Improved staging capacity calculations under dispatch pressure and configured limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->