### PR TITLE
Introduce periodic forced allocator collection reclaiming abandoned segments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1543,6 +1543,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3654,6 +3660,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
 dependencies = [
  "cc",
+ "cty",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6411,6 +6411,7 @@ dependencies = [
  "futures-util",
  "hex",
  "libc",
+ "libmimalloc-sys",
  "metrics",
  "metrics-exporter-prometheus",
  "mimalloc",

--- a/crates/sn2-validator/Cargo.toml
+++ b/crates/sn2-validator/Cargo.toml
@@ -43,5 +43,5 @@ rustls = { version = "0.23", default-features = false, features = ["ring"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"
 mimalloc = { workspace = true }
-libmimalloc-sys = "0.1"
+libmimalloc-sys = { version = "0.1", features = ["extended"] }
 ctor = { workspace = true }

--- a/crates/sn2-validator/Cargo.toml
+++ b/crates/sn2-validator/Cargo.toml
@@ -43,4 +43,5 @@ rustls = { version = "0.23", default-features = false, features = ["ring"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"
 mimalloc = { workspace = true }
+libmimalloc-sys = "0.1"
 ctor = { workspace = true }

--- a/crates/sn2-validator/src/validator_loop/maintenance.rs
+++ b/crates/sn2-validator/src/validator_loop/maintenance.rs
@@ -116,6 +116,19 @@ impl ValidatorLoop {
 
         if now.duration_since(self.timings.gc) > Duration::from_secs(120) {
             self.gc_stale_runs().await;
+            // Force the allocator to decommit freed and abandoned pages. The
+            // workload's large transient allocations happen on short-lived
+            // blocking threads whose heap segments are abandoned when the
+            // thread dies, and neither the purge delay nor the abandoned-page
+            // option returned them in production: resident memory climbed to
+            // the process manager's bound roughly hourly while every gauged
+            // container stayed small. An explicit forced collect reclaims
+            // abandoned segments and decommits free pages on our cadence, at
+            // a cost of milliseconds every two minutes.
+            #[cfg(target_os = "linux")]
+            unsafe {
+                libmimalloc_sys::mi_collect(true);
+            }
             self.timings.gc = now;
         }
 


### PR DESCRIPTION
Resident memory climbs to the process manager's bound roughly hourly while every gauged container in the memory line stays small, so the growth lives in the allocator rather than the application. The workload's large transient allocations, request payloads, activation tensors, and expanded verification structures, happen on short-lived blocking threads; when such a thread dies its heap segments are abandoned, and production testing showed neither a shorter purge delay nor the abandoned-page purge option returns them at any useful rate.

The maintenance loop now forces a full allocator collection every two minutes, which reclaims abandoned segments and decommits free pages explicitly rather than waiting on heuristics that this allocation pattern defeats. The call costs milliseconds and rides the existing garbage collection cadence. The binding is to the exact allocator library already compiled into the binary through the global allocator, promoted from a transitive to a direct dependency with no version change. If the resident set still climbs with collections active, the remaining growth is genuinely live and the gauges will name it; either way the hourly restart cycle ends or becomes attributable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved Linux-only memory reclamation during periodic maintenance cycles.
  * Enabled extended native allocator support on Linux to better reclaim freed pages.
  * Additional allocator GC is now triggered on the existing 120-second stale-run cleanup cadence to reduce memory growth over time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->