### PR TITLE
Migrate validator allocator to jemalloc resolving fragmentation retention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,16 +1515,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
-dependencies = [
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "ctr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,12 +1531,6 @@ checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher 0.4.4",
 ]
-
-[[package]]
-name = "cty"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "curve25519-dalek"
@@ -3654,16 +3638,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
-dependencies = [
- "cc",
- "cty",
-]
-
-[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3970,15 +3944,6 @@ dependencies = [
  "num_cpus",
  "quanta",
  "sketches-ddsketch",
-]
-
-[[package]]
-name = "mimalloc"
-version = "0.1.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
-dependencies = [
- "libmimalloc-sys",
 ]
 
 [[package]]
@@ -6411,17 +6376,14 @@ dependencies = [
  "btlightning",
  "bytes",
  "clap",
- "ctor",
  "dirs-next",
  "dsperse",
  "flate2",
  "futures-util",
  "hex",
  "libc",
- "libmimalloc-sys",
  "metrics",
  "metrics-exporter-prometheus",
- "mimalloc",
  "ndarray 0.17.2",
  "rand 0.9.4",
  "reqwest 0.12.28",
@@ -6434,6 +6396,7 @@ dependencies = [
  "sn2-types",
  "sn2-verify",
  "subxt",
+ "tikv-jemallocator",
  "tokio",
  "tokio-tungstenite 0.24.0",
  "tracing",
@@ -7090,6 +7053,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/crates/sn2-validator/Cargo.toml
+++ b/crates/sn2-validator/Cargo.toml
@@ -42,6 +42,4 @@ rustls = { version = "0.23", default-features = false, features = ["ring"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"
-mimalloc = { workspace = true }
-libmimalloc-sys = { version = "0.1", features = ["extended"] }
-ctor = { workspace = true }
+tikv-jemallocator = "0.7"

--- a/crates/sn2-validator/src/main.rs
+++ b/crates/sn2-validator/src/main.rs
@@ -2,34 +2,26 @@
 
 #[cfg(target_os = "linux")]
 #[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-// Mimalloc reads option env vars on first option access (lazy). The default
-// purge delay churns the page tables on our high-frequency dispatch
-// workload, observed as 38k mmap/munmap syscalls per 3s on mainnet, while
-// a delay of a minute holds every freed page for that long: at hundreds of
-// megabytes per second of transient allocation churn the rolling window of
-// freed-but-unpurged pages alone was six to ten gigabytes of resident
-// memory, which walked the process into allocation failure as throughput
-// grew. Five seconds keeps page operations batched several hundredfold
-// over the default while bounding the garbage window to a few seconds of
-// churn; measured on mainnet it restored peak-decay behavior with no
-// throughput regression. Setting the env var from a constructor that runs
-// before main() (and crucially before the tokio runtime build) captures
-// the cadence before any sustained allocation. Operators can still
-// override by setting the env var explicitly in their process
-// environment.
+// Jemalloc replaces mimalloc for the validator specifically. The workload
+// interleaves multi-megabyte transient allocations (request payloads,
+// activation tensors, expanded verification structures on short-lived
+// blocking threads) with long-lived small tracker state, and mimalloc's
+// segment model pinned pages hosting any live object: resident memory
+// ratcheted toward the host ceiling on an hourly cycle even with aggressive
+// purge settings and periodic forced collection, because fragmentation is
+// immune to both. Jemalloc segregates size classes into separate regions by
+// construction, so the transient and persistent lifetimes never share
+// pages, and the background thread batches page decommits, which also
+// avoids the page-table syscall storm that originally motivated mimalloc
+// here. Decay is set to ten seconds so freed pages return promptly without
+// per-free syscall churn.
 #[cfg(target_os = "linux")]
-#[ctor::ctor]
-fn configure_mimalloc_purge_delay() {
-    // SAFETY: ctor runs single-threaded before main; no other thread can
-    // race on environment state at this point.
-    unsafe {
-        if std::env::var_os("MIMALLOC_PURGE_DELAY").is_none() {
-            std::env::set_var("MIMALLOC_PURGE_DELAY", "5000");
-        }
-    }
-}
+#[allow(non_upper_case_globals)]
+#[export_name = "_rjem_malloc_conf"]
+pub static malloc_conf: &[u8] =
+    b"background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:10000\0";
 
 mod cli;
 mod config;

--- a/crates/sn2-validator/src/validator_loop/maintenance.rs
+++ b/crates/sn2-validator/src/validator_loop/maintenance.rs
@@ -116,19 +116,6 @@ impl ValidatorLoop {
 
         if now.duration_since(self.timings.gc) > Duration::from_secs(120) {
             self.gc_stale_runs().await;
-            // Force the allocator to decommit freed and abandoned pages. The
-            // workload's large transient allocations happen on short-lived
-            // blocking threads whose heap segments are abandoned when the
-            // thread dies, and neither the purge delay nor the abandoned-page
-            // option returned them in production: resident memory climbed to
-            // the process manager's bound roughly hourly while every gauged
-            // container stayed small. An explicit forced collect reclaims
-            // abandoned segments and decommits free pages on our cadence, at
-            // a cost of milliseconds every two minutes.
-            #[cfg(target_os = "linux")]
-            unsafe {
-                libmimalloc_sys::mi_collect(true);
-            }
             self.timings.gc = now;
         }
 


### PR DESCRIPTION
The resident memory investigation eliminated every application-side candidate: all long-lived containers are gauged and small, run tensor caches release on schedule, the bundle cache is byte-capped, and the remaining growth survived an aggressive purge cadence, the abandoned-page option, and periodic forced collection. What remains is fragmentation intrinsic to the allocator's segment model under this workload: multi-megabyte transient allocations on short-lived blocking threads interleave with long-lived small tracker state, any live object pins its page, and pinned pages accumulate until the process manager's memory bound cycles the service, lately about every two and a half hours.

Jemalloc addresses the mechanism rather than the symptom. Size classes are segregated into separate regions by construction, so transient and persistent lifetimes never share pages, and decay-based purging on a background thread returns freed pages within seconds while batching the page-table operations whose per-free cost originally motivated the previous allocator choice. Decay is configured at ten seconds through the embedded configuration symbol, which operators can override through the standard environment variable. The change is validator-only and Linux-only; the miner binary keeps its existing allocator since its allocation profile does not exhibit the interleaving. Both new crates were checksum-verified against the registry, are maintained by the TiKV project, and vendor the upstream allocator at a pinned release. The forced-collection call from the previous release is removed along with the previous allocator's tuning constructor and both related dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Updated Linux memory allocation to improve runtime memory management.
  * Adjusted allocator background cleanup and memory decay behavior.
  * Simplified periodic maintenance by removing an explicit forced memory collection step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->