### PR TITLE
Migrate bundle cache size accounting to the loaded compiled form

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,7 +1827,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 [[package]]
 name = "dsperse"
 version = "0.0.0"
-source = "git+https://github.com/inference-labs-inc/dsperse?rev=009f25151e75#009f25151e754e7db08a8bdd7aa5607f2e633f52"
+source = "git+https://github.com/inference-labs-inc/dsperse?rev=2fbcc0059883#2fbcc00598830bdd441139e35deb6c11f03d4768"
 dependencies = [
  "clap",
  "half 2.7.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ futures-util = "0.3"
 shellexpand = "3.1.2"
 openssl = { version = "0.10", features = ["vendored"] }
 flate2 = "1"
-dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "009f25151e75" }
+dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "2fbcc0059883" }
 ndarray = { version = "0.17", features = ["serde"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 bittensor-drand = { git = "https://github.com/inference-labs-inc/bittensor-drand.git", rev = "e55ed98", default-features = false }


### PR DESCRIPTION
Adopts the dependency release correcting bundle cache size accounting. The previous release introduced the byte-capped cache but sized entries from path metadata, and bundle paths resolve to directories, so every entry accounted as zero bytes and the cap never evicted; production gauges showed the count climbing while the byte gauge stayed at zero. Entries are now sized from the loaded compiled form's own byte vectors, the actual resident allocation the cap bounds, so the two-gigabyte ceiling becomes effective and the byte gauge reports real occupancy. Dependency revision bump only; no workspace code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency revision to incorporate the latest available changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->