### PR TITLE
Introduce best-effort output delivery ahead of proof coverage

### DIFF
--- a/crates/sn2-validator/src/incremental_runner.rs
+++ b/crates/sn2-validator/src/incremental_runner.rs
@@ -683,6 +683,14 @@ impl IncrementalRunManager {
             .collect()
     }
 
+    pub fn api_run_uids(&self) -> Vec<String> {
+        self.runs
+            .iter()
+            .filter(|(_, run)| run.run_source == RunSource::Api)
+            .map(|(uid, _)| uid.clone())
+            .collect()
+    }
+
     pub fn evict_by_circuit(&mut self, circuit_id: &str) -> Vec<String> {
         let to_remove: Vec<String> = self
             .runs

--- a/crates/sn2-validator/src/incremental_runner.rs
+++ b/crates/sn2-validator/src/incremental_runner.rs
@@ -217,6 +217,17 @@ impl IncrementalRunManager {
             .sum()
     }
 
+    /// Credit a non-tiled slice's single implicit tile toward coverage. Tiled
+    /// slices accrue verified tiles through record_tile; non-tiled slices
+    /// complete via mark_slice_done and would otherwise never count, so their
+    /// one tile is registered here. Guarded by the caller to fire once.
+    pub fn record_verified_slice(&mut self, run_uid: &str, slice_id: &str) {
+        *self
+            .verified_tile_counts
+            .entry((run_uid.to_string(), slice_id.to_string()))
+            .or_insert(0) += 1;
+    }
+
     pub fn slice_tile_counts(&self, run_uid: &str) -> (usize, usize, HashMap<String, usize>) {
         let run = match self.runs.get(run_uid) {
             Some(r) => r,
@@ -964,6 +975,16 @@ mod tests {
         let mgr = make_manager_with_run("run-1");
         assert_eq!(mgr.pending_slice_count("run-1"), 0);
         assert_eq!(mgr.pending_slice_count("missing"), 0);
+    }
+
+    #[test]
+    fn record_verified_slice_credits_non_tiled_coverage() {
+        let mut mgr = make_manager_with_run("run-1");
+        assert_eq!(mgr.verified_tile_total("run-1"), 0);
+        mgr.record_verified_slice("run-1", "slice_0");
+        assert_eq!(mgr.verified_tile_total("run-1"), 1);
+        mgr.record_verified_slice("run-1", "slice_1");
+        assert_eq!(mgr.verified_tile_total("run-1"), 2);
     }
 
     #[test]

--- a/crates/sn2-validator/src/incremental_runner.rs
+++ b/crates/sn2-validator/src/incremental_runner.rs
@@ -220,12 +220,12 @@ impl IncrementalRunManager {
     /// Credit a non-tiled slice's single implicit tile toward coverage. Tiled
     /// slices accrue verified tiles through record_tile; non-tiled slices
     /// complete via mark_slice_done and would otherwise never count, so their
-    /// one tile is registered here. Guarded by the caller to fire once.
+    /// one tile is registered here. Idempotent: a non-tiled slice has exactly
+    /// one tile, so repeat completions leave the count at one.
     pub fn record_verified_slice(&mut self, run_uid: &str, slice_id: &str) {
-        *self
-            .verified_tile_counts
+        self.verified_tile_counts
             .entry((run_uid.to_string(), slice_id.to_string()))
-            .or_insert(0) += 1;
+            .or_insert(1);
     }
 
     pub fn slice_tile_counts(&self, run_uid: &str) -> (usize, usize, HashMap<String, usize>) {
@@ -983,6 +983,11 @@ mod tests {
         assert_eq!(mgr.verified_tile_total("run-1"), 0);
         mgr.record_verified_slice("run-1", "slice_0");
         assert_eq!(mgr.verified_tile_total("run-1"), 1);
+        // A repeat completion of the same non-tiled slice must not double-count:
+        // it has exactly one implicit tile.
+        mgr.record_verified_slice("run-1", "slice_0");
+        assert_eq!(mgr.verified_tile_total("run-1"), 1);
+        // A distinct non-tiled slice adds its own tile.
         mgr.record_verified_slice("run-1", "slice_1");
         assert_eq!(mgr.verified_tile_total("run-1"), 2);
     }

--- a/crates/sn2-validator/src/relay.rs
+++ b/crates/sn2-validator/src/relay.rs
@@ -23,6 +23,8 @@ const MSG_STATUS_RESULT: u8 = 0x21;
 const MSG_PROOF_REQ: u8 = 0x30;
 const MSG_PROOF_RESULT: u8 = 0x31;
 const MSG_BATCH_DONE: u8 = 0x40;
+const MSG_OUTPUT_READY: u8 = 0x41;
+const MSG_COVERAGE_UPDATE: u8 = 0x42;
 const MSG_ERROR: u8 = 0xFE;
 
 pub const FRAME_SUBMIT_RESULT: u8 = MSG_SUBMIT_RESULT;
@@ -567,6 +569,8 @@ impl RelayManager {
         if let Some(tx) = &self.ws_tx {
             let msg_type = match method {
                 "subnet-2.batch_completed" => MSG_BATCH_DONE,
+                "subnet-2.output_ready" => MSG_OUTPUT_READY,
+                "subnet-2.coverage_update" => MSG_COVERAGE_UPDATE,
                 _ => {
                     warn!(method = method, "unknown notification method");
                     return;

--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -197,6 +197,23 @@ impl ValidatorLoop {
             .await;
         }
 
+        // Best-effort delivery: the combined ONNX run has already produced the
+        // detection output, so push it to the relay now. The browser renders
+        // boxes immediately; proof coverage streams separately on completion
+        // and never gates the result.
+        if let Some(output) = self.run_manager.final_output_json(&run_uid) {
+            self.relay_send_notification(
+                "subnet-2.output_ready",
+                serde_json::json!({
+                    "run_uid": run_uid,
+                    "circuit_id": circuit.id,
+                    "total_tiles": total_tiles,
+                    "output": output,
+                }),
+            )
+            .await;
+        }
+
         let benchmark_uids = self.run_manager.benchmark_run_uids();
         for uid in &benchmark_uids {
             info!(run_uid = %uid, "preempting benchmark run for API dsperse submission");

--- a/crates/sn2-validator/src/validator_loop/maintenance.rs
+++ b/crates/sn2-validator/src/validator_loop/maintenance.rs
@@ -19,6 +19,9 @@ const DSLICE_STALL_TIMEOUT_SECS: u64 = 90;
 // How often the stale-run sweep runs. Kept well below the stall timeout so a
 // stalled run is closed out within roughly one stall window.
 const DSLICE_GC_INTERVAL_SECS: u64 = 30;
+// How often live proof coverage is pushed to the relay for in-flight API runs.
+// The detections are delivered up front, so this only streams the trust number.
+const DSLICE_COVERAGE_INTERVAL_SECS: u64 = 5;
 
 impl ValidatorLoop {
     pub(super) async fn run_periodic_tasks(&mut self) -> Result<()> {
@@ -121,6 +124,13 @@ impl ValidatorLoop {
         {
             self.replenish_dslice_queues().await;
             self.timings.replenish = now;
+        }
+
+        if now.duration_since(self.timings.coverage)
+            > Duration::from_secs(DSLICE_COVERAGE_INTERVAL_SECS)
+        {
+            self.emit_coverage_updates().await;
+            self.timings.coverage = now;
         }
 
         if now.duration_since(self.timings.gc) > Duration::from_secs(DSLICE_GC_INTERVAL_SECS) {

--- a/crates/sn2-validator/src/validator_loop/mod.rs
+++ b/crates/sn2-validator/src/validator_loop/mod.rs
@@ -95,6 +95,7 @@ pub(super) struct PeriodicTimings {
     pub(super) gc: Instant,
     pub(super) cooldown_prune: Instant,
     pub(super) bundle_cache_sweep: Instant,
+    pub(super) coverage: Instant,
 }
 
 impl PeriodicTimings {
@@ -111,6 +112,7 @@ impl PeriodicTimings {
             gc: now,
             cooldown_prune: now,
             bundle_cache_sweep: now,
+            coverage: now,
         }
     }
 }

--- a/crates/sn2-validator/src/validator_loop/relay.rs
+++ b/crates/sn2-validator/src/validator_loop/relay.rs
@@ -35,6 +35,26 @@ impl ValidatorLoop {
         }
     }
 
+    /// Stream live proof coverage for in-flight API runs. Detections are
+    /// delivered up front via output_ready, so this only advances the trust
+    /// number the browser shows; it never gates the result.
+    pub(super) async fn emit_coverage_updates(&self) {
+        for run_uid in self.run_manager.api_run_uids() {
+            let (_, total_tiles, _) = self.run_manager.slice_tile_counts(&run_uid);
+            let verified_tiles = self.run_manager.verified_tile_total(&run_uid);
+            self.relay_send_notification(
+                "subnet-2.coverage_update",
+                serde_json::json!({
+                    "run_uid": run_uid,
+                    "verified_tiles": verified_tiles,
+                    "total_tiles": total_tiles,
+                    "proof_coverage": proof_coverage_fraction(verified_tiles, total_tiles),
+                }),
+            )
+            .await;
+        }
+    }
+
     pub(super) async fn relay_register_pending(&self, hash: &str) {
         if let Some(relay) = &self.relay {
             relay.register_pending(hash).await;

--- a/crates/sn2-validator/src/validator_loop/results.rs
+++ b/crates/sn2-validator/src/validator_loop/results.rs
@@ -345,8 +345,11 @@ impl ValidatorLoop {
                     return;
                 }
             }
-        } else {
-            self.run_manager.mark_slice_done(&run_uid, &slice_num);
+        } else if self.run_manager.mark_slice_done(&run_uid, &slice_num) {
+            // A non-tiled slice carries a single implicit tile that never
+            // flows through record_tile; credit it on first completion so
+            // coverage reflects completed non-tiled proofs.
+            self.run_manager.record_verified_slice(&run_uid, &slice_num);
         }
 
         if self.run_manager.is_run_complete(&run_uid) {


### PR DESCRIPTION
The detection output is available from the validator's combined ONNX run at submission time, long before proofs converge. Rather than gating the result on run completion, push it immediately and stream coverage separately.

- On submission, emit `subnet-2.output_ready` {run_uid, output} right after the combined run computes the output.
- Every ~5s, emit `subnet-2.coverage_update` {run_uid, verified_tiles, total_tiles, proof_coverage} for in-flight API runs.
- Two new wire frames (0x41, 0x42) carry them.

A consumer renders the output at once and advances the coverage as it grows; nothing waits on completion. `cargo fmt`, `clippy -D warnings`, and the existing tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added notifications when final output becomes available for API-triggered runs.
  - Added periodic coverage updates every five seconds, showing verified tiles, total tiles, and proof coverage.
  - Notifications include relevant run and circuit details for easier progress tracking.
  - Added visibility into active API-run progress through coverage notifications.

- **Bug Fixes**
  - Improved coverage tracking for non-tiled slices.
  - Prevented duplicate slice completions from adding coverage credit more than once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->