### PR TITLE
Investigate keyfile deserialization failure on integer cryptoType field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,9 +885,9 @@ dependencies = [
 
 [[package]]
 name = "btlightning"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1decc19827f18122894effa8100775c6990b5602c6078a6bda8ca80e008c9bb5"
+checksum = "14a38bfc8fb8f0acf342b4bf5fa227aa89342251fcb6ba390e3a5b186577ab95"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,9 +912,9 @@ dependencies = [
 
 [[package]]
 name = "btwallet"
-version = "4.0.1"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfbd26f85078c02aa02c7913494602afb5b994580ab8581682c40a9c7361ffad"
+checksum = "8365dd736f1a158d7a84cf31c659f15c1060326e8a80364de9a0ed1439f5d357"
 dependencies = [
  "ansible-vault",
  "base64 0.22.1",
@@ -5390,13 +5390,13 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.5.2"
+version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac5b223d9738ef56e0b98305410be40fa0941bf6036c56f1506751e43552d64"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
 dependencies = [
  "libc",
  "rtoolbox",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ mimalloc = { version = "0.1", default-features = false }
 ctor = "0.2"
 hex = "0.4"
 sp-core = "34"
-bittensor_wallet = { version = "4.0.1", package = "btwallet", default-features = false }
+bittensor_wallet = { version = "4.1.0", package = "btwallet", default-features = false }
 subxt = "0.50"
 btlightning = { version = "0.2.14", features = ["btwallet", "subtensor"] }
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ hex = "0.4"
 sp-core = "34"
 bittensor_wallet = { version = "4.1.0", package = "btwallet", default-features = false }
 subxt = "0.50"
-btlightning = { version = "0.2.14", features = ["btwallet", "subtensor"] }
+btlightning = { version = "0.2.15", features = ["btwallet", "subtensor"] }
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
 metrics = "0.23"
 metrics-exporter-prometheus = "0.15"

--- a/crates/sn2-chain/src/wallet.rs
+++ b/crates/sn2-chain/src/wallet.rs
@@ -69,3 +69,52 @@ impl Wallet {
         Ok(subxt::utils::AccountId32::from(bytes))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    const MNEMONIC: &str = "bottom drive obey lake curtain smoke basket hold race lonely fit walk";
+    const EXPECTED_SS58: &str = "5DfhGyQdFobKM8NsWvEeAKk5EQQgYe9AydgJ7rMB6E1EqRzV";
+
+    fn write_wallet(dir: &std::path::Path, keyfile: &str) {
+        let hotkeys = dir.join("sn2-test").join("hotkeys");
+        std::fs::create_dir_all(&hotkeys).expect("create hotkeys dir");
+        let mut f = std::fs::File::create(hotkeys.join("default")).expect("create hotkey file");
+        f.write_all(keyfile.as_bytes()).expect("write hotkey file");
+    }
+
+    fn scratch_dir(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("sn2-wallet-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        dir
+    }
+
+    #[test]
+    fn loads_hotkey_written_without_crypto_type() {
+        let dir = scratch_dir("no-crypto-type");
+        write_wallet(&dir, &format!(r#"{{"secretPhrase":"{MNEMONIC}"}}"#));
+
+        let wallet = Wallet::from_paths("sn2-test", "default", Some(dir.to_str().unwrap()))
+            .expect("hotkey without cryptoType should load");
+        assert_eq!(wallet.hotkey_ss58(), EXPECTED_SS58);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn loads_hotkey_written_with_integer_crypto_type() {
+        let dir = scratch_dir("crypto-type");
+        write_wallet(
+            &dir,
+            &format!(r#"{{"secretPhrase":"{MNEMONIC}","cryptoType":1}}"#),
+        );
+
+        let wallet = Wallet::from_paths("sn2-test", "default", Some(dir.to_str().unwrap()))
+            .expect("hotkey carrying an integer cryptoType should load");
+        assert_eq!(wallet.hotkey_ss58(), EXPECTED_SS58);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}


### PR DESCRIPTION
## What

Validators reported that hotkeys generated with current upstream wallet tooling cannot be loaded. Hotkey loading fails with `DeserializationError("Failed to parse keyfile data.")`.

## Root cause

Current upstream tooling writes a `cryptoType` integer into the keyfile JSON alongside the existing string fields:

```json
{"secretPhrase":"...","ss58Address":"...","cryptoType":1}
```

The pinned wallet library deserializes the whole keyfile object as a map of string values, so a single integer aborts the entire parse before any field is read. Nothing about the affected keys is malformed. Keys written by older tooling omit the field and still load, which is why this only surfaced recently.

The tolerant revision models the keyfile as a generic JSON value and reads the crypto type properly.

## Verification

Reproduced through `Wallet::from_paths` itself, not just the library:

| keyfile | old pin | new pin |
|---|---|---|
| hotkey with integer `cryptoType` | FAILED — `DeserializationError` | ok |
| hotkey without `cryptoType` | ok | ok |

Both cases are now covered by tests in `crates/sn2-chain/src/wallet.rs`. `cargo build --release`, `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` are clean.

## Lockfile scope

The lock edit is confined to the two affected entries. A plain `cargo update` re-shuffled roughly thirty target-gated Windows dependency edges as a side effect, so the entries were advanced surgically instead and confirmed with `cargo check --locked`. Resolution of every other package is byte-identical.

The advanced revision constrains `rpassword` to `>=7.3, <7.5`, which moves it from 7.5.2 to 7.4.0. Neither package has a RustSec advisory. The new library revision was published 2026-05-28 and its checksum matches crates.io.

## Cross-repo note

`lightning` needs the same advance for its published crate and its Python wheels, and that change is going up separately. It is not a prerequisite here: cargo unifies this dependency across the whole graph, so this lockfile alone governs the copy `btlightning` links against.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for loading wallet files without a specified crypto type.
  * Added coverage for wallet files using an integer crypto type.
  * Verified that loaded wallets produce the expected SS58 addresses.
  * Improved validation across temporary wallet directories and cleanup workflows.
  * Expanded compatibility checks for wallet-loading scenarios to support more reliable account access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->