### PR TITLE
Introduce proof coverage and final output on run completion notification

### DIFF
--- a/crates/sn2-validator/src/incremental_runner.rs
+++ b/crates/sn2-validator/src/incremental_runner.rs
@@ -206,6 +206,17 @@ impl IncrementalRunManager {
             .unwrap_or(0)
     }
 
+    /// Total tiles verified across every slice of a run. Paired with the run's
+    /// total tile count this yields the fraction of the model whose execution
+    /// is backed by a verified proof.
+    pub fn verified_tile_total(&self, run_uid: &str) -> usize {
+        self.verified_tile_counts
+            .iter()
+            .filter(|((uid, _), _)| uid == run_uid)
+            .map(|(_, count)| *count)
+            .sum()
+    }
+
     pub fn slice_tile_counts(&self, run_uid: &str) -> (usize, usize, HashMap<String, usize>) {
         let run = match self.runs.get(run_uid) {
             Some(r) => r,

--- a/crates/sn2-validator/src/incremental_runner.rs
+++ b/crates/sn2-validator/src/incremental_runner.rs
@@ -892,6 +892,29 @@ mod tests {
     }
 
     #[test]
+    fn verified_tile_total_counts_until_run_removal() {
+        let mut mgr = make_manager_with_run("run-1");
+        let tiling: TilingInfo = serde_json::from_value(
+            serde_json::json!({ "num_tiles": 2, "tiles_y": 1, "tiles_x": 2 }),
+        )
+        .unwrap();
+        let expected: HashSet<u32> = [0u32, 1u32].into_iter().collect();
+        mgr.init_tile_counter("run-1", "slice_0", &tiling, expected)
+            .unwrap();
+
+        mgr.record_tile("run-1", "slice_0", 0);
+        mgr.record_tile("run-1", "slice_0", 1);
+
+        // Both tiles verified: the completion notification snapshots this here.
+        assert_eq!(mgr.verified_tile_total("run-1"), 2);
+
+        // remove_run clears tile state, which is why finalize_combined_run must
+        // read the counts before calling it.
+        mgr.remove_run("run-1");
+        assert_eq!(mgr.verified_tile_total("run-1"), 0);
+    }
+
+    #[test]
     fn skipped_slices_cleared_on_run_removal() {
         let mut mgr = make_manager_with_run("run-1");
         mgr.note_slice_skipped("run-1", "slice_a");

--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -1469,6 +1469,10 @@ impl ValidatorLoop {
         }
 
         let final_output = self.run_manager.final_output_json(run_uid);
+        // Snapshot the tile counts before remove_run clears the run's tile
+        // state, otherwise the completion metrics report zero.
+        let (_, total_tiles, _) = self.run_manager.slice_tile_counts(run_uid);
+        let verified_tiles = self.run_manager.verified_tile_total(run_uid);
         let mut active_run = self.run_manager.remove_run(run_uid);
 
         if let Some(ref run) = active_run {
@@ -1478,8 +1482,15 @@ impl ValidatorLoop {
 
         let relay_output = final_output.clone();
         self.spawn_artifact_upload(run_uid, &mut active_run, final_output);
-        self.notify_run_completed(run_uid, &active_run, relay_output, failed_count)
-            .await;
+        self.notify_run_completed(
+            run_uid,
+            &active_run,
+            relay_output,
+            failed_count,
+            verified_tiles,
+            total_tiles,
+        )
+        .await;
     }
 
     pub(super) async fn replenish_dslice_queues(&mut self) {

--- a/crates/sn2-validator/src/validator_loop/relay.rs
+++ b/crates/sn2-validator/src/validator_loop/relay.rs
@@ -145,6 +145,13 @@ impl ValidatorLoop {
         final_output: Option<serde_json::Value>,
         failed_count: usize,
     ) {
+        let (_, total_tiles, _) = self.run_manager.slice_tile_counts(run_uid);
+        let verified_tiles = self.run_manager.verified_tile_total(run_uid);
+        let proof_coverage = if total_tiles > 0 {
+            (verified_tiles as f64 / total_tiles as f64).min(1.0)
+        } else {
+            0.0
+        };
         let notify_circuit_id = active_run
             .as_ref()
             .map(|r| r.circuit_id.as_str())
@@ -156,7 +163,7 @@ impl ValidatorLoop {
             "complete"
         };
         let mut result = serde_json::json!({"run_uid": run_uid, "status": status});
-        if let Some(output) = final_output {
+        if let Some(output) = final_output.clone() {
             result["output"] = output;
         }
         if failed_count > 0 {
@@ -172,7 +179,13 @@ impl ValidatorLoop {
             "run_uid": run_uid,
             "circuit_id": notify_circuit_id,
             "status": notification_status,
+            "verified_tiles": verified_tiles,
+            "total_tiles": total_tiles,
+            "proof_coverage": proof_coverage,
         });
+        if let Some(output) = final_output {
+            notification["output"] = output;
+        }
         if failed_count > 0 {
             notification["failed_slices"] = serde_json::json!(failed_count);
         }

--- a/crates/sn2-validator/src/validator_loop/relay.rs
+++ b/crates/sn2-validator/src/validator_loop/relay.rs
@@ -7,6 +7,16 @@ use crate::dsperse_events::DsperseEventClient;
 use crate::relay::FRAME_SUBMIT_RESULT;
 use crate::stats_reporter::{DsperseRunReport, DsperseSliceReport};
 
+/// Fraction of a run's tiles backed by a verified proof, clamped to 1.0.
+/// Zero total tiles yields 0.0 rather than a division by zero.
+pub(super) fn proof_coverage_fraction(verified_tiles: usize, total_tiles: usize) -> f64 {
+    if total_tiles > 0 {
+        (verified_tiles as f64 / total_tiles as f64).min(1.0)
+    } else {
+        0.0
+    }
+}
+
 impl ValidatorLoop {
     pub(super) async fn relay_send_response(
         &self,
@@ -144,14 +154,12 @@ impl ValidatorLoop {
         active_run: &Option<crate::incremental_runner::ActiveRun>,
         final_output: Option<serde_json::Value>,
         failed_count: usize,
+        verified_tiles: usize,
+        total_tiles: usize,
     ) {
-        let (_, total_tiles, _) = self.run_manager.slice_tile_counts(run_uid);
-        let verified_tiles = self.run_manager.verified_tile_total(run_uid);
-        let proof_coverage = if total_tiles > 0 {
-            (verified_tiles as f64 / total_tiles as f64).min(1.0)
-        } else {
-            0.0
-        };
+        // Tile counts are snapshotted by the caller before the run is removed
+        // from the run manager; reading them here would return zero.
+        let proof_coverage = proof_coverage_fraction(verified_tiles, total_tiles);
         let notify_circuit_id = active_run
             .as_ref()
             .map(|r| r.circuit_id.as_str())
@@ -283,5 +291,26 @@ impl ValidatorLoop {
         self.dslice_input_scales
             .retain(|(uid, _), _| uid != run_uid);
         self.relay_remove_pending(run_uid).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::proof_coverage_fraction;
+
+    #[test]
+    fn proof_coverage_partial_run() {
+        assert_eq!(proof_coverage_fraction(1, 4), 0.25);
+    }
+
+    #[test]
+    fn proof_coverage_full_run_clamps() {
+        assert_eq!(proof_coverage_fraction(4, 4), 1.0);
+        assert_eq!(proof_coverage_fraction(5, 4), 1.0);
+    }
+
+    #[test]
+    fn proof_coverage_zero_tiles_is_zero() {
+        assert_eq!(proof_coverage_fraction(0, 0), 0.0);
     }
 }


### PR DESCRIPTION
Adds three fields to the `batch_completed` notification emitted when a run finishes: `verified_tiles`, `total_tiles`, and `proof_coverage` (verified ÷ total, clamped to 1.0), alongside the run's `final_output`.

Also adds `verified_tile_total` to sum verified tiles across a run's slices.

Proving remains caller-controlled via `prove_pct` and defaults to full coverage when unset. No change to submission, dispatch, or verification behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Completion notifications now include the total number of verified tiles and the overall tile count.
  * Notifications report proof coverage, including correct handling for empty runs and coverage capped at 100%.
  * Final output is included consistently in both completion results and notifications.
  * Completion metrics remain available through run finalization, ensuring accurate reporting before a run is removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->