### PR TITLE
Migrate verifier to byte-capped bundle cache resolving resident memory exhaustion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,7 +1827,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 [[package]]
 name = "dsperse"
 version = "0.0.0"
-source = "git+https://github.com/inference-labs-inc/dsperse?rev=3a4fbf080bb3#3a4fbf080bb326c7651c876fcdb7d5d488aec55b"
+source = "git+https://github.com/inference-labs-inc/dsperse?rev=009f25151e75#009f25151e754e7db08a8bdd7aa5607f2e633f52"
 dependencies = [
  "clap",
  "half 2.7.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ futures-util = "0.3"
 shellexpand = "3.1.2"
 openssl = { version = "0.10", features = ["vendored"] }
 flate2 = "1"
-dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "3a4fbf080bb3" }
+dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "009f25151e75" }
 ndarray = { version = "0.17", features = ["serde"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 bittensor-drand = { git = "https://github.com/inference-labs-inc/bittensor-drand.git", rev = "e55ed98", default-features = false }

--- a/crates/sn2-types/src/constants.rs
+++ b/crates/sn2-types/src/constants.rs
@@ -78,6 +78,14 @@ pub const IP_REGION_CAP_FRACTION: f64 = 0.25;
 /// recovered miner re-enters dispatch within the same scoring window.
 pub const REHAB_BLOCKS: u64 = 360;
 
+/// Byte bound on the validator's compiled bundle cache. Sampled verification
+/// spreads across many distinct circuits, so per-circuit reuse is too sparse
+/// for residency to earn its memory; without a bound the cache was measured
+/// holding five to twelve gigabytes of bundles with a near-zero hit rate. A
+/// cache miss reloads from local disk in fractions of a second, which the
+/// sampled verify rate absorbs without backlog.
+pub const VERIFIER_BUNDLE_CACHE_CAP_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+
 pub const MAX_POW_QUEUE_SIZE: usize = 1024;
 pub const POW_OUTPUT_STRIDE: usize = MAX_POW_QUEUE_SIZE;
 pub const POW_SCORES_OFFSET: usize = 0;

--- a/crates/sn2-validator/src/validator_loop/maintenance.rs
+++ b/crates/sn2-validator/src/validator_loop/maintenance.rs
@@ -169,8 +169,11 @@ impl ValidatorLoop {
             let (runs, artifacts, artifact_bytes, tile_entries, tile_tiles) =
                 self.run_manager.memory_stats();
             let disabled_slices: usize = self.disabled_slices.values().map(|m| m.len()).sum();
+            let (bundle_count, bundle_bytes) = sn2_verify::bundle_cache_stats();
             info!(
                 rss_mb = process_rss_mb(),
+                bundle_count = bundle_count,
+                bundle_mb = bundle_bytes / (1024 * 1024),
                 unit_time_keys = unit_keys,
                 unit_time_samples = unit_samples,
                 own_best_entries = own_best,

--- a/crates/sn2-validator/src/validator_loop/mod.rs
+++ b/crates/sn2-validator/src/validator_loop/mod.rs
@@ -201,6 +201,8 @@ impl ValidatorLoop {
             );
         }
 
+        sn2_verify::set_bundle_cache_byte_cap(Some(sn2_types::VERIFIER_BUNDLE_CACHE_CAP_BYTES));
+
         let score_path = dirs_next::home_dir()
             .unwrap_or_default()
             .join(".bittensor")

--- a/crates/sn2-verify/src/lib.rs
+++ b/crates/sn2-verify/src/lib.rs
@@ -7,5 +7,6 @@ pub mod verify;
 
 pub use store::{StoredTile, TileStore};
 pub use verify::{
-    clear_circuit_cache, evict_circuit_cache, evict_idle_bundles, verify_inner, VerifyResult,
+    bundle_cache_stats, clear_circuit_cache, evict_circuit_cache, evict_idle_bundles,
+    set_bundle_cache_byte_cap, verify_inner, VerifyResult,
 };

--- a/crates/sn2-verify/src/verify.rs
+++ b/crates/sn2-verify/src/verify.rs
@@ -25,6 +25,19 @@ pub fn evict_idle_bundles(ttl_secs: u64) -> usize {
     BACKEND.evict_idle(std::time::Duration::from_secs(ttl_secs))
 }
 
+/// Bound the compiled bundle cache's total approximate bytes; `None` removes
+/// the bound. Verifiers that sample across many distinct circuits set this
+/// because their per-circuit reuse is too sparse for a residency cache to
+/// earn its memory.
+pub fn set_bundle_cache_byte_cap(bytes: Option<u64>) {
+    BACKEND.set_cache_byte_cap(bytes);
+}
+
+/// Bundle cache occupancy as (entry count, total approximate bytes).
+pub fn bundle_cache_stats() -> (usize, u64) {
+    BACKEND.cache_stats()
+}
+
 pub fn evict_circuit_cache(path_prefix: &str) {
     EVICTION_GENERATION.fetch_add(1, Ordering::SeqCst);
     BACKEND.evict_cache_by_prefix(std::path::Path::new(path_prefix));


### PR DESCRIPTION
The validator process has been terminating on failed allocations after resident memory climbs to the host ceiling. The memory observability added in the previous release localized the growth: every instrumented container stays small while the resident set oscillates many gigabytes above them, and the only uninstrumented structure of that scale is the compiled bundle cache inside the verification backend. Live logs corroborate it, with the idle sweep evicting roughly fifty bundles per minute, implying a steady-state residency of fifty to a hundred large compiled bundles under the time-based eviction model.

The residency model is wrong for this host's access pattern. Sampled verification spreads a few percent of responses across well over a thousand distinct circuit keys, so the interval between visits to the same bundle far exceeds any reasonable idle window: the cache was holding gigabytes of bundles with a near-zero hit rate. The backend now supports a byte cap enforced at insert by least-recently-used eviction, sized here to two gigabytes; a miss reloads from local disk in fractions of a second, which the sampled verify rate absorbs without backlog. Proving deployments are unaffected because the cap is opt-in and their bursty reuse keeps earning residency under the existing idle sweep.

The periodic memory line gains bundle count and byte gauges so the cache's occupancy is visible against the resident set, confirming the ceiling holds in production. Includes the dependency migration resolving the pointer formatting advisory, already adopted and reviewed in this workspace, so the release gate accepts the tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a 2 GiB limit for the validator’s compiled bundle cache.
  * Added cache monitoring, including the number of cached bundles and approximate memory usage.
  * Cache misses now reload bundles from local storage without accumulating backlog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->