### PR TITLE
Introduce all declared model outputs in best-effort delivery

### DIFF
--- a/crates/sn2-validator/src/incremental_runner.rs
+++ b/crates/sn2-validator/src/incremental_runner.rs
@@ -610,6 +610,31 @@ impl IncrementalRunManager {
         Some(arrayd_to_json(output))
     }
 
+    /// Every declared model output by name, each as `{data, shape}`. A single
+    /// final tensor is not enough to decode multi-head models (e.g. detection
+    /// transformers emit separate box and class tensors), so the full set is
+    /// surfaced and the consumer decodes from it.
+    pub fn final_outputs_json(&self, run_uid: &str) -> Option<serde_json::Value> {
+        let run = self.runs.get(run_uid)?;
+        let combined = run.combined.as_ref()?;
+        let meta = combined.model_meta();
+        let mut map = serde_json::Map::new();
+        for (i, name) in meta.output_names.iter().enumerate() {
+            if let Some(flat) = combined.outputs_for_names(std::slice::from_ref(name)) {
+                let shape = meta.output_shapes.get(i).cloned().unwrap_or_default();
+                map.insert(
+                    name.clone(),
+                    serde_json::json!({ "data": flat, "shape": shape }),
+                );
+            }
+        }
+        if map.is_empty() {
+            None
+        } else {
+            Some(serde_json::Value::Object(map))
+        }
+    }
+
     pub fn push_artifact(&mut self, run_uid: &str, artifact: SliceArtifact) {
         if let Some(run) = self.runs.get_mut(run_uid) {
             run.artifacts.push(artifact);

--- a/crates/sn2-validator/src/validator_loop/dslice.rs
+++ b/crates/sn2-validator/src/validator_loop/dslice.rs
@@ -202,6 +202,7 @@ impl ValidatorLoop {
         // boxes immediately; proof coverage streams separately on completion
         // and never gates the result.
         if let Some(output) = self.run_manager.final_output_json(&run_uid) {
+            let outputs = self.run_manager.final_outputs_json(&run_uid);
             self.relay_send_notification(
                 "subnet-2.output_ready",
                 serde_json::json!({
@@ -209,6 +210,7 @@ impl ValidatorLoop {
                     "circuit_id": circuit.id,
                     "total_tiles": total_tiles,
                     "output": output,
+                    "outputs": outputs,
                 }),
             )
             .await;


### PR DESCRIPTION
Emit every declared model output (name, data, shape) in the best-effort `output_ready` payload rather than only the single final tensor.

Detection transformers expose their result across multiple tensors (boxes plus class logits); forwarding only one leaves the client unable to decode class or confidence. `final_outputs_json` walks the combined run's declared output names and attaches each tensor with its shape; `dslice` includes the map on the notification.

Scoped to sn2-validator; no protocol version change (additive field).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Output-ready notifications now include all declared final outputs, including their values and shapes.
  * Existing single-output information remains available for compatibility.

* **Bug Fixes**
  * Notifications now omit final output details when the run or output data is unavailable, avoiding incomplete results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->