### PR TITLE
Introduce container-size memory observability into the health cadence

### DIFF
--- a/crates/sn2-validator/src/incremental_runner.rs
+++ b/crates/sn2-validator/src/incremental_runner.rs
@@ -578,6 +578,49 @@ impl IncrementalRunManager {
         self.runs.len()
     }
 
+    /// Sizes of the run manager's long-lived containers, for the periodic
+    /// memory line in the health log. Returns (runs, artifacts,
+    /// artifact_bytes, tile_counter_entries, tile_counter_tiles). Artifact
+    /// bytes counts the dominant owned payloads (proof and witness hex plus
+    /// serialized outputs), not exact heap usage.
+    pub fn memory_stats(&self) -> (usize, usize, usize, usize, usize) {
+        fn json_size_estimate(v: &serde_json::Value) -> usize {
+            match v {
+                serde_json::Value::Array(a) => 24 + a.iter().map(json_size_estimate).sum::<usize>(),
+                serde_json::Value::Object(o) => {
+                    o.iter()
+                        .map(|(k, v)| k.len() + 48 + json_size_estimate(v))
+                        .sum::<usize>()
+                        + 32
+                }
+                serde_json::Value::String(s) => s.len() + 24,
+                _ => 16,
+            }
+        }
+        let mut artifacts = 0usize;
+        let mut artifact_bytes = 0usize;
+        for run in self.runs.values() {
+            artifacts += run.artifacts.len();
+            for a in &run.artifacts {
+                artifact_bytes += a.proof_hex.as_ref().map_or(0, |s| s.len())
+                    + a.witness_hex.as_ref().map_or(0, |s| s.len())
+                    + a.computed_outputs.as_ref().map_or(0, json_size_estimate);
+            }
+        }
+        let tile_tiles = self
+            .tile_counters
+            .values()
+            .map(|c| c.expected.len() + c.received.len())
+            .sum();
+        (
+            self.runs.len(),
+            artifacts,
+            artifact_bytes,
+            self.tile_counters.len(),
+            tile_tiles,
+        )
+    }
+
     pub fn benchmark_run_uids(&self) -> Vec<String> {
         self.runs
             .iter()

--- a/crates/sn2-validator/src/performance.rs
+++ b/crates/sn2-validator/src/performance.rs
@@ -356,6 +356,26 @@ impl PerformanceTracker {
         );
     }
 
+    /// Sizes of the tracker's long-lived containers, for the periodic memory
+    /// line in the health log. Returns (unit_time_keys, unit_time_samples,
+    /// own_best_entries, reference_cache_keys, cap_events, delivered_buckets).
+    pub fn memory_stats(&self) -> (usize, usize, usize, usize, usize, usize) {
+        let unit_keys = self.unit_times.len();
+        let unit_samples = self.unit_times.values().map(|v| v.len()).sum();
+        let own_best = self.unit_own_best.values().map(|m| m.len()).sum();
+        let ref_cache = self.unit_reference_cache.len();
+        let cap_events = self.cap_events.len();
+        let buckets = self.delivered_work.values().map(|v| v.len()).sum();
+        (
+            unit_keys,
+            unit_samples,
+            own_best,
+            ref_cache,
+            cap_events,
+            buckets,
+        )
+    }
+
     pub fn adaptive_timeout(&self) -> f64 {
         let times: Vec<f64> = self
             .windows

--- a/crates/sn2-validator/src/validator_loop/maintenance.rs
+++ b/crates/sn2-validator/src/validator_loop/maintenance.rs
@@ -164,6 +164,28 @@ impl ValidatorLoop {
                 pressure_backoffs = pressure_backoffs,
                 "health"
             );
+            let (unit_keys, unit_samples, own_best, ref_cache, cap_events, work_buckets) =
+                self.performance_tracker.memory_stats();
+            let (runs, artifacts, artifact_bytes, tile_entries, tile_tiles) =
+                self.run_manager.memory_stats();
+            let disabled_slices: usize = self.disabled_slices.values().map(|m| m.len()).sum();
+            info!(
+                rss_mb = process_rss_mb(),
+                unit_time_keys = unit_keys,
+                unit_time_samples = unit_samples,
+                own_best_entries = own_best,
+                reference_cache_keys = ref_cache,
+                cap_events = cap_events,
+                delivered_buckets = work_buckets,
+                runs = runs,
+                artifacts = artifacts,
+                artifact_mb = artifact_bytes / (1024 * 1024),
+                tile_counter_entries = tile_entries,
+                tile_counter_tiles = tile_tiles,
+                disabled_slices = disabled_slices,
+                dispatch_cooldowns = self.dispatch_cooldowns.len(),
+                "memory"
+            );
             if let Some(reporter) = &mut self.stats_reporter {
                 reporter.sample_health(active_tasks, queue_size);
             }
@@ -582,4 +604,19 @@ impl ValidatorLoop {
 
         Ok(())
     }
+}
+
+/// Resident set size of this process in MiB, read from procfs. Returns 0 on
+/// platforms without /proc (development hosts), so the memory log line is
+/// meaningful only on the Linux deployment target.
+fn process_rss_mb() -> u64 {
+    std::fs::read_to_string("/proc/self/statm")
+        .ok()
+        .and_then(|s| {
+            s.split_whitespace()
+                .nth(1)
+                .and_then(|pages| pages.parse::<u64>().ok())
+        })
+        .map(|pages| pages * 4096 / (1024 * 1024))
+        .unwrap_or(0)
 }


### PR DESCRIPTION
The validator process has been terminating on failed allocations after resident memory climbs over roughly a day of uptime, and the process manager restart that follows is visible to miners as a brief outage. The remaining growth survives the earlier releases that bounded the dominant caches, so the source is not identifiable from existing logs.

This adds a memory line to the fifteen-second health cadence reporting the process resident set alongside the sizes of every long-lived container that plausibly grows with work mix rather than with fleet size: unit-time keys and samples, own-best entries, reference-cache keys, capacity events, delivered-work buckets, active runs with their artifact counts and payload bytes, tile-counter entries and tile totals, disabled slices, and dispatch cooldowns. Artifact payload bytes are estimated structurally without serializing, so the line costs microseconds. The resident set is read from procfs and reports zero on platforms without it.

A day of these lines against the resident-set curve identifies which container, if any, tracks the growth, or rules the instrumented set out and points the investigation at allocator retention or transport buffers. No behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added memory usage statistics for active validation runs, artifacts, tile counters, performance tracking, and work queues.
  * Enhanced periodic health reporting with detailed memory metrics and process resident memory usage.

* **Bug Fixes**
  * Memory reporting now safely falls back when system memory information is unavailable or cannot be read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->