### PR TITLE
Resolve resident overshoot by sizing bundle cache bound to expansion factor

### DIFF
--- a/crates/sn2-types/src/constants.rs
+++ b/crates/sn2-types/src/constants.rs
@@ -78,13 +78,16 @@ pub const IP_REGION_CAP_FRACTION: f64 = 0.25;
 /// recovered miner re-enters dispatch within the same scoring window.
 pub const REHAB_BLOCKS: u64 = 360;
 
-/// Byte bound on the validator's compiled bundle cache. Sampled verification
-/// spreads across many distinct circuits, so per-circuit reuse is too sparse
-/// for residency to earn its memory; without a bound the cache was measured
-/// holding five to twelve gigabytes of bundles with a near-zero hit rate. A
-/// cache miss reloads from local disk in fractions of a second, which the
-/// sampled verify rate absorbs without backlog.
-pub const VERIFIER_BUNDLE_CACHE_CAP_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+/// Byte bound on the validator's compiled bundle cache, accounted at the
+/// stored (compressed) form. Sampled verification spreads across many
+/// distinct circuits, so per-circuit reuse is too sparse for residency to
+/// earn its memory, and the resident cost of a cached bundle is several
+/// times its stored bytes once the verifier expands it. Production showed a
+/// two gigabyte accounted cap admitting an order of magnitude more resident
+/// memory; the bound is therefore sized small enough that even with the
+/// expansion factor the cache stays a minor term. A miss reloads from local
+/// disk in fractions of a second, which the sampled verify rate absorbs.
+pub const VERIFIER_BUNDLE_CACHE_CAP_BYTES: u64 = 256 * 1024 * 1024;
 
 pub const MAX_POW_QUEUE_SIZE: usize = 1024;
 pub const POW_OUTPUT_STRIDE: usize = MAX_POW_QUEUE_SIZE;


### PR DESCRIPTION
The byte-capped bundle cache held its accounted bound exactly in production, the gauge pinned at the cap while least-recently-used entries were evicted, yet the resident set still climbed toward the host ceiling. The accounted figure is the stored compressed form; the verifier expands a bundle severalfold when it runs, and the allocator retains the peak, so a two gigabyte accounted cap admitted an order of magnitude more resident memory than intended.

The bound drops to two hundred fifty six mebibytes accounted, sized so that even with the observed expansion factor the cache remains a minor term in the process footprint. The hit-rate argument is unchanged and unaffected: sampled verification across well over a thousand distinct circuits gave the residency cache a near-zero hit rate at any size, so shrinking it costs effectively nothing while a miss reloads from local disk in fractions of a second. The host process manager also now carries a memory restart bound as a defense in depth, so a future regression restarts the service cleanly instead of dying on a failed allocation mid-proof.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the validator’s compiled bundle cache size limit to improve resource usage.
  * Updated documentation to clarify cache reload behavior when the limit is reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->