### PR TITLE
Resolve pointer formatting advisory by migrating crossbeam-epoch to 0.9.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1424,9 +1424,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
The tagged release gate rejects the workspace on a registry advisory against the pinned crossbeam-epoch: the pointer formatting implementations for its atomic types dereferenced the underlying pointer to format its address, which is undefined behavior when the pointer is null or otherwise invalid. The patched release formats the raw address without dereferencing and carries a regression test asserting a null formats as 0x0.

The updated crate was manually reviewed before adoption: the tarball checksum matches the registry entry, the embedded source commit exists upstream in the crossbeam repository as the release preparation commit, the publisher is the crate's primary maintainer, the new build script is a fourteen-line sanitizer configuration probe with no network, filesystem, or process access, and no dependencies were added. Every source hunk between the pinned and patched versions maps to a documented changelog entry; the only behavioral change beyond the formatting fix aligns a fetch-update return value with standard library semantics. Lockfile-only change; the full suite passes unchanged.