### PR TITLE
Migrate transport to phase-scoped query budgets via btlightning 0.2.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,9 +885,9 @@ dependencies = [
 
 [[package]]
 name = "btlightning"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0e4c3f2addbb7445a597e4e27d6f2797fc08bd31323566bcdc0b77b1aa0455b"
+checksum = "1f5cae81943dd30056a18d18b62a2422f2628fd6060aec9d5c900c8e8858ffaa"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4901,7 +4901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -4921,7 +4921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4934,7 +4934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ hex = "0.4"
 sp-core = "34"
 bittensor_wallet = { version = "4.0.1", package = "btwallet", default-features = false }
 subxt = "0.50"
-btlightning = { version = "0.2.12", features = ["btwallet", "subtensor"] }
+btlightning = { version = "0.2.13", features = ["btwallet", "subtensor"] }
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
 metrics = "0.23"
 metrics-exporter-prometheus = "0.15"


### PR DESCRIPTION
Adopts the transport release that bounds each phase of a miner query independently: the dial keeps its connect timeout, the request transfer receives a budget sized to the payload with a hard ceiling, and the adaptive query timeout now bounds only the wait for the response frame. Previously the adaptive timeout wrapped the entire query including the request transfer, so a large payload written to a bandwidth-constrained miner could be cancelled mid-frame; the miner read a truncated request it never had a chance to serve, while the validator recorded a timeout and charged the work. Operators observed exactly this as streams closing before the full request frame arrived.

After this change a large request either arrives intact within its transfer budget or fails with a distinct transfer-timeout reason that reports the byte count, and the response clock starts only once the request has been fully acknowledged. Failure classification downstream is unchanged: the timeout reason string is identical, transfer failures debit like every other non-delivery, and no scoring semantics move. The lockfile checksum for the new crate version was cross-verified against the registry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the underlying Lightning integration to version 0.2.13 while preserving existing wallet and Subtensor functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->