### PR TITLE
Resolve subtensor storage reads by excluding archive RPC backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,9 +885,9 @@ dependencies = [
 
 [[package]]
 name = "btlightning"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f5cae81943dd30056a18d18b62a2422f2628fd6060aec9d5c900c8e8858ffaa"
+checksum = "1decc19827f18122894effa8100775c6990b5602c6078a6bda8ca80e008c9bb5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ hex = "0.4"
 sp-core = "34"
 bittensor_wallet = { version = "4.0.1", package = "btwallet", default-features = false }
 subxt = "0.50"
-btlightning = { version = "0.2.13", features = ["btwallet", "subtensor"] }
+btlightning = { version = "0.2.14", features = ["btwallet", "subtensor"] }
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
 metrics = "0.23"
 metrics-exporter-prometheus = "0.15"

--- a/crates/sn2-chain/src/lib.rs
+++ b/crates/sn2-chain/src/lib.rs
@@ -6,7 +6,11 @@ mod subxt_helpers;
 mod wallet;
 mod weights;
 
+use std::sync::Arc;
+
 use anyhow::{Context, Result};
+use subxt::backend::{ChainHeadBackend, CombinedBackend, LegacyBackend};
+use subxt::rpcs::RpcClient;
 use subxt::{OnlineClient, PolkadotConfig};
 
 pub use metagraph::{Metagraph, NeuronInfo};
@@ -34,13 +38,39 @@ pub fn resolve_endpoint(network: &str, override_endpoint: Option<&str>) -> Strin
 /// TLS-validating `from_url`; `ws://` URLs use `from_insecure_url`, which
 /// subxt requires for non-TLS sockets even when reaching localhost or a
 /// private substrate node.
+///
+/// The backend is assembled explicitly rather than via
+/// `OnlineClient::from_url`, which builds a `CombinedBackend` that enables the
+/// `archive_v1_*` backend whenever the node advertises those methods in
+/// `rpc_methods`. Pruned subtensor nodes advertise the archive namespace but
+/// answer every archive call with `Method not found (-32601)`, and the archive
+/// backend builds its storage streams lazily, so the failure surfaces on first
+/// poll rather than at construction and `CombinedBackend`'s per-call fallback
+/// chain never gets the chance to retry against `chainHead` or the legacy
+/// `state_*` methods. Omitting the archive backend keeps storage reads on the
+/// two backends every subtensor node actually serves.
 pub async fn connect_chain(endpoint: &str) -> Result<OnlineClient<PolkadotConfig>> {
-    let result = if endpoint.starts_with("ws://") {
-        OnlineClient::<PolkadotConfig>::from_insecure_url(endpoint).await
+    let rpc_client = if endpoint.starts_with("ws://") {
+        RpcClient::from_insecure_url(endpoint).await
     } else {
-        OnlineClient::<PolkadotConfig>::from_url(endpoint).await
-    };
-    result.with_context(|| format!("connecting to subtensor at {endpoint}"))
+        RpcClient::from_url(endpoint).await
+    }
+    .with_context(|| format!("connecting to subtensor at {endpoint}"))?;
+
+    let chain_head = ChainHeadBackend::builder().build_with_background_driver(rpc_client.clone());
+    let legacy = LegacyBackend::builder().build(rpc_client.clone());
+
+    let backend = CombinedBackend::<PolkadotConfig>::builder()
+        .no_default_backends()
+        .with_chainhead_backend(chain_head)
+        .with_legacy_backend(legacy)
+        .build_with_background_driver(rpc_client)
+        .await
+        .with_context(|| format!("building subtensor backend for {endpoint}"))?;
+
+    OnlineClient::<PolkadotConfig>::from_backend(Arc::new(backend))
+        .await
+        .with_context(|| format!("connecting to subtensor at {endpoint}"))
 }
 
 pub fn is_rpc_disconnect(err: &anyhow::Error) -> bool {


### PR DESCRIPTION
## Investigation

The mainnet validator has been in a crash loop, failing before it reaches the dispatch loop:

```
Error: building validator config

Caused by:
    0: initial metagraph sync
    1: Cannot fetch the storage value: Backend error: RPC error: RPC error: User error: Method not found (-32601)
```

Tracing the RPC traffic (`RUST_LOG=jsonrpsee=trace`) shows the failing request is the very first storage read of `Metagraph::sync`:

```json
{"method":"archive_v1_storage","params":["0x0fb6...736e",[{"key":"0x658faa38...0200","type":"value"}],null]}
```

Probing the endpoints directly confirms the split:

| Endpoint | `archive_v1_storage` |
| --- | --- |
| `wss://entrypoint-finney.opentensor.ai:443` | `-32601 Method not found` |
| `wss://lite.chain.opentensor.ai:443` | `-32601 Method not found` |
| `wss://test.finney.opentensor.ai:443` | works |
| `wss://archive.chain.opentensor.ai:443` | works |

Every node advertises the full `archive_v1_*` namespace in `rpc_methods`, but only true archive nodes actually serve it. Pruned nodes list the methods and then reject each call. Testnet is backed by an archive node, which is why the failure is mainnet-only and went unnoticed until the recent chain upgrade started advertising the namespace on pruned entrypoints.

## Root cause

`OnlineClient::from_url` builds a `CombinedBackend`, which decides which sub-backends to enable purely from the advertised method list:

```rust
let has_archive_methods = methods.iter().any(|m| m.starts_with("archive_v1_"));
```

`CombinedBackend` does carry a per-call fallback chain (`archive` then `chainHead` then `legacy`), and that chain works for block headers and runtime calls, which is why the trace shows `archive_v1_header` failing and `chainHead_v1_header` succeeding immediately after. Storage is different: `ArchiveBackend::storage_fetch_values` constructs `ArchiveStorageStream` lazily and returns `Ok(stream)` without issuing any RPC, so `try_backends` records a success and never tries `chainHead` or `legacy`. The `-32601` only surfaces when the caller polls the stream, well past the point where a fallback could happen.

So the archive backend is selected on evidence that is wrong for pruned nodes, and the one code path where that mistake matters is also the one path the fallback cannot cover.

## Change

`connect_chain` now assembles the backend explicitly instead of relying on `from_url`, keeping the `chainHead` and `legacy` backends and their ordering while dropping `archive` entirely:

```rust
let chain_head = ChainHeadBackend::builder().build_with_background_driver(rpc_client.clone());
let legacy = LegacyBackend::builder().build(rpc_client.clone());

let backend = CombinedBackend::<PolkadotConfig>::builder()
    .no_default_backends()
    .with_chainhead_backend(chain_head)
    .with_legacy_backend(legacy)
    .build_with_background_driver(rpc_client)
    .await?;
```

`CombinedBackend::build` still gates `chainHead` on the node advertising `chainHead_v1_*`, so a node offering only the legacy `state_*` methods degrades to legacy exactly as before. Nothing is lost by omitting archive: every operation the validator performs is served by one of the two remaining backends, and no production entrypoint reliably serves the archive namespace anyway.

Both the validator and the miner route through `connect_chain`, so both are covered.

## Verification

Built from this branch on the mainnet validator host and run against `wss://entrypoint-finney.opentensor.ai:443` with the live wallet:

```
INFO sn2_validator: starting sn2-validator netuid=2 network=finney
INFO sn2_chain::metagraph: syncing metagraph netuid=2 n=256 block=8715526 kappa=32767 tempo=360
INFO sn2_chain::metagraph: synced via runtime API netuid=2 neurons=256
INFO sn2_chain::metagraph: metagraph synced netuid=2 neurons=256
INFO sn2_validator::scoring: loaded scores from disk count=256
INFO sn2_validator::validator_loop: initialized verification concurrency verification_concurrency=64
```

Startup completes and the validator proceeds through scoring load, circuit store hydration, and into its dispatch loop. Prior to the change the same invocation aborted on the first storage read. The smoke run used `--no-relay --disable-benchmark` and a non-default metrics port so it would not contend with the live process on that host.

`cargo fmt --check` and `cargo clippy -p sn2-chain --all-targets -- -D warnings` are clean.

## Dependency bump

`btlightning` carried the identical defect: its metagraph monitor built clients with `OnlineClient::from_url` and performed the same dynamic storage reads. That is resolved in inference-labs-inc/btlightning#64 and released as 0.2.14, which this branch now pins. Both halves are needed for the validator and miner to survive a pruned entrypoint, since the QUIC client keeps its own subtensor connection for the metagraph monitor.

The published crate was checked before pinning:

| Check | Result |
| --- | --- |
| crates.io sha256 | `1decc19827f18122894effa8100775c6990b5602c6078a6bda8ca80e008c9bb5` |
| Downloaded artifact sha256 | matches |
| `Cargo.lock` checksum | matches |
| Build provenance | verifies against `a62e3e2` at `refs/tags/v0.2.14` via `release.yml` |

`Cargo.lock` moves only the `btlightning` entry; no transitive dependency shifted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blockchain connection handling for both secure (`wss://`) and insecure (`ws://`) WebSocket endpoints.
  * Enhanced compatibility by explicitly constructing the client backend using chain-head and legacy backends.
  * Added clearer error messages when connection setup or backend preparation fails.
* **Documentation**
  * Expanded guidance on connection/backends and how archive-related behavior is handled.
* **Chores**
  * Updated the `btlightning` workspace dependency to `0.2.14` (same feature set).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->