### PR TITLE
Merge testnet into main for 14.12.21 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,9 +885,9 @@ dependencies = [
 
 [[package]]
 name = "btlightning"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1decc19827f18122894effa8100775c6990b5602c6078a6bda8ca80e008c9bb5"
+checksum = "14a38bfc8fb8f0acf342b4bf5fa227aa89342251fcb6ba390e3a5b186577ab95"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -912,9 +912,9 @@ dependencies = [
 
 [[package]]
 name = "btwallet"
-version = "4.0.1"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfbd26f85078c02aa02c7913494602afb5b994580ab8581682c40a9c7361ffad"
+checksum = "8365dd736f1a158d7a84cf31c659f15c1060326e8a80364de9a0ed1439f5d357"
 dependencies = [
  "ansible-vault",
  "base64 0.22.1",
@@ -5390,13 +5390,13 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.5.2"
+version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac5b223d9738ef56e0b98305410be40fa0941bf6036c56f1506751e43552d64"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
 dependencies = [
  "libc",
  "rtoolbox",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,9 @@ mimalloc = { version = "0.1", default-features = false }
 ctor = "0.2"
 hex = "0.4"
 sp-core = "34"
-bittensor_wallet = { version = "4.0.1", package = "btwallet", default-features = false }
+bittensor_wallet = { version = "4.1.0", package = "btwallet", default-features = false }
 subxt = "0.50"
-btlightning = { version = "0.2.14", features = ["btwallet", "subtensor"] }
+btlightning = { version = "0.2.15", features = ["btwallet", "subtensor"] }
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
 metrics = "0.23"
 metrics-exporter-prometheus = "0.15"

--- a/crates/sn2-chain/src/wallet.rs
+++ b/crates/sn2-chain/src/wallet.rs
@@ -69,3 +69,52 @@ impl Wallet {
         Ok(subxt::utils::AccountId32::from(bytes))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    const MNEMONIC: &str = "bottom drive obey lake curtain smoke basket hold race lonely fit walk";
+    const EXPECTED_SS58: &str = "5DfhGyQdFobKM8NsWvEeAKk5EQQgYe9AydgJ7rMB6E1EqRzV";
+
+    fn write_wallet(dir: &std::path::Path, keyfile: &str) {
+        let hotkeys = dir.join("sn2-test").join("hotkeys");
+        std::fs::create_dir_all(&hotkeys).expect("create hotkeys dir");
+        let mut f = std::fs::File::create(hotkeys.join("default")).expect("create hotkey file");
+        f.write_all(keyfile.as_bytes()).expect("write hotkey file");
+    }
+
+    fn scratch_dir(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("sn2-wallet-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        dir
+    }
+
+    #[test]
+    fn loads_hotkey_written_without_crypto_type() {
+        let dir = scratch_dir("no-crypto-type");
+        write_wallet(&dir, &format!(r#"{{"secretPhrase":"{MNEMONIC}"}}"#));
+
+        let wallet = Wallet::from_paths("sn2-test", "default", Some(dir.to_str().unwrap()))
+            .expect("hotkey without cryptoType should load");
+        assert_eq!(wallet.hotkey_ss58(), EXPECTED_SS58);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn loads_hotkey_written_with_integer_crypto_type() {
+        let dir = scratch_dir("crypto-type");
+        write_wallet(
+            &dir,
+            &format!(r#"{{"secretPhrase":"{MNEMONIC}","cryptoType":1}}"#),
+        );
+
+        let wallet = Wallet::from_paths("sn2-test", "default", Some(dir.to_str().unwrap()))
+            .expect("hotkey carrying an integer cryptoType should load");
+        assert_eq!(wallet.hotkey_ss58(), EXPECTED_SS58);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}


### PR DESCRIPTION
Promotes the keyfile deserialization fix from `testnet` to `main` for the 14.12.21 patch release.

## Scope

One commit, three files. Nothing else has landed on `testnet` since 14.12.20, so this promotion carries the fix alone.

* inference-labs-inc/subnet-2#610 — Investigate keyfile deserialization failure on integer cryptoType field

## What it fixes

Hotkeys generated by current upstream wallet tooling could not be loaded. Hotkey loading failed with `DeserializationError("Failed to parse keyfile data.")`, because that tooling now writes a `cryptoType` integer into the keyfile JSON and the pinned wallet library parsed the whole object as a map of string values — a single integer aborted the parse before any field was read.

Operators hitting this cannot run the validator or miner at all until they take this build.

## Changes

| dependency | from | to |
|---|---|---|
| btwallet | 4.0.1 | 4.1.0 |
| btlightning | 0.2.14 | 0.2.15 |

Plus regression coverage in `crates/sn2-chain/src/wallet.rs` for keyfiles written both with and without the `cryptoType` field.

## Compatibility

Verified rather than assumed:

* Old keyfiles without `cryptoType` still load.
* Encrypted `$NACL` keyfiles written by the previous library still decrypt, to the same address, with wrong passwords still rejected.
* The same mnemonic yields a byte-identical public key and SS58 address under both library revisions, and a signature produced by the old revision verifies under the new one.

No key rotation, no re-registration, and existing signatures stay valid. `WEIGHTS_VERSION` is unchanged, so weight-commit compatibility is unaffected.

The transport dependency now declares a floor of btwallet 4.1.0 as well, so the corrected parsing is enforced from both this manifest and the transport crate and cannot silently regress on a future update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated underlying wallet and networking components for improved compatibility and maintenance.

* **Tests**
  * Expanded wallet validation coverage for additional wallet file formats, including files with and without cryptographic type metadata.
  * Verified that wallets continue to load correctly and produce the expected account addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->