### PR TITLE
Resolve allocator page retention and gauge run tensor occupancy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,7 +1827,7 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 [[package]]
 name = "dsperse"
 version = "0.0.0"
-source = "git+https://github.com/inference-labs-inc/dsperse?rev=2fbcc0059883#2fbcc00598830bdd441139e35deb6c11f03d4768"
+source = "git+https://github.com/inference-labs-inc/dsperse?rev=8cec531e51bc#8cec531e51bc6615757de47f96bea14271384ab7"
 dependencies = [
  "clap",
  "half 2.7.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ futures-util = "0.3"
 shellexpand = "3.1.2"
 openssl = { version = "0.10", features = ["vendored"] }
 flate2 = "1"
-dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "2fbcc0059883" }
+dsperse = { git = "https://github.com/inference-labs-inc/dsperse", rev = "8cec531e51bc" }
 ndarray = { version = "0.17", features = ["serde"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 bittensor-drand = { git = "https://github.com/inference-labs-inc/bittensor-drand.git", rev = "e55ed98", default-features = false }

--- a/crates/sn2-validator/src/incremental_runner.rs
+++ b/crates/sn2-validator/src/incremental_runner.rs
@@ -621,6 +621,21 @@ impl IncrementalRunManager {
         )
     }
 
+    /// Total activation tensor cache occupancy across active combined runs,
+    /// as (tensor count, approximate bytes at eight bytes per element).
+    pub fn tensor_store_stats(&self) -> (usize, usize) {
+        let mut tensors = 0usize;
+        let mut bytes = 0usize;
+        for run in self.runs.values() {
+            if let Some(combined) = run.combined.as_ref() {
+                let (count, elements) = combined.tensor_store_stats();
+                tensors += count;
+                bytes += elements * 8;
+            }
+        }
+        (tensors, bytes)
+    }
+
     pub fn benchmark_run_uids(&self) -> Vec<String> {
         self.runs
             .iter()

--- a/crates/sn2-validator/src/main.rs
+++ b/crates/sn2-validator/src/main.rs
@@ -5,13 +5,20 @@
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 // Mimalloc reads option env vars on first option access (lazy). The default
-// `purge_delay` of ~1s churns the page tables on our high-frequency
-// dispatch workload — observed 38k mmap/munmap syscalls per 3s on mainnet,
-// re-introducing a single-thread bottleneck at the allocator layer. Setting
-// the env var from a constructor that runs before main() (and crucially
-// before the tokio runtime build) captures the desired cadence before any
-// sustained allocation. Operators can still override by setting the env
-// var explicitly in their process environment.
+// purge delay churns the page tables on our high-frequency dispatch
+// workload, observed as 38k mmap/munmap syscalls per 3s on mainnet, while
+// a delay of a minute holds every freed page for that long: at hundreds of
+// megabytes per second of transient allocation churn the rolling window of
+// freed-but-unpurged pages alone was six to ten gigabytes of resident
+// memory, which walked the process into allocation failure as throughput
+// grew. Five seconds keeps page operations batched several hundredfold
+// over the default while bounding the garbage window to a few seconds of
+// churn; measured on mainnet it restored peak-decay behavior with no
+// throughput regression. Setting the env var from a constructor that runs
+// before main() (and crucially before the tokio runtime build) captures
+// the cadence before any sustained allocation. Operators can still
+// override by setting the env var explicitly in their process
+// environment.
 #[cfg(target_os = "linux")]
 #[ctor::ctor]
 fn configure_mimalloc_purge_delay() {
@@ -19,7 +26,7 @@ fn configure_mimalloc_purge_delay() {
     // race on environment state at this point.
     unsafe {
         if std::env::var_os("MIMALLOC_PURGE_DELAY").is_none() {
-            std::env::set_var("MIMALLOC_PURGE_DELAY", "60000");
+            std::env::set_var("MIMALLOC_PURGE_DELAY", "5000");
         }
     }
 }

--- a/crates/sn2-validator/src/validator_loop/maintenance.rs
+++ b/crates/sn2-validator/src/validator_loop/maintenance.rs
@@ -170,10 +170,13 @@ impl ValidatorLoop {
                 self.run_manager.memory_stats();
             let disabled_slices: usize = self.disabled_slices.values().map(|m| m.len()).sum();
             let (bundle_count, bundle_bytes) = sn2_verify::bundle_cache_stats();
+            let (run_tensors, run_tensor_bytes) = self.run_manager.tensor_store_stats();
             info!(
                 rss_mb = process_rss_mb(),
                 bundle_count = bundle_count,
                 bundle_mb = bundle_bytes / (1024 * 1024),
+                run_tensors = run_tensors,
+                run_tensor_mb = run_tensor_bytes / (1024 * 1024),
                 unit_time_keys = unit_keys,
                 unit_time_samples = unit_samples,
                 own_best_entries = own_best,


### PR DESCRIPTION
Two changes closing out the resident memory investigation. First, the allocator purge delay drops from one minute to five seconds. The minute-long value was set to stop a page-table churn bottleneck and was correct for the syscall problem, but it holds every freed page for a minute, and at current throughput the rolling window of freed-but-unpurged pages alone accounted for multiple gigabytes of resident memory that grew with load. Five seconds was validated live on the production host via environment override before adoption: resident memory regained peak-decay behavior, throughput held with no syscall regression, and codifying it in the binary protects the setting from being lost on redeploy, which refreshes the process environment.

Second, the periodic memory line gains gauges for the activation tensor caches carried by active combined runs, via a new read-only accessor in the pipeline dependency. This was the last large consumer in the process footprint without a gauge; with it, every multi-gigabyte term in the resident set is charted against the process total every fifteen seconds, so any future growth is attributable from logs alone. Overnight the process-manager memory bound cycled the service roughly hourly with zero allocation failures; these gauges exist to identify and retire whatever drives that remaining accumulation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added additional health monitoring metrics for active run tensor counts and memory usage.
* **Improvements**
  * Reduced the default Linux memory allocator purge delay to improve memory reclamation responsiveness.
  * Updated the underlying `dsperse` component revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->