### PR TITLE
Resolve stalled API runs by finalizing on dispatch exhaustion

### DIFF
--- a/crates/sn2-validator/src/incremental_runner.rs
+++ b/crates/sn2-validator/src/incremental_runner.rs
@@ -527,6 +527,34 @@ impl IncrementalRunManager {
             .unwrap_or(0)
     }
 
+    /// Slices still awaiting a verified proof. Non-zero at finalize means the
+    /// run is being closed out after its dispatch stalled rather than after a
+    /// clean completion.
+    pub fn pending_slice_count(&self, run_uid: &str) -> usize {
+        self.runs
+            .get(run_uid)
+            .and_then(|r| r.combined.as_ref())
+            .map(|c| c.pending_count())
+            .unwrap_or(0)
+    }
+
+    /// API run ids whose last activity predates the stall threshold. Their
+    /// dispatch has stopped producing proofs but some slices never completed,
+    /// so they must be finalized (partially) rather than left hanging. Scoped
+    /// to API runs because a waiting client depends on their completion;
+    /// benchmark runs are handled by the hard idle eviction.
+    pub fn stale_api_run_uids(&self, idle_timeout: Duration) -> Vec<String> {
+        let now = Instant::now();
+        self.runs
+            .iter()
+            .filter(|(_, run)| {
+                run.run_source == RunSource::Api
+                    && now.duration_since(run.last_activity) >= idle_timeout
+            })
+            .map(|(uid, _)| uid.clone())
+            .collect()
+    }
+
     /// Record that a slice was marked failed without ever being dispatched.
     /// Used by the run-wide failure guard in finalize_combined_run to avoid
     /// conflating deterministic skips (already-disabled slices, preflight
@@ -889,6 +917,45 @@ mod tests {
         mgr.note_slice_skipped("run-1", "slice_a");
         assert!(mgr.is_slice_skipped("run-1", "slice_a"));
         assert!(!mgr.is_slice_skipped("run-2", "slice_a"));
+    }
+
+    #[test]
+    fn stale_api_run_uids_scoped_to_api_source() {
+        // make_manager_with_run starts a benchmark run; add an API run.
+        let mut mgr = make_manager_with_run("run-bench");
+        mgr.start_run(
+            "run-api".to_string(),
+            "test-circuit".to_string(),
+            "test".to_string(),
+            RunSource::Api,
+            None,
+            None,
+        );
+        // Zero timeout treats every run as idle; only the API run is returned.
+        let stale = mgr.stale_api_run_uids(Duration::ZERO);
+        assert_eq!(stale, vec!["run-api".to_string()]);
+    }
+
+    #[test]
+    fn stale_api_run_uids_respects_idle_threshold() {
+        let mut mgr = make_manager_with_run("run-bench");
+        mgr.start_run(
+            "run-api".to_string(),
+            "test-circuit".to_string(),
+            "test".to_string(),
+            RunSource::Api,
+            None,
+            None,
+        );
+        // A freshly started run is not idle for an hour.
+        assert!(mgr.stale_api_run_uids(Duration::from_secs(3600)).is_empty());
+    }
+
+    #[test]
+    fn pending_slice_count_zero_without_combined() {
+        let mgr = make_manager_with_run("run-1");
+        assert_eq!(mgr.pending_slice_count("run-1"), 0);
+        assert_eq!(mgr.pending_slice_count("missing"), 0);
     }
 
     #[test]

--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -1397,8 +1397,13 @@ impl ValidatorLoop {
         self.dslice_input_scales
             .retain(|(uid, _), _| uid != run_uid);
 
-        let failed_count = self.run_manager.failed_slice_count(run_uid);
-        info!(run_uid = %run_uid, failed_count, "combined run complete");
+        // Slices still pending at finalize mean the run is being closed out
+        // after its dispatch stalled; count them alongside the explicitly
+        // failed slices so the completion reports its true partial status
+        // instead of a clean finish. A normally completing run has none.
+        let pending_count = self.run_manager.pending_slice_count(run_uid);
+        let failed_count = self.run_manager.failed_slice_count(run_uid) + pending_count;
+        info!(run_uid = %run_uid, failed_count, pending_count, "combined run complete");
 
         if let Some(circuit_id) = self
             .run_manager

--- a/crates/sn2-validator/src/validator_loop/maintenance.rs
+++ b/crates/sn2-validator/src/validator_loop/maintenance.rs
@@ -11,6 +11,15 @@ use super::{is_valid_ip, ValidatorLoop, WeightTaskResult};
 use crate::metrics_server as metrics;
 use sn2_circuit_store::CircuitStore;
 
+// An API run that has received no proof or failure for this long has stalled:
+// its dispatch is exhausted but some slices never produced a verified proof.
+// It is finalized (partially) rather than left to hang. Active proving updates
+// last activity roughly continuously, so this only fires on a genuine stall.
+const DSLICE_STALL_TIMEOUT_SECS: u64 = 90;
+// How often the stale-run sweep runs. Kept well below the stall timeout so a
+// stalled run is closed out within roughly one stall window.
+const DSLICE_GC_INTERVAL_SECS: u64 = 30;
+
 impl ValidatorLoop {
     pub(super) async fn run_periodic_tasks(&mut self) -> Result<()> {
         let now = std::time::Instant::now();
@@ -114,7 +123,7 @@ impl ValidatorLoop {
             self.timings.replenish = now;
         }
 
-        if now.duration_since(self.timings.gc) > Duration::from_secs(120) {
+        if now.duration_since(self.timings.gc) > Duration::from_secs(DSLICE_GC_INTERVAL_SECS) {
             self.gc_stale_runs().await;
             self.timings.gc = now;
         }
@@ -252,6 +261,20 @@ impl ValidatorLoop {
     }
 
     async fn gc_stale_runs(&mut self) {
+        // An API run whose last activity predates the stall threshold has
+        // stopped receiving proofs: its dispatch is exhausted but some slices
+        // never completed. Finalize it so the waiting relay/client gets a
+        // partial completion — carrying whatever coverage and output were
+        // achieved — instead of hanging until the hard eviction removes it
+        // silently. finalize_combined_run removes the run itself.
+        let stalled = self
+            .run_manager
+            .stale_api_run_uids(Duration::from_secs(DSLICE_STALL_TIMEOUT_SECS));
+        for uid in stalled {
+            warn!(run_uid = %uid, "finalizing stalled API run with incomplete coverage");
+            self.finalize_combined_run(&uid).await;
+        }
+
         let evicted = self.run_manager.gc_stale(Duration::from_secs(600));
         for uid in &evicted {
             self.cleanup_run_resources(uid).await;


### PR DESCRIPTION
A dsperse run finalizes only when every slice is proven (`pending_slices` empty). When a slice's tiles never all produce a verified proof, dispatch exhausts but pending slices never drain, so the run is never finalized: no completion is emitted, and a waiting client hangs until the run is silently evicted after ten idle minutes. Observed directly — API runs reach thousands of verified proofs then plateau with zero `run_complete`.

- Sweep API runs whose last activity predates a stall threshold (90s) and finalize them; the sweep runs every 30s.
- `finalize_combined_run` now counts still-pending slices alongside failed ones, so a stalled finalize reports its true partial status and carries the computed output (boxes) and achieved coverage. A normally completing run has no pending slices, so its behaviour is unchanged.
- Scoped to API runs, since a waiting client depends on their completion; benchmark runs keep the existing idle eviction.

Bounds worst-case completion latency to roughly one stall window instead of an indefinite hang. This is a mitigation: the deeper question of why individual tiles never converge at high coverage remains. cargo fmt, clippy -D warnings, and three new run-manager tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of API runs that stop receiving proofs by automatically finalizing stale runs.
  * Incomplete slices are now included in failed-slice totals, providing more accurate run results.
  * Maintenance checks run more frequently to detect stalled runs sooner.
  * Benchmark runs are excluded from stale API-run handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->